### PR TITLE
feat(init): Configure placeholder tokens during onboarding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,14 @@ export { statusCommand } from "./commands/status.js";
 
 export { detectStack, getStackConfig, STACKS } from "./lib/stacks.js";
 export { getManifest, createManifest, updateManifest } from "./lib/manifest.js";
+export { getConfig, saveConfig } from "./lib/config.js";
 export {
   copyTemplates,
   listTemplateFiles,
   getTemplateContent,
+  processTemplate,
 } from "./lib/templates.js";
 
 export type { StackConfig } from "./lib/stacks.js";
 export type { Manifest } from "./lib/manifest.js";
+export type { SequantConfig } from "./lib/config.js";

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,40 @@
+/**
+ * Sequant configuration management
+ *
+ * Stores user-configured values (like DEV_URL) that persist across updates.
+ */
+
+import { readFile, writeFile, fileExists, ensureDir } from "./fs.js";
+import { dirname } from "path";
+
+const CONFIG_PATH = ".claude/.sequant/config.json";
+
+export interface SequantConfig {
+  tokens: Record<string, string>;
+  stack: string;
+  initialized: string;
+}
+
+/**
+ * Get the current sequant configuration
+ */
+export async function getConfig(): Promise<SequantConfig | null> {
+  if (!(await fileExists(CONFIG_PATH))) {
+    return null;
+  }
+
+  try {
+    const content = await readFile(CONFIG_PATH);
+    return JSON.parse(content) as SequantConfig;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save the sequant configuration
+ */
+export async function saveConfig(config: SequantConfig): Promise<void> {
+  await ensureDir(dirname(CONFIG_PATH));
+  await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2));
+}

--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -18,6 +18,7 @@ export interface StackConfig {
     dev?: string;
   };
   variables: Record<string, string>;
+  devUrl: string;
 }
 
 export const STACKS: Record<string, StackConfig> = {
@@ -39,6 +40,7 @@ export const STACKS: Record<string, StackConfig> = {
       BUILD_COMMAND: "npm run build",
       LINT_COMMAND: "npm run lint",
     },
+    devUrl: "http://localhost:3000",
   },
   rust: {
     name: "rust",
@@ -56,6 +58,7 @@ export const STACKS: Record<string, StackConfig> = {
       BUILD_COMMAND: "cargo build --release",
       LINT_COMMAND: "cargo clippy",
     },
+    devUrl: "http://localhost:8080",
   },
   python: {
     name: "python",
@@ -73,6 +76,7 @@ export const STACKS: Record<string, StackConfig> = {
       BUILD_COMMAND: "python -m build",
       LINT_COMMAND: "ruff check .",
     },
+    devUrl: "http://localhost:5000",
   },
   go: {
     name: "go",
@@ -90,6 +94,7 @@ export const STACKS: Record<string, StackConfig> = {
       BUILD_COMMAND: "go build ./...",
       LINT_COMMAND: "golangci-lint run",
     },
+    devUrl: "http://localhost:8080",
   },
   astro: {
     name: "astro",
@@ -110,6 +115,7 @@ export const STACKS: Record<string, StackConfig> = {
       BUILD_COMMAND: "npm run build",
       LINT_COMMAND: "npm run lint",
     },
+    devUrl: "http://localhost:4321",
   },
   generic: {
     name: "generic",
@@ -125,6 +131,7 @@ export const STACKS: Record<string, StackConfig> = {
       BUILD_COMMAND: "npm run build",
       LINT_COMMAND: "npm run lint",
     },
+    devUrl: "http://localhost:3000",
   },
 };
 

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -21,7 +21,7 @@ function getTemplatesDir(): string {
 /**
  * Process template variables in content
  */
-function processTemplate(
+export function processTemplate(
   content: string,
   variables: Record<string, string>,
 ): string {
@@ -77,11 +77,15 @@ export async function getTemplateContent(
 /**
  * Copy all templates to .claude/ directory
  */
-export async function copyTemplates(stack: string): Promise<void> {
+export async function copyTemplates(
+  stack: string,
+  tokens?: Record<string, string>,
+): Promise<void> {
   const templatesDir = getTemplatesDir();
   const stackConfig = getStackConfig(stack);
   const variables = {
     ...stackConfig.variables,
+    ...tokens,
     PROJECT_NAME: basename(process.cwd()) || "project",
     STACK: stack,
   };


### PR DESCRIPTION
## Summary

- Add dev server URL prompt during `sequant init` with smart stack-based defaults
- Store token values in `.claude/.sequant/config.json` for persistence
- Preserve tokens during `sequant update` for seamless upgrades
- Replace `{{DEV_URL}}` placeholder in skill templates

## Acceptance Criteria

- [x] AC-1: `sequant init` prompts for dev server URL with smart stack defaults
- [x] AC-2: Tokens replaced in skill templates during initialization
- [x] AC-3: Token values stored in `.claude/.sequant/config.json`
- [x] AC-4: `sequant update` preserves user-configured token values

## Changes

| File | Description |
|------|-------------|
| `src/lib/config.ts` | New config module with `getConfig()`, `saveConfig()` |
| `src/lib/stacks.ts` | Added `devUrl` defaults per stack |
| `src/commands/init.ts` | Dev URL prompt, config saving, tokens to templates |
| `src/lib/templates.ts` | Accept tokens parameter, export `processTemplate()` |
| `src/commands/update.ts` | Config loading, legacy migration, token processing |
| `src/index.ts` | Export new config functions |
| `src/commands/init.test.ts` | Updated mocks |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` - 144 tests pass
- [ ] Manual test: `sequant init` in fresh project prompts for URL
- [ ] Manual test: `sequant update` preserves configured URL

Fixes #18

---
Generated with [Claude Code](https://claude.com/claude-code)