### PR TITLE
feat(#11): Add SvelteKit, Remix, and Nuxt stack detection

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -124,6 +124,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
           message: "Select your project stack:",
           choices: [
             { name: "Next.js / React", value: "nextjs" },
+            { name: "Astro", value: "astro" },
+            { name: "SvelteKit", value: "sveltekit" },
+            { name: "Remix", value: "remix" },
+            { name: "Nuxt", value: "nuxt" },
             { name: "Rust", value: "rust" },
             { name: "Python", value: "python" },
             { name: "Go", value: "go" },

--- a/src/lib/stacks.test.ts
+++ b/src/lib/stacks.test.ts
@@ -33,6 +33,78 @@ describe("STACKS", () => {
       expect(STACKS.astro.commands.lint).toBe("npm run lint");
     });
   });
+
+  describe("sveltekit config", () => {
+    it("has correct detection files", () => {
+      expect(STACKS.sveltekit.detection.files).toEqual([
+        "svelte.config.js",
+        "svelte.config.ts",
+      ]);
+    });
+
+    it("has @sveltejs/kit in packageDeps", () => {
+      expect(STACKS.sveltekit.detection.packageDeps).toContain("@sveltejs/kit");
+    });
+
+    it("has correct commands", () => {
+      expect(STACKS.sveltekit.commands.build).toBe("npm run build");
+      expect(STACKS.sveltekit.commands.dev).toBe("npm run dev");
+      expect(STACKS.sveltekit.commands.test).toBe("npm test");
+      expect(STACKS.sveltekit.commands.lint).toBe("npm run lint");
+    });
+
+    it("has correct devUrl for Vite-based server", () => {
+      expect(STACKS.sveltekit.devUrl).toBe("http://localhost:5173");
+    });
+  });
+
+  describe("remix config", () => {
+    it("has correct detection files", () => {
+      expect(STACKS.remix.detection.files).toEqual([
+        "remix.config.js",
+        "remix.config.ts",
+      ]);
+    });
+
+    it("has @remix-run/react in packageDeps", () => {
+      expect(STACKS.remix.detection.packageDeps).toContain("@remix-run/react");
+    });
+
+    it("has correct commands", () => {
+      expect(STACKS.remix.commands.build).toBe("npm run build");
+      expect(STACKS.remix.commands.dev).toBe("npm run dev");
+      expect(STACKS.remix.commands.test).toBe("npm test");
+      expect(STACKS.remix.commands.lint).toBe("npm run lint");
+    });
+
+    it("has correct devUrl for Vite-based server", () => {
+      expect(STACKS.remix.devUrl).toBe("http://localhost:5173");
+    });
+  });
+
+  describe("nuxt config", () => {
+    it("has correct detection files", () => {
+      expect(STACKS.nuxt.detection.files).toEqual([
+        "nuxt.config.ts",
+        "nuxt.config.js",
+      ]);
+    });
+
+    it("has nuxt in packageDeps", () => {
+      expect(STACKS.nuxt.detection.packageDeps).toContain("nuxt");
+    });
+
+    it("has correct commands", () => {
+      expect(STACKS.nuxt.commands.build).toBe("npm run build");
+      expect(STACKS.nuxt.commands.dev).toBe("npm run dev");
+      expect(STACKS.nuxt.commands.test).toBe("npm test");
+      expect(STACKS.nuxt.commands.lint).toBe("npm run lint");
+    });
+
+    it("has correct devUrl", () => {
+      expect(STACKS.nuxt.devUrl).toBe("http://localhost:3000");
+    });
+  });
 });
 
 describe("detectStack", () => {
@@ -99,6 +171,150 @@ describe("detectStack", () => {
     });
   });
 
