### PR TITLE
feat(#74): implement graceful shutdown for sequant run

### DIFF
--- a/src/lib/shutdown.test.ts
+++ b/src/lib/shutdown.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for ShutdownManager
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ShutdownManager } from "./shutdown.js";
+
+describe("ShutdownManager", () => {
+  let mockOutput: ReturnType<typeof vi.fn>;
+  let mockErrorOutput: ReturnType<typeof vi.fn>;
+  let mockExit: ReturnType<typeof vi.fn>;
+  let manager: ShutdownManager;
+
+  beforeEach(() => {
+    mockOutput = vi.fn();
+    mockErrorOutput = vi.fn();
+    mockExit = vi.fn();
+  });
+
+  afterEach(() => {
+    // Always dispose to remove signal handlers
+    manager?.dispose();
+  });
+
+  function createManager(options?: { forceExitTimeout?: number }) {
+    manager = new ShutdownManager({
+      output: mockOutput,
+      errorOutput: mockErrorOutput,
+      exit: mockExit,
+      forceExitTimeout: options?.forceExitTimeout ?? 10000,
+    });
+    return manager;
+  }
+
+  describe("initialization", () => {
+    it("should start with isShuttingDown = false", () => {
+      const mgr = createManager();
+      expect(mgr.isShuttingDown).toBe(false);
+      expect(mgr.shuttingDown).toBe(false);
+    });
+
+    it("should start with no cleanup tasks", () => {
+      const mgr = createManager();
+      expect(mgr.getCleanupTaskCount()).toBe(0);
+    });
+  });
+
+  describe("cleanup task registration", () => {
+    it("should register cleanup tasks", () => {
+      const mgr = createManager();
+
+      mgr.registerCleanup("Task 1", async () => {});
+      expect(mgr.getCleanupTaskCount()).toBe(1);
+
+      mgr.registerCleanup("Task 2", async () => {});
+      expect(mgr.getCleanupTaskCount()).toBe(2);
+    });
+
+    it("should unregister cleanup tasks by name", () => {
+      const mgr = createManager();
+
+      mgr.registerCleanup("Task 1", async () => {});
+      mgr.registerCleanup("Task 2", async () => {});
+      expect(mgr.getCleanupTaskCount()).toBe(2);
+
+      mgr.unregisterCleanup("Task 1");
+      expect(mgr.getCleanupTaskCount()).toBe(1);
+    });
+
+    it("should not error when unregistering non-existent task", () => {
+      const mgr = createManager();
+      mgr.registerCleanup("Task 1", async () => {});
+
+      // Should not throw
+      mgr.unregisterCleanup("Non-existent");
+      expect(mgr.getCleanupTaskCount()).toBe(1);
+    });
+  });
+
+  describe("graceful shutdown", () => {
+    it("should set isShuttingDown to true", async () => {
+      const mgr = createManager();
+
+      await mgr.gracefulShutdown("SIGINT");
+
+      expect(mgr.isShuttingDown).toBe(true);
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+
+    it("should abort the active controller", async () => {
+      const mgr = createManager();
+      const abortController = new AbortController();
+
+      mgr.setAbortController(abortController);
+      expect(abortController.signal.aborted).toBe(false);
+
+      await mgr.gracefulShutdown("SIGINT");
+
+      expect(abortController.signal.aborted).toBe(true);
+      expect(mockOutput).toHaveBeenCalledWith(
+        expect.stringContaining("Aborted active phase"),
+      );
+    });
+
+    it("should execute cleanup tasks in LIFO order", async () => {
+      const mgr = createManager();
+      const executionOrder: string[] = [];
+
+      mgr.registerCleanup("First", async () => {
+        executionOrder.push("First");
+      });
+      mgr.registerCleanup("Second", async () => {
+        executionOrder.push("Second");
+      });
+      mgr.registerCleanup("Third", async () => {
+        executionOrder.push("Third");
+      });
+
+      await mgr.gracefulShutdown("SIGINT");
+
+      // LIFO: Third, Second, First
+      expect(executionOrder).toEqual(["Third", "Second", "First"]);
+    });
+
+    it("should continue cleanup even if a task fails", async () => {
+      const mgr = createManager();
+      const executionOrder: string[] = [];
+
+      mgr.registerCleanup("First", async () => {
+        executionOrder.push("First");
+      });
+      mgr.registerCleanup("Failing", async () => {
+        throw new Error("Cleanup failed");
+      });
+      mgr.registerCleanup("Third", async () => {
+        executionOrder.push("Third");
+      });
+
+      await mgr.gracefulShutdown("SIGINT");
+
+      // Should execute Third, fail on Failing, then execute First
+      expect(executionOrder).toEqual(["Third", "First"]);
+      expect(mockErrorOutput).toHaveBeenCalledWith(
+        expect.stringContaining("Failing: Cleanup failed"),
+      );
+    });
+
+    it("should print success message for completed cleanup tasks", async () => {
+      const mgr = createManager();
+
+      mgr.registerCleanup("Save logs", async () => {});
+
+      await mgr.gracefulShutdown("SIGINT");
+
+      expect(mockOutput).toHaveBeenCalledWith(
+        expect.stringContaining("✓ Save logs"),
+      );
+    });
+
+    it("should exit with code 0 on successful shutdown", async () => {
+      const mgr = createManager();
+
+      await mgr.gracefulShutdown("SIGINT");
+
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe("double signal (force exit)", () => {
+    it("should force exit on second signal", async () => {
+      vi.useFakeTimers();
+
+      const mgr = createManager({ forceExitTimeout: 10000 });
+
+      // Register a slow task that we'll never complete
+      let taskStarted = false;
+      mgr.registerCleanup("Slow task", async () => {
+        taskStarted = true;
+        // This task hangs indefinitely
+        await new Promise(() => {});
+      });
+
+      // First signal - starts shutdown (don't await)
+      const shutdownPromise = mgr.gracefulShutdown("SIGINT");
+
+      // Wait a tick for the task to start
+      await vi.advanceTimersByTimeAsync(10);
+      expect(taskStarted).toBe(true);
+      expect(mgr.isShuttingDown).toBe(true);
+
+      // Second signal while shutting down - should force exit immediately
+      await mgr.gracefulShutdown("SIGINT");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockErrorOutput).toHaveBeenCalledWith(
+        expect.stringContaining("Force exiting"),
+      );
+
+      vi.useRealTimers();
+
+      // Don't await the hanging promise
+      shutdownPromise.catch(() => {});
+    });
+  });
+
+  describe("timeout", () => {
+    it("should force exit if cleanup takes too long", async () => {
+      vi.useFakeTimers();
+
+      const mgr = createManager({ forceExitTimeout: 100 });
+
+      mgr.registerCleanup("Hanging task", async () => {
+        // This task never completes
+        await new Promise(() => {});
+      });
+
+      // Start shutdown (don't await - it will hang)
+      const shutdownPromise = mgr.gracefulShutdown("SIGINT");
+
+      // Advance timer past timeout
+      await vi.advanceTimersByTimeAsync(150);
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockErrorOutput).toHaveBeenCalledWith(
+        expect.stringContaining("Cleanup timeout"),
+      );
+
+      vi.useRealTimers();
+
+      // Don't await the hanging promise
+      shutdownPromise.catch(() => {});
+    });
+  });
+
+  describe("abort controller management", () => {
+    it("should set and clear abort controller", () => {
+      const mgr = createManager();
+      const controller = new AbortController();
+
+      mgr.setAbortController(controller);
+      // Can't directly test the internal state, but we can test behavior
+
+      mgr.clearAbortController();
+      // After clear, graceful shutdown should not abort anything
+    });
+
+    it("should not error when aborting with no controller set", async () => {
+      const mgr = createManager();
+
+      // Should not throw
+      await mgr.gracefulShutdown("SIGINT");
+
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe("dispose", () => {
+    it("should clear cleanup tasks", () => {
+      const mgr = createManager();
+
+      mgr.registerCleanup("Task 1", async () => {});
+      mgr.registerCleanup("Task 2", async () => {});
+      expect(mgr.getCleanupTaskCount()).toBe(2);
+
+      mgr.dispose();
+      expect(mgr.getCleanupTaskCount()).toBe(0);
+    });
+
+    it("should allow multiple managers in sequence", () => {
+      // Create and dispose first manager
+      const mgr1 = createManager();
+      mgr1.registerCleanup("Task", async () => {});
+      mgr1.dispose();
+
+      // Create second manager - should work without issues
+      const mgr2 = createManager();
+      mgr2.registerCleanup("Task", async () => {});
+      expect(mgr2.getCleanupTaskCount()).toBe(1);
+      mgr2.dispose();
+    });
+  });
+
+  describe("signal handling", () => {
+    it("should handle SIGTERM same as SIGINT", async () => {
+      const mgr = createManager();
+
+      await mgr.gracefulShutdown("SIGTERM");
+
+      expect(mockOutput).toHaveBeenCalledWith(
+        expect.stringContaining("SIGTERM"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -1,0 +1,223 @@
+/**
+ * Graceful shutdown manager for sequant run
+ *
+ * Handles SIGINT/SIGTERM signals and coordinates cleanup tasks
+ * when the process is interrupted.
+ *
+ * @example
+ * ```typescript
+ * const shutdown = new ShutdownManager();
+ *
+ * // Register cleanup tasks
+ * shutdown.registerCleanup('Save logs', async () => {
+ *   await logWriter.finalize();
+ * });
+ *
+ * // Set abort controller for current phase
+ * shutdown.setAbortController(abortController);
+ *
+ * // In finally block
+ * shutdown.dispose();
+ * ```
+ */
+
+import chalk from "chalk";
+
+/**
+ * Cleanup task with name for user feedback
+ */
+interface CleanupTask {
+  name: string;
+  task: () => Promise<void>;
+}
+
+/**
+ * Options for ShutdownManager
+ */
+export interface ShutdownManagerOptions {
+  /** Timeout for cleanup tasks in milliseconds (default: 10000) */
+  forceExitTimeout?: number;
+  /** Custom output function for testing (default: console.log) */
+  output?: (message: string) => void;
+  /** Custom error output function for testing (default: console.error) */
+  errorOutput?: (message: string) => void;
+  /** Custom exit function for testing (default: process.exit) */
+  exit?: (code: number) => void;
+}
+
+/**
+ * Manages graceful shutdown for sequant run
+ *
+ * Features:
+ * - Registers SIGINT/SIGTERM handlers
+ * - Manages cleanup tasks (executed in LIFO order)
+ * - Integrates with AbortController for phase cancellation
+ * - Supports double Ctrl+C for force exit
+ * - Has configurable timeout to prevent hanging
+ */
+export class ShutdownManager {
+  private cleanupTasks: CleanupTask[] = [];
+  private _isShuttingDown = false;
+  private abortController: AbortController | null = null;
+  private forceExitTimeout: number;
+  private output: (message: string) => void;
+  private errorOutput: (message: string) => void;
+  private exit: (code: number) => void;
+
+  // Store bound handlers for removal in dispose()
+  private sigintHandler: () => void;
+  private sigtermHandler: () => void;
+
+  constructor(options: ShutdownManagerOptions = {}) {
+    this.forceExitTimeout = options.forceExitTimeout ?? 10000;
+    this.output = options.output ?? console.log.bind(console);
+    this.errorOutput = options.errorOutput ?? console.error.bind(console);
+    this.exit = options.exit ?? process.exit.bind(process);
+
+    // Bind handlers so we can remove them later
+    this.sigintHandler = () => this.gracefulShutdown("SIGINT");
+    this.sigtermHandler = () => this.gracefulShutdown("SIGTERM");
+
+    // Register signal handlers
+    process.on("SIGINT", this.sigintHandler);
+    process.on("SIGTERM", this.sigtermHandler);
+  }
+
+  /**
+   * Whether a shutdown is currently in progress
+   */
+  get isShuttingDown(): boolean {
+    return this._isShuttingDown;
+  }
+
+  /**
+   * Alias for isShuttingDown (matches proposed API)
+   */
+  get shuttingDown(): boolean {
+    return this._isShuttingDown;
+  }
+
+  /**
+   * Set the abort controller for the current phase
+   *
+   * When shutdown is triggered, this controller will be aborted
+   * to cancel any in-flight operations.
+   */
+  setAbortController(controller: AbortController): void {
+    this.abortController = controller;
+  }
+
+  /**
+   * Clear the abort controller (e.g., after phase completes)
+   */
+  clearAbortController(): void {
+    this.abortController = null;
+  }
+
+  /**
+   * Register a cleanup task
+   *
+   * Tasks are executed in LIFO order (last registered = first executed).
+   * This allows dependent cleanup to happen in correct order.
+   *
+   * @param name - Human-readable name for user feedback
+   * @param task - Async function to execute during cleanup
+   */
+  registerCleanup(name: string, task: () => Promise<void>): void {
+    this.cleanupTasks.push({ name, task });
+  }
+
+  /**
+   * Unregister a cleanup task by name
+   *
+   * Use this when a resource is cleaned up normally (e.g., worktree
+   * removed after successful merge).
+   */
+  unregisterCleanup(name: string): void {
+    this.cleanupTasks = this.cleanupTasks.filter((t) => t.name !== name);
+  }
+
+  /**
+   * Get the number of registered cleanup tasks
+   */
+  getCleanupTaskCount(): number {
+    return this.cleanupTasks.length;
+  }
+
+  /**
+   * Trigger graceful shutdown
+   *
+   * This is called automatically on SIGINT/SIGTERM, but can also
+   * be called programmatically for testing.
+   */
+  async gracefulShutdown(signal: string): Promise<void> {
+    // Double signal = force exit
+    if (this._isShuttingDown) {
+      this.errorOutput(chalk.red("\nForce exiting..."));
+      this.exit(1);
+      return;
+    }
+
+    this._isShuttingDown = true;
+
+    this.output(
+      chalk.yellow(`\n⚠️  Received ${signal}, shutting down gracefully...`),
+    );
+
+    // Abort in-flight phase immediately
+    if (this.abortController) {
+      this.abortController.abort();
+      this.output(chalk.green("✓ Aborted active phase"));
+    }
+
+    // Set up force exit timeout
+    const forceExitTimer = setTimeout(() => {
+      this.errorOutput(chalk.red("Cleanup timeout, force exiting"));
+      this.exit(1);
+    }, this.forceExitTimeout);
+
+    // Run cleanup tasks in reverse order (LIFO)
+    const tasksToRun = [...this.cleanupTasks].reverse();
+
+    for (const { name, task } of tasksToRun) {
+      try {
+        await task();
+        this.output(chalk.green(`✓ ${name}`));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.errorOutput(chalk.red(`✗ ${name}: ${message}`));
+      }
+    }
+
+    clearTimeout(forceExitTimer);
+
+    // Print summary
+    this.output(chalk.yellow("\nInterrupted. Cleanup complete."));
+
+    this.exit(0);
+  }
+
+  /**
+   * Remove signal handlers and clean up
+   *
+   * Call this in a finally block to prevent handler accumulation
+   * across multiple runs in the same process.
+   */
+  dispose(): void {
+    process.removeListener("SIGINT", this.sigintHandler);
+    process.removeListener("SIGTERM", this.sigtermHandler);
+    this.cleanupTasks = [];
+    this.abortController = null;
+  }
+}
+
+/**
+ * Create a shutdown manager with default options
+ *
+ * Convenience function for standard usage.
+ */
+export function createShutdownManager(
+  options?: ShutdownManagerOptions,
+): ShutdownManager {
+  return new ShutdownManager(options);
+}


### PR DESCRIPTION
## Summary

- Add `ShutdownManager` class to handle SIGINT/SIGTERM signals gracefully
- Register cleanup tasks for LogWriter finalization and worktree removal (newly created only)
- Abort active phases via AbortController integration when shutdown is triggered
- Support double Ctrl+C for force exit and configurable timeout (default 10s)

## Implementation Details

**New files:**
- `src/lib/shutdown.ts` - Core ShutdownManager class
- `src/lib/shutdown.test.ts` - 18 unit tests covering all functionality

**Modified:**
- `src/commands/run.ts` - Wire ShutdownManager into run workflow

## Test Plan

- [x] Unit tests for ShutdownManager (18 tests, all passing)
- [x] Full test suite passes (332 tests)
- [x] Build succeeds
- [ ] Manual testing: Ctrl+C during `sequant run` shows cleanup messages and exits cleanly

## AC Coverage

- AC-1: ✅ ShutdownManager initializes signal handlers on construction
- AC-2: ✅ SIGINT triggers graceful shutdown
- AC-3: ✅ LogWriter.finalize() registered as cleanup task
- AC-4: ✅ Worktree cleanup registered for newly created worktrees
- AC-5: ✅ Pre-existing worktrees preserved during cleanup
- AC-6: ✅ User feedback during shutdown ("Received SIGINT...", cleanup status)
- AC-7: ✅ Double Ctrl+C forces immediate exit (code 1)
- AC-8: ✅ 10-second timeout (configurable) for cleanup operations
- AC-9: ✅ SIGTERM handled identically to SIGINT
- AC-10: ✅ 18 unit tests for ShutdownManager

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)