### PR TITLE
feat(#17): Make /test skill configurable and framework-agnostic

### DIFF
--- a/.claude/skills/test/references/browser-testing-patterns.md
+++ b/.claude/skills/test/references/browser-testing-patterns.md
@@ -21,7 +21,7 @@ Standard pattern for testing forms (login, search, data entry):
 
 ```javascript
 // Step 1: Navigate and identify form fields
-navigate_page({url: "http://localhost:3000/login"})
+navigate_page({url: "{{DEV_URL}}/login"})
 take_snapshot()  // Find UIDs for form elements
 
 // Step 2: Fill form fields
@@ -108,7 +108,7 @@ Pattern for data grids (AG Grid, TanStack Table, custom tables):
 
 ```javascript
 // Step 1: Navigate to grid view
-navigate_page({url: "http://localhost:3000/admin/data"})
+navigate_page({url: "{{DEV_URL}}/admin/data"})
 take_snapshot()  // Identify cell UIDs
 
 // Step 2: Enter edit mode
@@ -325,7 +325,8 @@ wait_for({text: "partial match"})  // Use substring
 // Check if it's in an iframe or shadow DOM
 
 // 4. Server might be slow
-// Ensure dev server is running: lsof -ti:3000
+// Ensure dev server is running: lsof -ti:<PORT>
+// (extract port from DEV_URL in config.json)
 ```
 
 ### Dialog Handling

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -202,6 +202,77 @@ Or modify `.sequant-manifest.json`:
 
 4. **Test updates** - After running `sequant update`, verify your customizations still work.
 
+## Testing Configuration
+
+The `/test` skill uses configurable settings for dev server URL and package manager commands.
+
+### Default Values by Stack
+
+| Stack | Dev URL | Dev Command |
+|-------|---------|-------------|
+| Next.js | `http://localhost:3000` | `npm run dev` |
+| Astro | `http://localhost:4321` | `npm run dev` |
+| SvelteKit | `http://localhost:5173` | `npm run dev` |
+| Vite/Remix | `http://localhost:5173` | `npm run dev` |
+| Nuxt | `http://localhost:3000` | `npm run dev` |
+| Python | `http://localhost:5000` | - |
+| Rust | `http://localhost:8080` | - |
+| Go | `http://localhost:8080` | - |
+| Generic | `http://localhost:3000` | `npm run dev` |
+
+### Customizing Dev Server URL
+
+The dev server URL is set during `sequant init` and stored in `.claude/.sequant/config.json`:
+
+```json
+{
+  "tokens": {
+    "DEV_URL": "http://localhost:4321",
+    "PM_RUN": "npm run"
+  },
+  "stack": "astro",
+  "initialized": "2024-01-01T00:00:00.000Z"
+}
+```
+
+**To change the dev server URL:**
+
+1. Edit `.claude/.sequant/config.json` directly
+2. Update the `DEV_URL` value
+3. Run `sequant update` to refresh templates with the new value
+
+**Example for custom port:**
+```json
+{
+  "tokens": {
+    "DEV_URL": "http://localhost:8080",
+    "PM_RUN": "bun run"
+  }
+}
+```
+
+### Package Manager Detection
+
+Sequant automatically detects your package manager from lockfiles:
+
+| Lockfile | Package Manager | PM_RUN Value |
+|----------|-----------------|--------------|
+| `bun.lockb` or `bun.lock` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn` |
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `package-lock.json` | npm | `npm run` |
+
+The `PM_RUN` token is used in skill templates to run scripts with the correct package manager.
+
+### Chrome DevTools MCP (Optional)
+
+The `/test` skill works best with the Chrome DevTools MCP for browser automation, but it's **optional**:
+
+**With MCP:** Automated browser testing with screenshots and element interaction
+**Without MCP:** Generates a manual testing checklist with URLs and steps
+
+To install Chrome DevTools MCP, see the [MCP documentation](https://github.com/anthropics/claude-code).
+
 ## See Also
 
 - [Stack Guides](stacks/)

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -221,12 +221,13 @@ describe("init command", () => {
       expect(mockCreateDefaultSettings).toHaveBeenCalled();
       expect(mockSaveConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          tokens: { DEV_URL: "http://localhost:3000" },
+          tokens: { DEV_URL: "http://localhost:3000", PM_RUN: "npm run" },
           stack: "nextjs",
         }),
       );
       expect(mockCopyTemplates).toHaveBeenCalledWith("nextjs", {
         DEV_URL: "http://localhost:3000",
+        PM_RUN: "npm run",
       });
       expect(mockCreateManifest).toHaveBeenCalledWith("nextjs", "npm");
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -284,7 +284,13 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   // Save config with tokens
   console.log(chalk.blue("💾 Saving configuration..."));
-  const tokens = { DEV_URL: devUrl };
+  const pmConfig = packageManager
+    ? getPackageManagerCommands(packageManager)
+    : getPackageManagerCommands("npm");
+  const tokens = {
+    DEV_URL: devUrl,
+    PM_RUN: pmConfig.run, // e.g., "npm run", "bun run", "yarn", "pnpm run"
+  };
   await saveConfig({
     tokens,
     stack: stack!,

--- a/templates/skills/test/SKILL.md
+++ b/templates/skills/test/SKILL.md
@@ -8,13 +8,13 @@ metadata:
 allowed-tools:
   - Read
   - Bash
-  - mcp__chrome-devtools__*
+  - mcp__chrome-devtools__*  # Optional: falls back to manual checklist if unavailable
   - Glob
   - Grep
   - TodoWrite
   - Bash(gh issue view:*)
   - Bash(gh issue comment:*)
-  - Bash(npm run dev:*)
+  - Bash({{PM_RUN}} dev:*)
   - Bash(lsof:*)
   - Bash(npx tsx:*)
 ---
@@ -101,17 +101,28 @@ Check for test data requirements:
 
 ### 1.4 Dev Server Check
 
-Check if dev server is running:
+**Extract port from DEV_URL configuration:**
+The dev server URL is configured in `.claude/.sequant/config.json` under `tokens.DEV_URL`. Extract the port for the `lsof` check:
+
 ```bash
-lsof -ti:3000
+# Get DEV_URL from config (default: {{DEV_URL}})
+# Extract port: http://localhost:PORT -> PORT
+DEV_PORT=$(echo "{{DEV_URL}}" | sed -E 's/.*:([0-9]+).*/\1/')
+
+# Check if dev server is running on configured port
+lsof -ti:$DEV_PORT
 ```
 
-If not running, start it:
+If not running, start it using the project's package manager:
 ```bash
-npm run dev
+{{PM_RUN}} dev
 ```
 
 Wait for server ready before proceeding.
+
+**Note:** If `{{DEV_URL}}` or `{{PM_RUN}}` are not replaced with actual values, the defaults are:
+- DEV_URL: `http://localhost:3000` (Next.js), `http://localhost:4321` (Astro), `http://localhost:5173` (Vite-based)
+- PM_RUN: `npm run` (or `bun run`, `yarn`, `pnpm run` based on lockfile)
 
 ## Decision Point: Feature Implemented or Not?
 
@@ -239,6 +250,62 @@ When a bug is discovered during testing:
    - After fix, restart blocked test
    - Mark as PASS/FAIL based on fix
    - Continue with remaining tests
+
+### 2.4 MCP Availability Check (Graceful Fallback)
+
+**Before starting browser automation**, check if Chrome DevTools MCP is available:
+
+```
+Check if mcp__chrome-devtools__* tools are available in your current session.
+```
+
+**If MCP IS available:**
+- Proceed with automated browser testing (Phase 2.1-2.3)
+
+**If MCP is NOT available:**
+- Skip browser automation steps
+- Generate a **Manual Testing Checklist** instead
+
+**Manual Testing Checklist (No MCP Fallback):**
+
+When browser automation is unavailable, generate a structured manual testing guide:
+
+```markdown
+## Manual Testing Checklist for Issue #<N>
+
+**Pre-requisites:**
+- [ ] Dev server running at {{DEV_URL}}
+- [ ] Browser open with DevTools ready
+- [ ] Test data prepared (see section 1.3)
+
+### Test 1: [Description]
+**URL:** {{DEV_URL}}/path/to/feature
+**Steps:**
+1. Navigate to the URL above
+2. [Action to perform]
+3. [Expected result to verify]
+
+**Expected Result:** [What should happen]
+**Actual Result:** [ ] PASS / [ ] FAIL - Notes: ___
+
+### Test 2: [Description]
+**URL:** {{DEV_URL}}/path/to/feature
+**Steps:**
+1. [Step 1]
+2. [Step 2]
+
+**Expected Result:** [What should happen]
+**Actual Result:** [ ] PASS / [ ] FAIL - Notes: ___
+
+---
+**Summary:** Complete each test above and mark PASS/FAIL.
+Post results as a comment on this issue.
+```
+
+**Why this matters:**
+- `/test` skill remains useful even without Chrome DevTools MCP
+- Manual testers can follow the structured checklist
+- Test results format remains consistent for reporting
 
 ## Phase 3: Reporting
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `localhost:3000` with configurable `{{DEV_URL}}` token
- Add `{{PM_RUN}}` token for package manager-aware dev commands
- Add graceful fallback when Chrome DevTools MCP is unavailable
- Generate manual testing checklist as fallback workflow
- Document testing configuration in `docs/customization.md`

## Changes

- `.claude/skills/test/SKILL.md` - Add DEV_URL/PM_RUN tokens, MCP fallback section
- `templates/skills/test/SKILL.md` - Mirror changes to template
- `docs/customization.md` - New documentation for test configuration
- `src/commands/init.ts` - Save PM_RUN config during init
- `src/commands/update.ts` - Add backwards compatibility for PM_RUN

Closes #17
Supersedes #57

🤖 Generated with [Claude Code](https://claude.ai/code)