### PR TITLE
docs: Document Windows support and WSL requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ npx sequant run 123 --dry-run          # Preview without execution
 | Windows WSL | ✅ Supported | Use WSL2 with bash |
 | Windows Native | ⚠️ Limited | CLI works, but shell scripts require WSL |
 
+### Windows Users
+
+**WSL is recommended** for the full Sequant experience on Windows. Here's why:
+
+| Feature | Native Windows | Windows + WSL |
+|---------|----------------|---------------|
+| CLI commands (`init`, `doctor`, `status`) | ✅ Works | ✅ Works |
+| Workflow hooks (pre-tool, post-tool) | ❌ Requires bash | ✅ Works |
+| Shell scripts (`new-feature.sh`, etc.) | ❌ Requires bash | ✅ Works |
+| Git worktree workflows | ✅ Works | ✅ Works |
+
+**Quick WSL Setup:**
+
+1. Install WSL (run in PowerShell as Administrator): `wsl --install`
+2. Restart your computer when prompted
+3. Open Ubuntu from Start menu and complete setup
+4. Install Node.js: See [NodeSource distributions](https://github.com/nodesource/distributions)
+5. Install GitHub CLI: `apt install gh` then `gh auth login`
+6. Use Sequant: `npx sequant init`
+
+For detailed instructions, see [Microsoft's WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/install).
+
 ### Requirements
 
 - **Node.js** 18.0.0 or higher

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -234,6 +234,78 @@ Common issues and solutions when using Sequant.
 
 3. Check your lint configuration is correct for your stack.
 
+## Windows Issues
+
+### "bash: command not found" or scripts don't work
+
+**Problem:** Shell scripts (hooks, `new-feature.sh`) fail because bash isn't available.
+
+**Solution:** Install WSL (Windows Subsystem for Linux):
+
+1. Open PowerShell as Administrator
+2. Run: `wsl --install`
+3. Restart your computer
+4. Open Ubuntu from Start menu and complete setup
+5. Run Sequant commands from within WSL
+
+See the [README Windows Users section](../README.md#windows-users) for full setup instructions.
+
+### Line ending issues (CRLF vs LF)
+
+**Problem:** Git shows all files as modified, or scripts fail with "bad interpreter" errors.
+
+**Solution:** Configure Git to use LF line endings:
+
+```bash
+# Set global config
+git config --global core.autocrlf input
+
+# Fix existing repo
+git rm --cached -r .
+git reset --hard
+```
+
+If using VSCode, add to `.vscode/settings.json`:
+```json
+{
+  "files.eol": "\n"
+}
+```
+
+### Path issues between Windows and WSL
+
+**Problem:** Paths like `C:\Users\...` don't work in WSL, or vice versa.
+
+**Solutions:**
+
+1. **Access Windows files from WSL:**
+   ```bash
+   cd /mnt/c/Users/YourName/Projects
+   ```
+
+2. **Access WSL files from Windows:**
+   ```
+   \\wsl$\Ubuntu\home\username
+   ```
+
+3. **Best practice:** Keep your projects in the WSL filesystem (`~/projects/`) for better performance.
+
+### npm/node not found in WSL
+
+**Problem:** Node.js works in Windows but not in WSL.
+
+**Solution:** Install Node.js inside WSL (it's a separate environment):
+
+```bash
+# Using nvm (recommended)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+source ~/.bashrc
+nvm install --lts
+
+# Or using NodeSource
+# See: https://github.com/nodesource/distributions
+```
+
 ## Git Issues
 
 ### GPG signing failed

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,7 +5,12 @@
 import chalk from "chalk";
 import { fileExists, isExecutable } from "../lib/fs.js";
 import { getManifest } from "../lib/manifest.js";
-import { commandExists, isGhAuthenticated } from "../lib/system.js";
+import {
+  commandExists,
+  isGhAuthenticated,
+  isNativeWindows,
+  isWSL,
+} from "../lib/system.js";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface DoctorOptions {
@@ -189,6 +194,23 @@ export async function doctorCommand(options: DoctorOptions): Promise<void> {
       message: "jq not installed (optional, hooks will use grep fallback)",
     });
   }
+
+  // Check 11: Windows platform detection
+  if (isNativeWindows()) {
+    checks.push({
+      name: "Platform",
+      status: "warn",
+      message:
+        "Running on native Windows - WSL recommended for full functionality (hooks, scripts)",
+    });
+  } else if (isWSL()) {
+    checks.push({
+      name: "Platform",
+      status: "pass",
+      message: "Running in WSL - full functionality available",
+    });
+  }
+  // On macOS/Linux, don't add a platform check (not relevant)
 
   // Display results
   let passCount = 0;

--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -29,6 +29,32 @@ export function isGhAuthenticated(): boolean {
 }
 
 /**
+ * Check if running in Windows Subsystem for Linux (WSL)
+ */
+export function isWSL(): boolean {
+  if (process.platform !== "linux") {
+    return false;
+  }
+  try {
+    const fs = require("fs");
+    const procVersion = fs.readFileSync("/proc/version", "utf8");
+    return (
+      procVersion.toLowerCase().includes("microsoft") ||
+      procVersion.toLowerCase().includes("wsl")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if running on native Windows (not WSL)
+ */
+export function isNativeWindows(): boolean {
+  return process.platform === "win32";
+}
+
+/**
  * Get platform-specific install hint for a package
  */
 export function getInstallHint(pkg: string): string {


### PR DESCRIPTION
## Summary

- Add Windows Users section to README with WSL setup guide
- Add Windows troubleshooting section to docs
- Add doctor check that warns on native Windows without WSL

## Changes

- **README.md** (+22 lines) - Windows Users section with feature matrix and WSL setup
- **docs/troubleshooting.md** (+72 lines) - Windows Issues section (bash, line endings, paths, npm)
- **src/lib/system.ts** (+26 lines) - `isNativeWindows()` and `isWSL()` detection
- **src/commands/doctor.ts** (+24 lines) - Platform check with WSL recommendation
- **src/commands/doctor.test.ts** (+51 lines) - Unit tests for Windows detection

## Test Plan

- [x] All 147 tests passing
- [x] Build succeeds
- [x] Manual review of docs
- [x] QA passed

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)