### PR TITLE
fix(#85): Add safeguards against losing unpushed work on main

### DIFF
--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -190,6 +190,23 @@ git branch -a | grep -i "<issue-number>"
 
 **Execution Phase:** Create and work in a feature worktree.
 
+**CRITICAL: Main Branch Safeguard (Issue #85)**
+
+Before starting any implementation, verify you are NOT on the main/master branch:
+
+```bash
+# Check current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "Current branch: $CURRENT_BRANCH"
+```
+
+**If on main/master branch:**
+1. **STOP** - Do not implement directly on main
+2. Create a feature worktree first: `./scripts/dev/new-feature.sh <issue-number>`
+3. Navigate to the worktree before making any changes
+
+**Why this matters:** Work done directly on main can be lost during sync operations (git reset, git pull --rebase, etc.). Worktrees provide isolation and safe recovery through branches.
+
 **If orchestrated (SEQUANT_WORKTREE is set):**
 - Use the provided worktree path directly: `cd $SEQUANT_WORKTREE`
 - Skip steps 1-2 below (worktree already created by orchestrator)

--- a/docs/concepts/worktree-isolation.md
+++ b/docs/concepts/worktree-isolation.md
@@ -196,6 +196,57 @@ Return to any issue with full context:
 - Uncommitted changes
 - Development server state
 
+## Safety Safeguards
+
+Sequant includes automatic safeguards to prevent accidental work loss.
+
+### Hard Reset Protection
+
+The pre-tool hook blocks `git reset --hard` when unpushed commits exist on main:
+
+```bash
+# This will be blocked if you have unpushed commits on main
+git reset --hard origin/main
+# HOOK_BLOCKED: 3 unpushed commit(s) on main would be lost
+#   Push first: git push origin main
+#   Or stash: git stash
+```
+
+**Why this matters:** Work can be permanently lost when `git reset --hard` runs before changes are pushed. This safeguard prevents accidental data loss during sync operations.
+
+**To bypass (if intentional):**
+```bash
+CLAUDE_HOOKS_DISABLED=true git reset --hard origin/main
+```
+
+### Main Branch Protection
+
+The `/exec` skill refuses to implement directly on main/master branch:
+
+```bash
+# Check your branch before implementing
+git rev-parse --abbrev-ref HEAD
+# If on 'main' - create a worktree first!
+./scripts/dev/new-feature.sh <issue-number>
+```
+
+**Why this matters:**
+- Work on main is vulnerable to sync operations
+- No branch means no recovery via reflog
+- Worktrees provide isolated, recoverable work environments
+
+### Hook Log
+
+All blocked operations are logged for debugging:
+
+```bash
+# View blocked operations
+cat /tmp/claude-hook.log
+
+# View quality warnings
+cat /tmp/claude-quality.log
+```
+
 ## Common Operations
 
 ### List Worktrees


### PR DESCRIPTION
## Summary

- Add hard reset protection hook that blocks `git reset --hard` when unpushed commits exist on main/master
- Update `/exec` skill to enforce worktree usage before implementation
- Add Safety Safeguards documentation to `docs/concepts/worktree-isolation.md`

## Changes

| File | Change |
|------|--------|
| `.claude/hooks/pre-tool.sh` | Add hard reset protection (AC-1, AC-2, AC-3) |
| `templates/hooks/pre-tool.sh` | Same protection for new installations |
| `.claude/skills/exec/SKILL.md` | Main branch safeguard (AC-4) |
| `docs/concepts/worktree-isolation.md` | Safety Safeguards section (AC-5) |

## Acceptance Criteria

- [x] `git reset --hard origin/main` is blocked when unpushed commits exist on main
- [x] Warning message shows number of commits that would be lost
- [x] Hook log records blocked reset attempts
- [x] `/exec` skill refuses to implement on main without worktree
- [x] Documentation updated with worktree workflow requirements

## Test plan

- [x] `npm test` - 363 tests pass
- [x] `npm run build` - TypeScript compiles successfully
- [ ] Manual test: Create unpushed commit on main, verify `git reset --hard origin/main` is blocked

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)