### PR TITLE
feat(#3): Add Claude Code CLI check to doctor command

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -128,6 +128,46 @@ describe("doctor command", () => {
     });
   });
 
+  describe("Claude Code CLI checks", () => {
+    it("passes when claude CLI is installed", async () => {
+      mockCommandExists.mockReturnValue(true);
+      mockIsGhAuthenticated.mockReturnValue(true);
+
+      await doctorCommand({});
+
+      const output = consoleLogSpy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Claude Code CLI");
+      expect(output).toContain("claude CLI is installed");
+    });
+
+    it("fails when claude CLI is not installed", async () => {
+      mockCommandExists.mockImplementation((cmd: string) => cmd !== "claude");
+      mockIsGhAuthenticated.mockReturnValue(true);
+
+      await doctorCommand({});
+
+      const output = consoleLogSpy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Claude Code CLI");
+      expect(output).toContain("claude CLI not installed");
+      expect(output).toContain(
+        "https://docs.anthropic.com/en/docs/claude-code",
+      );
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("shows install link when claude CLI is missing", async () => {
+      mockCommandExists.mockImplementation((cmd: string) => cmd !== "claude");
+      mockIsGhAuthenticated.mockReturnValue(true);
+
+      await doctorCommand({});
+
+      const output = consoleLogSpy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain(
+        "https://docs.anthropic.com/en/docs/claude-code",
+      );
+    });
+  });
+
   describe("jq checks", () => {
     it("passes when jq is installed", async () => {
       mockCommandExists.mockReturnValue(true);

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -180,7 +180,23 @@ export async function doctorCommand(options: DoctorOptions): Promise<void> {
     });
   }
 
-  // Check 10: jq installed (optional but recommended)
+  // Check 10: Claude Code CLI installed (critical)
+  if (commandExists("claude")) {
+    checks.push({
+      name: "Claude Code CLI",
+      status: "pass",
+      message: "claude CLI is installed",
+    });
+  } else {
+    checks.push({
+      name: "Claude Code CLI",
+      status: "fail",
+      message:
+        "claude CLI not installed - see: https://docs.anthropic.com/en/docs/claude-code",
+    });
+  }
+
+  // Check 12: jq installed (optional but recommended)
   if (commandExists("jq")) {
     checks.push({
       name: "jq",
@@ -195,7 +211,7 @@ export async function doctorCommand(options: DoctorOptions): Promise<void> {
     });
   }
 
-  // Check 11: Windows platform detection
+  // Check 13: Windows platform detection
   if (isNativeWindows()) {
     checks.push({
       name: "Platform",


### PR DESCRIPTION
## Summary
- Add critical check for `claude` CLI presence in doctor command
- Mark check as critical failure (not warning) - all sequant skills depend on it
- Include install link in error message for easy resolution

## Test plan
- [x] Unit tests pass (`npm test`)
- [x] Build passes (`npm run build`)
- [ ] Manual test: Run `sequant doctor` to verify check appears
- [ ] Manual test: Temporarily rename `claude` binary to verify failure behavior

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)