### PR TITLE
feat(#50): prioritize CI environment in non-interactive message

### DIFF
--- a/src/lib/tty.test.ts
+++ b/src/lib/tty.test.ts
@@ -204,7 +204,7 @@ describe("tty utilities", () => {
       expect(getNonInteractiveReason()).toBeNull();
     });
 
-    it("returns stdin reason when stdin is not TTY", () => {
+    it("returns stdin reason when stdin is not TTY and not in CI", () => {
       Object.defineProperty(process.stdin, "isTTY", {
         value: false,
         writable: true,
@@ -213,12 +213,13 @@ describe("tty utilities", () => {
         value: true,
         writable: true,
       });
+      // No CI env vars set (cleared in beforeEach)
       expect(getNonInteractiveReason()).toBe(
         "stdin is not a terminal (piped input detected)",
       );
     });
 
-    it("returns stdout reason when stdout is not TTY", () => {
+    it("returns stdout reason when stdout is not TTY and not in CI", () => {
       Object.defineProperty(process.stdin, "isTTY", {
         value: true,
         writable: true,
@@ -227,6 +228,7 @@ describe("tty utilities", () => {
         value: false,
         writable: true,
       });
+      // No CI env vars set (cleared in beforeEach)
       expect(getNonInteractiveReason()).toBe("stdout is not a terminal");
     });
 
@@ -257,6 +259,55 @@ describe("tty utilities", () => {
       process.env.GITLAB_CI = "true";
       expect(getNonInteractiveReason()).toBe(
         "running in CI environment (gitlab ci)",
+      );
+    });
+
+    // Tests for CI priority over TTY checks (issue #50)
+    it("returns CI reason when in GitHub Actions even if stdin is non-TTY", () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: false,
+        writable: true,
+      });
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        writable: true,
+      });
+      process.env.GITHUB_ACTIONS = "true";
+      // CI reason should take priority over stdin reason
+      expect(getNonInteractiveReason()).toBe(
+        "running in CI environment (github actions)",
+      );
+    });
+
+    it("returns CI reason when in GitLab CI even if stdout is non-TTY", () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: true,
+        writable: true,
+      });
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        writable: true,
+      });
+      process.env.GITLAB_CI = "true";
+      // CI reason should take priority over stdout reason
+      expect(getNonInteractiveReason()).toBe(
+        "running in CI environment (gitlab ci)",
+      );
+    });
+
+    it("returns CI reason when in CI even if both stdin and stdout are non-TTY", () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: false,
+        writable: true,
+      });
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        writable: true,
+      });
+      process.env.CIRCLECI = "true";
+      // CI reason should take priority over both TTY reasons
+      expect(getNonInteractiveReason()).toBe(
+        "running in CI environment (circleci)",
       );
     });
   });

--- a/src/lib/tty.ts
+++ b/src/lib/tty.ts
@@ -66,14 +66,12 @@ export function shouldUseInteractiveMode(forceInteractive?: boolean): boolean {
 
 /**
  * Get a human-readable reason for non-interactive mode
+ *
+ * Priority order: CI first (more informative), then TTY checks
  */
 export function getNonInteractiveReason(): string | null {
-  if (!isStdinTTY()) {
-    return "stdin is not a terminal (piped input detected)";
-  }
-  if (!isStdoutTTY()) {
-    return "stdout is not a terminal";
-  }
+  // Check CI first - more informative for users in CI environments
+  // (CI typically has non-TTY stdin, but the CI reason is more helpful)
   if (isCI()) {
     // Find which CI environment
     for (const envVar of CI_ENV_VARS) {
@@ -84,5 +82,14 @@ export function getNonInteractiveReason(): string | null {
     }
     return "running in CI environment";
   }
+
+  // Then check TTY
+  if (!isStdinTTY()) {
+    return "stdin is not a terminal (piped input detected)";
+  }
+  if (!isStdoutTTY()) {
+    return "stdout is not a terminal";
+  }
+
   return null;
 }


### PR DESCRIPTION
## Summary

- Reorder checks in `getNonInteractiveReason()` to check CI environment first
- CI environments (GitHub Actions, GitLab CI, etc.) now show the CI name instead of "stdin is not a terminal"
- Add 3 new tests verifying CI priority over TTY checks

## Changes

| File | Changes |
|------|---------|
| `src/lib/tty.ts` | Reorder CI check to top of `getNonInteractiveReason()` |
| `src/lib/tty.test.ts` | Add 3 new priority tests, clarify existing test names |

## Test plan

- [x] `npm test` passes (284 tests)
- [x] `npm run build` passes
- [ ] Manual: Set `GITHUB_ACTIONS=true` and pipe input → should show "running in CI environment (github actions)"

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)