### PR TITLE
feat(#6): Detect and support Bun package manager

### DIFF
--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -17,6 +17,13 @@ vi.mock("../lib/settings.js", () => ({
 // Mock stacks
 vi.mock("../lib/stacks.js", () => ({
   detectStack: vi.fn(),
+  detectPackageManager: vi.fn(() => Promise.resolve("npm")),
+  getPackageManagerCommands: vi.fn(() => ({
+    run: "npm run",
+    exec: "npx",
+    install: "npm install",
+    installSilent: "npm install --silent",
+  })),
   getStackConfig: vi.fn(() => ({
     name: "generic",
     displayName: "Generic",
@@ -204,7 +211,7 @@ describe("init command", () => {
       expect(mockCopyTemplates).toHaveBeenCalledWith("nextjs", {
         DEV_URL: "http://localhost:3000",
       });
-      expect(mockCreateManifest).toHaveBeenCalledWith("nextjs");
+      expect(mockCreateManifest).toHaveBeenCalledWith("nextjs", "npm");
 
       const output = consoleLogSpy.mock.calls.map((c) => c[0]).join("\n");
       expect(output).toContain("Sequant initialized successfully");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,7 +4,13 @@
 
 import chalk from "chalk";
 import inquirer from "inquirer";
-import { detectStack, getStackConfig } from "../lib/stacks.js";
+import {
+  detectStack,
+  getStackConfig,
+  detectPackageManager,
+  getPackageManagerCommands,
+  type PackageManager,
+} from "../lib/stacks.js";
 import { copyTemplates } from "../lib/templates.js";
 import { createManifest } from "../lib/manifest.js";
 import { saveConfig } from "../lib/config.js";
@@ -137,6 +143,12 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   console.log(chalk.blue(`\n📋 Stack: ${stack}`));
 
+  // Detect package manager
+  const packageManager = await detectPackageManager();
+  if (packageManager) {
+    console.log(chalk.blue(`📦 Package Manager: ${packageManager}`));
+  }
+
   // Get stack config for default dev URL
   const stackConfig = getStackConfig(stack!);
   let devUrl = stackConfig.devUrl;
@@ -212,7 +224,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   // Create manifest
   console.log(chalk.blue("📋 Creating manifest..."));
-  await createManifest(stack!);
+  await createManifest(stack!, packageManager ?? undefined);
 
   // Build optional suggestions section
   const optionalSuggestions = suggestions.filter((s) =>

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -13,6 +13,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
 import { getManifest } from "../lib/manifest.js";
 import { getSettings } from "../lib/settings.js";
+import { getPackageManagerCommands, PM_CONFIG } from "../lib/stacks.js";
 import {
   LogWriter,
   createPhaseLogFromTiming,
@@ -149,6 +150,7 @@ async function ensureWorktree(
   issueNumber: number,
   title: string,
   verbose: boolean,
+  packageManager?: string,
 ): Promise<WorktreeInfo | null> {
   const gitRoot = getGitRoot();
   if (!gitRoot) {
@@ -247,7 +249,11 @@ async function ensureWorktree(
     if (verbose) {
       console.log(chalk.gray(`    📦 Installing dependencies...`));
     }
-    spawnSync("npm", ["install", "--silent"], {
+    // Use detected package manager or default to npm
+    const pm = (packageManager as keyof typeof PM_CONFIG) || "npm";
+    const pmConfig = PM_CONFIG[pm];
+    const [cmd, ...args] = pmConfig.installSilent.split(" ");
+    spawnSync(cmd, args, {
       cwd: worktreePath,
       stdio: "pipe",
     });
@@ -271,13 +277,19 @@ async function ensureWorktree(
 async function ensureWorktrees(
   issues: Array<{ number: number; title: string }>,
   verbose: boolean,
+  packageManager?: string,
 ): Promise<Map<number, WorktreeInfo>> {
   const worktrees = new Map<number, WorktreeInfo>();
 
   console.log(chalk.blue("\n  📂 Preparing worktrees..."));
 
   for (const issue of issues) {
-    const worktree = await ensureWorktree(issue.number, issue.title, verbose);
+    const worktree = await ensureWorktree(
+      issue.number,
+      issue.title,
+      verbose,
+      packageManager,
+    );
     if (worktree) {
       worktrees.set(issue.number, worktree);
     }
@@ -1069,7 +1081,11 @@ export async function runCommand(
       number: num,
       title: issueInfoMap.get(num)?.title || `Issue #${num}`,
     }));
-    worktreeMap = await ensureWorktrees(issueData, config.verbose);
+    worktreeMap = await ensureWorktrees(
+      issueData,
+      config.verbose,
+      manifest.packageManager,
+    );
   }
 
   // Execute

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -3,6 +3,7 @@
  */
 
 import { readFile, writeFile, fileExists } from "./fs.js";
+import type { PackageManager } from "./stacks.js";
 
 const MANIFEST_PATH = ".sequant-manifest.json";
 const PACKAGE_VERSION = "0.1.0";
@@ -10,6 +11,7 @@ const PACKAGE_VERSION = "0.1.0";
 export interface Manifest {
   version: string;
   stack: string;
+  packageManager?: PackageManager;
   installedAt: string;
   updatedAt?: string;
   files: Record<string, string>; // path -> hash
@@ -28,10 +30,14 @@ export async function getManifest(): Promise<Manifest | null> {
   }
 }
 
-export async function createManifest(stack: string): Promise<void> {
+export async function createManifest(
+  stack: string,
+  packageManager?: PackageManager,
+): Promise<void> {
   const manifest: Manifest = {
     version: PACKAGE_VERSION,
     stack,
+    ...(packageManager && { packageManager }),
     installedAt: new Date().toISOString(),
     files: {},
   };

--- a/src/lib/stacks.test.ts
+++ b/src/lib/stacks.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { detectStack, getStackConfig, STACKS } from "./stacks.js";
+import {
+  detectStack,
+  getStackConfig,
+  STACKS,
+  detectPackageManager,
+  getPackageManagerCommands,
+  PM_CONFIG,
+} from "./stacks.js";
 
 // Mock the fs module
 vi.mock("./fs.js", () => ({
@@ -178,5 +185,149 @@ describe("getStackConfig", () => {
   it("returns generic config for empty string", () => {
     const config = getStackConfig("");
     expect(config.name).toBe("generic");
+  });
+});
+
+describe("detectPackageManager", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFileExists.mockResolvedValue(false);
+  });
+
+  describe("lockfile detection", () => {
+    it("detects bun.lockb", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "bun.lockb";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("bun");
+    });
+
+    it("detects bun.lock", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "bun.lock";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("bun");
+    });
+
+    it("detects yarn.lock", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "yarn.lock";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("yarn");
+    });
+
+    it("detects pnpm-lock.yaml", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "pnpm-lock.yaml";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("pnpm");
+    });
+
+    it("detects package-lock.json", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package-lock.json";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("npm");
+    });
+  });
+
+  describe("priority", () => {
+    it("bun takes priority over yarn", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "bun.lockb" || path === "yarn.lock";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("bun");
+    });
+
+    it("yarn takes priority over pnpm", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "yarn.lock" || path === "pnpm-lock.yaml";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("yarn");
+    });
+
+    it("pnpm takes priority over npm", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "pnpm-lock.yaml" || path === "package-lock.json";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("pnpm");
+    });
+  });
+
+  describe("fallback behavior", () => {
+    it("falls back to npm when only package.json exists", async () => {
+      mockFileExists.mockImplementation(async (path) => {
+        return path === "package.json";
+      });
+
+      const result = await detectPackageManager();
+      expect(result).toBe("npm");
+    });
+
+    it("returns null when no package.json exists", async () => {
+      mockFileExists.mockResolvedValue(false);
+
+      const result = await detectPackageManager();
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("getPackageManagerCommands", () => {
+  it("returns correct npm commands", () => {
+    const config = getPackageManagerCommands("npm");
+    expect(config.run).toBe("npm run");
+    expect(config.exec).toBe("npx");
+    expect(config.install).toBe("npm install");
+    expect(config.installSilent).toBe("npm install --silent");
+  });
+
+  it("returns correct bun commands", () => {
+    const config = getPackageManagerCommands("bun");
+    expect(config.run).toBe("bun run");
+    expect(config.exec).toBe("bunx");
+    expect(config.install).toBe("bun install");
+    expect(config.installSilent).toBe("bun install --silent");
+  });
+
+  it("returns correct yarn commands", () => {
+    const config = getPackageManagerCommands("yarn");
+    expect(config.run).toBe("yarn");
+    expect(config.exec).toBe("yarn dlx");
+    expect(config.install).toBe("yarn install");
+    expect(config.installSilent).toBe("yarn install --silent");
+  });
+
+  it("returns correct pnpm commands", () => {
+    const config = getPackageManagerCommands("pnpm");
+    expect(config.run).toBe("pnpm run");
+    expect(config.exec).toBe("pnpm dlx");
+    expect(config.install).toBe("pnpm install");
+    expect(config.installSilent).toBe("pnpm install --silent");
+  });
+});
+
+describe("PM_CONFIG", () => {
+  it("has all supported package managers", () => {
+    expect(PM_CONFIG).toHaveProperty("npm");
+    expect(PM_CONFIG).toHaveProperty("bun");
+    expect(PM_CONFIG).toHaveProperty("yarn");
+    expect(PM_CONFIG).toHaveProperty("pnpm");
   });
 });

--- a/templates/hooks/post-tool.sh
+++ b/templates/hooks/post-tool.sh
@@ -190,14 +190,16 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
 fi
 
 # === DETECT TEST FAILURES ===
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'npm (test|run test)'; then
+# Supports: npm, bun, yarn, pnpm
+if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE '(npm (test|run test)|bun (test|run test)|yarn (test|run test)|pnpm (test|run test))'; then
     if echo "$TOOL_OUTPUT" | grep -qE '(FAIL|failed|Error:)'; then
         echo "$(date +%H:%M:%S) TEST_FAILURE detected" >> "$QUALITY_LOG"
     fi
 fi
 
 # === DETECT BUILD FAILURES ===
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'npm run build'; then
+# Supports: npm, bun, yarn, pnpm
+if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE '(npm run build|bun run build|yarn build|yarn run build|pnpm run build)'; then
     if echo "$TOOL_OUTPUT" | grep -qE '(error TS|Build failed|Error:)'; then
         echo "$(date +%H:%M:%S) BUILD_FAILURE detected" >> "$QUALITY_LOG"
     fi


### PR DESCRIPTION
## Summary
- Add package manager detection from lockfiles (bun > yarn > pnpm > npm priority)
- Store detected package manager in manifest
- Use correct install/run commands for each package manager
- Expand hook detection patterns for all package managers

## Changes
- `src/lib/stacks.ts`: Add `PackageManager` type, `PM_CONFIG`, `detectPackageManager()`, `getPackageManagerCommands()`
- `src/lib/manifest.ts`: Add optional `packageManager` field to Manifest interface
- `src/commands/init.ts`: Detect and display PM, pass to manifest creation
- `src/commands/run.ts`: Use manifest PM for worktree dependency installation
- `src/commands/update.ts`: Use manifest PM for post-update install
- `templates/hooks/post-tool.sh`: Support test/build detection for npm, bun, yarn, pnpm

## Test plan
- [x] Unit tests for `detectPackageManager()` with each lockfile type
- [x] Unit tests for lockfile priority (bun > yarn > pnpm > npm)
- [x] Unit tests for `getPackageManagerCommands()` 
- [x] Unit tests for fallback to npm when only package.json exists
- [x] All 171 tests passing
- [x] Build succeeds with no type errors

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)