### PR TITLE
feat(#15): Document MCP dependencies and make them optional

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -8,7 +8,6 @@ metadata:
 allowed-tools:
   - Read
   - Bash
-  - mcp__chrome-devtools__*
   - Glob
   - Grep
   - TodoWrite
@@ -17,6 +16,8 @@ allowed-tools:
   - Bash(npm run dev:*)
   - Bash(lsof:*)
   - Bash(npx tsx:*)
+  # Optional MCP tools (enhanced functionality if available)
+  # - mcp__chrome-devtools__* (browser automation)
 ---
 
 # Browser Testing Command
@@ -112,6 +113,44 @@ npm run dev
 ```
 
 Wait for server ready before proceeding.
+
+## MCP Availability Check
+
+Before executing browser tests, check if Chrome DevTools MCP is available:
+
+**If Chrome DevTools MCP is available (`mcp__chrome-devtools__*` tools exist):**
+- Use automated browser testing with snapshots and screenshots
+- Full test automation as described in Phase 2
+
+**If Chrome DevTools MCP is NOT available:**
+- Switch to manual testing mode
+- Generate a detailed test checklist for human execution
+- Provide step-by-step manual testing instructions
+- Include expected outcomes for each step
+- Use screenshots taken by the user when provided
+
+**Manual Testing Fallback Template:**
+```markdown
+## Manual Test Checklist
+
+### Test 1: [Test Name]
+**Steps:**
+1. Navigate to [URL]
+2. Click [element]
+3. Enter [value] in [field]
+4. Click [submit button]
+
+**Expected Result:**
+- [Expected behavior]
+- [Expected UI state]
+
+**Actual Result:** [ ] Pass [ ] Fail
+**Notes:** ___
+```
+
+Run `sequant doctor` to check MCP availability.
+
+---
 
 ## Decision Point: Feature Implemented or Not?
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ npx sequant init
 - **📦 Stack Adapters** - Pre-configured for Next.js, Rust, Python, Go
 - **🔄 Update-Safe** - Customize without losing updates
 
+## Optional MCP Integrations
+
+Sequant works fully without any MCP servers, but these optional integrations enhance specific workflows:
+
+| MCP Server | Skills | Purpose | Install |
+|------------|--------|---------|---------|
+| [Chrome DevTools](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-chrome-devtools) | `/test`, `/testgen`, `/loop` | Browser automation for UI testing | See [setup guide](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-chrome-devtools#setup) |
+| [Context7](https://github.com/upstash/context7) | `/exec`, `/fullsolve` | External library documentation lookup | `npx -y @anthropic/mcp-cli add upstash/context7` |
+| [Sequential Thinking](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-sequential-thinking) | `/fullsolve` | Complex multi-step reasoning | See [setup guide](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-sequential-thinking#setup) |
+
+**What happens without MCPs:**
+- `/test` and `/testgen` fall back to manual testing instructions
+- `/exec` uses codebase search instead of library docs lookup
+- `/fullsolve` uses standard reasoning (no extended thinking)
+
+Run `sequant doctor` to check which optional MCPs are configured.
+
 ## Commands
 
 ### CLI Commands


### PR DESCRIPTION
## Summary
- Add MCP server detection to `sequant doctor` command - checks Claude Desktop config for optional MCPs
- Document all optional MCPs in README with installation instructions
- Update test skill with graceful fallback when Chrome DevTools MCP unavailable
- Add comprehensive test coverage for MCP detection logic

## Changes
| File | Changes |
|------|---------|
| `README.md` | Add "Optional MCP Integrations" section with table |
| `src/commands/doctor.ts` | Add MCP check (Check 12) with pass/warn status |
| `src/lib/system.ts` | Add MCP server info, config path detection, check functions |
| `src/commands/doctor.test.ts` | Add 6 tests for MCP detection scenarios |
| `.claude/skills/test/SKILL.md` | Add MCP availability check and manual fallback |

## Acceptance Criteria Coverage
- [x] Document all optional MCPs in README
- [x] Add MCP check to `sequant doctor`
- [x] Update skills to handle missing MCPs gracefully
- [x] Provide install instructions for each MCP
- [ ] Remove mcp__supabase references → Deferred to #12

## Test Plan
- [x] All 240 tests pass
- [x] Build succeeds
- [x] `sequant doctor` shows MCP status (verified manually)
- [x] No new `any` types introduced
- [x] No deleted test files

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)