+  describe("SvelteKit detection", () => {
+    it("detects svelte.config.js", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "svelte.config.js";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("sveltekit");
+    });
+
+    it("detects svelte.config.ts", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "svelte.config.ts";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("sveltekit");
+    });
+
+    it("detects @sveltejs/kit in dependencies via package.json", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          dependencies: { "@sveltejs/kit": "^2.0.0" },
+        }),
+      );
+
+      const result = await detectStack();
+      expect(result).toBe("sveltekit");
+    });
+
+    it("detects @sveltejs/kit in devDependencies via package.json", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          devDependencies: { "@sveltejs/kit": "^2.0.0" },
+        }),
+      );
+
+      const result = await detectStack();
+      expect(result).toBe("sveltekit");
+    });
+  });
+
+  describe("Remix detection", () => {
+    it("detects remix.config.js", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "remix.config.js";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("remix");
+    });
+
+    it("detects remix.config.ts", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "remix.config.ts";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("remix");
+    });
+
+    it("detects @remix-run/react in dependencies via package.json", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          dependencies: { "@remix-run/react": "^2.0.0" },
+        }),
+      );
+
+      const result = await detectStack();
+      expect(result).toBe("remix");
+    });
+
+    it("detects @remix-run/react in devDependencies via package.json", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          devDependencies: { "@remix-run/react": "^2.0.0" },
+        }),
+      );
+
+      const result = await detectStack();
+      expect(result).toBe("remix");
+    });
+  });
+
+  describe("Nuxt detection", () => {
+    it("detects nuxt.config.ts", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "nuxt.config.ts";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("nuxt");
+    });
+
+    it("detects nuxt.config.js", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "nuxt.config.js";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("nuxt");
+    });
+
+    it("detects nuxt in dependencies via package.json", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          dependencies: { nuxt: "^3.0.0" },
+        }),
+      );
+
+      const result = await detectStack();
+      expect(result).toBe("nuxt");
+    });
+
+    it("detects nuxt in devDependencies via package.json", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          devDependencies: { nuxt: "^3.0.0" },
+        }),
+      );
+
+      const result = await detectStack();
+      expect(result).toBe("nuxt");
+    });
+  });
+
   describe("priority", () => {
     it("Next.js takes priority over Astro when both present", async () => {
       mockFileExists.mockImplementation(async (path) => {
@@ -130,6 +346,59 @@ describe("detectStack", () => {
 
       const result = await detectStack();
       expect(result).toBe("astro");
+    });
+
+    it("Astro takes priority over SvelteKit when both present", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "astro.config.mjs" || path === "svelte.config.js";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("astro");
+    });
+
+    it("SvelteKit takes priority over Remix when both present", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "svelte.config.js" || path === "remix.config.js";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("sveltekit");
+    });
+
+    it("Remix takes priority over Nuxt when both present", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "remix.config.js" || path === "nuxt.config.ts";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("remix");
+    });
+
+    it("SvelteKit dep takes priority over Remix dep", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          dependencies: {
+            "@sveltejs/kit": "^2.0.0",
+            "@remix-run/react": "^2.0.0",
+          },
+        }),
+      );
+
+      const result = await detectStack();
+      expect(result).toBe("sveltekit");
+    });
+
+    it("Nuxt config file takes priority over Rust", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "nuxt.config.ts" || path === "Cargo.toml";
+      });
+
+      const result = await detectStack();
+      expect(result).toBe("nuxt");
     });
   });
 
@@ -168,6 +437,24 @@ describe("getStackConfig", () => {
     const config = getStackConfig("astro");
     expect(config.name).toBe("astro");
     expect(config.displayName).toBe("Astro");
+  });
+
+  it("returns sveltekit config for sveltekit stack", () => {
+    const config = getStackConfig("sveltekit");
+    expect(config.name).toBe("sveltekit");
+    expect(config.displayName).toBe("SvelteKit");
+  });
+
+  it("returns remix config for remix stack", () => {
+    const config = getStackConfig("remix");
+    expect(config.name).toBe("remix");
+    expect(config.displayName).toBe("Remix");
+  });
+
+  it("returns nuxt config for nuxt stack", () => {
+    const config = getStackConfig("nuxt");
+    expect(config.name).toBe("nuxt");
+    expect(config.displayName).toBe("Nuxt");
   });
 
   it("returns generic config for unknown stack", () => {

--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -117,6 +117,66 @@ export const STACKS: Record<string, StackConfig> = {
     },
     devUrl: "http://localhost:4321",
   },
+  sveltekit: {
+    name: "sveltekit",
+    displayName: "SvelteKit",
+    detection: {
+      files: ["svelte.config.js", "svelte.config.ts"],
+      packageDeps: ["@sveltejs/kit"],
+    },
+    commands: {
+      test: "npm test",
+      build: "npm run build",
+      lint: "npm run lint",
+      dev: "npm run dev",
+    },
+    variables: {
+      TEST_COMMAND: "npm test",
+      BUILD_COMMAND: "npm run build",
+      LINT_COMMAND: "npm run lint",
+    },
+    devUrl: "http://localhost:5173",
+  },
+  remix: {
+    name: "remix",
+    displayName: "Remix",
+    detection: {
+      files: ["remix.config.js", "remix.config.ts"],
+      packageDeps: ["@remix-run/react"],
+    },
+    commands: {
+      test: "npm test",
+      build: "npm run build",
+      lint: "npm run lint",
+      dev: "npm run dev",
+    },
+    variables: {
+      TEST_COMMAND: "npm test",
+      BUILD_COMMAND: "npm run build",
+      LINT_COMMAND: "npm run lint",
+    },
+    devUrl: "http://localhost:5173",
+  },
+  nuxt: {
+    name: "nuxt",
+    displayName: "Nuxt",
+    detection: {
+      files: ["nuxt.config.ts", "nuxt.config.js"],
+      packageDeps: ["nuxt"],
+    },
+    commands: {
+      test: "npm test",
+      build: "npm run build",
+      lint: "npm run lint",
+      dev: "npm run dev",
+    },
+    variables: {
+      TEST_COMMAND: "npm test",
+      BUILD_COMMAND: "npm run build",
+      LINT_COMMAND: "npm run lint",
+    },
+    devUrl: "http://localhost:3000",
+  },
   generic: {
     name: "generic",
     displayName: "Generic",
@@ -136,41 +196,52 @@ export const STACKS: Record<string, StackConfig> = {
 };
 
 export async function detectStack(): Promise<string | null> {
-  // Check for Next.js
+  // Check for Next.js config files
   for (const file of STACKS.nextjs.detection.files || []) {
     if (await fileExists(file)) {
       return "nextjs";
     }
   }
 
-  // Check package.json for Next.js dependency
-  if (await fileExists("package.json")) {
-    try {
-      const pkg = JSON.parse(await readFile("package.json"));
-      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-      if (deps.next) {
-        return "nextjs";
-      }
-    } catch {
-      // Ignore parse errors
-    }
-  }
-
-  // Check for Astro
+  // Check for Astro config files
   for (const file of STACKS.astro.detection.files || []) {
     if (await fileExists(file)) {
       return "astro";
     }
   }
 
-  // Check package.json for Astro dependency
+  // Check for SvelteKit config files
+  for (const file of STACKS.sveltekit.detection.files || []) {
+    if (await fileExists(file)) {
+      return "sveltekit";
+    }
+  }
+
+  // Check for Remix config files
+  for (const file of STACKS.remix.detection.files || []) {
+    if (await fileExists(file)) {
+      return "remix";
+    }
+  }
+
+  // Check for Nuxt config files
+  for (const file of STACKS.nuxt.detection.files || []) {
+    if (await fileExists(file)) {
+      return "nuxt";
+    }
+  }
+
+  // Check package.json for all JS framework dependencies (read once)
+  // Priority order: Next.js > Astro > SvelteKit > Remix > Nuxt
   if (await fileExists("package.json")) {
     try {
       const pkg = JSON.parse(await readFile("package.json"));
       const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-      if (deps.astro) {
-        return "astro";
-      }
+      if (deps.next) return "nextjs";
+      if (deps.astro) return "astro";
+      if (deps["@sveltejs/kit"]) return "sveltekit";
+      if (deps["@remix-run/react"]) return "remix";
+      if (deps.nuxt) return "nuxt";
     } catch {
       // Ignore parse errors
     }


### PR DESCRIPTION
## Summary

- Add stack detection for SvelteKit, Remix, and Nuxt meta-frameworks
- Refactor `detectStack()` to read package.json only once for all JS framework dependency checks
- Add new framework choices to interactive init (including Astro which was missing)
- Add comprehensive unit tests for config, detection, and priority

## Implementation Details

| Stack | Config Files | Package Dep | Dev URL |
|-------|--------------|-------------|---------|
| SvelteKit | svelte.config.js/.ts | @sveltejs/kit | localhost:5173 |
| Remix | remix.config.js/.ts | @remix-run/react | localhost:5173 |
| Nuxt | nuxt.config.ts/.js | nuxt | localhost:3000 |

**Detection Priority:** Next.js > Astro > SvelteKit > Remix > Nuxt > Rust > Go > Python

## Test Plan

- [x] Unit tests for each new stack configuration
- [x] Unit tests for file-based detection (all config file variants)
- [x] Unit tests for package.json dependency detection
- [x] Unit tests for priority ordering
- [x] All 188 tests pass
- [x] Build succeeds

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)