### PR TITLE
feat(#99): Add adversarial self-questioning to workflow phases

### DIFF
--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -701,7 +701,42 @@ When in doubt, choose:
 
 The goal is to satisfy AC with the smallest, safest change possible.
 
-### 5. Progress Summary and Draft Issue Update
+### 5. Adversarial Self-Evaluation (REQUIRED)
+
+**Before outputting your final summary**, you MUST complete this adversarial self-evaluation to catch issues that automated checks miss.
+
+**Why this matters:** Sessions show that honest self-questioning consistently catches real issues:
+- Tests that pass but don't cover the actual changes
+- Features that build but don't work as expected
+- AC items marked "done" but with weak implementation
+
+**Answer these questions honestly:**
+1. "Did anything not work as expected during implementation?"
+2. "If this feature broke tomorrow, would the current tests catch it?"
+3. "What's the weakest part of this implementation?"
+4. "Am I reporting success metrics without honest self-evaluation?"
+
+**Include this section in your output:**
+
+```markdown
+### Self-Evaluation
+
+- **Worked as expected:** [Yes/No - if No, explain what didn't work]
+- **Test coverage confidence:** [High/Medium/Low - explain why]
+- **Weakest part:** [Identify the weakest aspect of the implementation]
+- **Honest assessment:** [Any concerns or caveats?]
+```
+
+**If any answer reveals concerns:**
+- Address the issues before proceeding
+- Re-run relevant checks (`npm test`, `npm run build`)
+- Update the self-evaluation after fixes
+
+**Do NOT skip this self-evaluation.** Honest reflection catches issues that automated checks miss.
+
+---
+
+### 6. Progress Summary and Draft Issue Update
 
 **If orchestrated (SEQUANT_ORCHESTRATOR is set):**
 - Skip posting progress comments to GitHub (orchestrator handles summary)
@@ -758,6 +793,7 @@ You may be invoked multiple times for the same issue. Each time, re-establish co
 
 **Before responding, verify your output includes ALL of these:**
 
+- [ ] **Self-Evaluation Completed** - Adversarial self-evaluation section included in output
 - [ ] **AC Progress Summary** - Which AC items are satisfied, partially met, or blocked
 - [ ] **Files Changed** - List of key files modified
 - [ ] **Test/Build Results** - Output from `npm test` and `npm run build`

--- a/.claude/skills/fullsolve/SKILL.md
+++ b/.claude/skills/fullsolve/SKILL.md
@@ -395,6 +395,42 @@ while qa_iteration < 2:
 - Code quality validated
 - Ready for merge
 
+### 4.4 Adversarial Self-Evaluation (REQUIRED)
+
+**Before proceeding to PR creation**, you MUST complete this adversarial self-evaluation to catch issues that all automated phases missed.
+
+**Why this matters:** The full workflow passes automated checks, but honest self-reflection catches:
+- Features that don't actually work as expected
+- Edge cases that weren't tested
+- Integration issues with existing features
+- Success metrics reported without honest evaluation
+
+**Answer these questions honestly:**
+1. "Did anything not work as expected during the entire workflow?"
+2. "If this feature broke tomorrow, would the current tests catch it?"
+3. "What's the weakest part of this implementation?"
+4. "Am I reporting success because checks passed, or because I verified it actually works?"
+
+**Include this section in your output:**
+
+```markdown
+### Self-Evaluation
+
+- **Worked as expected:** [Yes/No - if No, explain what didn't work]
+- **Test coverage confidence:** [High/Medium/Low - explain why]
+- **Weakest part:** [Identify the weakest aspect of the implementation]
+- **Honest assessment:** [Any concerns or caveats about this PR?]
+```
+
+**If any answer reveals concerns:**
+- Address the issues before proceeding to PR creation
+- Re-run relevant quality checks
+- Update the self-evaluation after fixes
+
+**Do NOT skip this self-evaluation.** This is the last opportunity to catch issues before the PR is created.
+
+---
+
 ## Phase 5: Pull Request (PR)
 
 ### 5.1 Create PR (if not exists)
@@ -630,6 +666,7 @@ Each issue gets its own worktree, PR, and quality validation.
 
 **Before responding, verify your output includes ALL of these:**
 
+- [ ] **Self-Evaluation Completed** - Adversarial self-evaluation section included in output
 - [ ] **Progress Table** - Phase, iterations, and status for each phase
 - [ ] **AC Coverage** - Each AC marked MET/PARTIALLY_MET/NOT_MET
 - [ ] **Quality Metrics** - Tests passed, build status, type issues

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -247,7 +247,42 @@ Before any READY_FOR_MERGE verdict, complete the adversarial thinking checklist:
 
 See [testing-requirements.md](references/testing-requirements.md) for edge case checklists.
 
-### 5. A+ Status Verdict
+### 5. Adversarial Self-Evaluation (REQUIRED)
+
+**Before issuing your verdict**, you MUST complete this adversarial self-evaluation to catch issues that automated quality checks miss.
+
+**Why this matters:** QA automation catches type issues, deleted tests, and scope creep - but misses:
+- Features that don't actually work as expected
+- Tests that pass but don't test the right things
+- Edge cases only apparent when actually using the feature
+
+**Answer these questions honestly:**
+1. "Did the implementation actually work when I reviewed it, or am I assuming it works?"
+2. "Do the tests actually test the feature's primary purpose, or just pass?"
+3. "What's the most likely way this feature could break in production?"
+4. "Am I giving a positive verdict because the code looks clean, or because I verified it works?"
+
+**Include this section in your output:**
+
+```markdown
+### Self-Evaluation
+
+- **Verified working:** [Yes/No - did you actually verify the feature works, or assume it does?]
+- **Test efficacy:** [High/Medium/Low - do tests catch the feature breaking?]
+- **Likely failure mode:** [What would most likely break this in production?]
+- **Verdict confidence:** [High/Medium/Low - explain any uncertainty]
+```
+
+**If any answer reveals concerns:**
+- Factor the concerns into your verdict
+- If significant, change verdict to `AC_NOT_MET` or `AC_MET_BUT_NOT_A_PLUS`
+- Document the concerns in the QA comment
+
+**Do NOT skip this self-evaluation.** Honest reflection catches issues that code review cannot.
+
+---
+
+### 6. A+ Status Verdict
 
 Provide an overall verdict:
 
@@ -281,7 +316,7 @@ npx tsx scripts/lib/__tests__/run-security-scan.ts 2>/dev/null
 
 See [scripts/quality-checks.sh](scripts/quality-checks.sh) for the complete automation script.
 
-### 6. Draft Review/QA Comment
+### 7. Draft Review/QA Comment
 
 Produce a Markdown snippet for the PR/issue:
 - Short summary of the change
@@ -289,7 +324,7 @@ Produce a Markdown snippet for the PR/issue:
 - Key strengths and issues
 - Clear, actionable next steps
 
-### 7. Update GitHub Issue
+### 8. Update GitHub Issue
 
 **If orchestrated (SEQUANT_ORCHESTRATOR is set):**
 - Skip posting GitHub comment (orchestrator handles aggregated summary)
@@ -303,7 +338,7 @@ Post the draft comment to GitHub and update labels:
 - `READY_FOR_MERGE`: add `ready-for-review` label
 - `AC_MET_BUT_NOT_A_PLUS`: add `needs-improvement` label
 
-### 8. Documentation Reminder
+### 9. Documentation Reminder
 
 If verdict is `READY_FOR_MERGE` or `AC_MET_BUT_NOT_A_PLUS`:
 
@@ -311,7 +346,7 @@ If verdict is `READY_FOR_MERGE` or `AC_MET_BUT_NOT_A_PLUS`:
 **Documentation:** Before merging, run `/docs <issue>` to generate feature documentation.
 ```
 
-### 9. Script/CLI Execution Verification
+### 10. Script/CLI Execution Verification
 
 **REQUIRED for CLI/script features:** When `scripts/` files are modified, execution verification is required before `READY_FOR_MERGE`.
 
@@ -357,6 +392,7 @@ fi
 
 **Before responding, verify your output includes ALL of these:**
 
+- [ ] **Self-Evaluation Completed** - Adversarial self-evaluation section included in output
 - [ ] **AC Coverage** - Each AC item marked as MET, PARTIALLY_MET, or NOT_MET
 - [ ] **Verdict** - One of: READY_FOR_MERGE, AC_MET_BUT_NOT_A_PLUS, AC_NOT_MET
 - [ ] **Quality Metrics** - Type issues, deleted tests, files changed, additions/deletions


### PR DESCRIPTION
## Summary

- Adds mandatory **adversarial self-evaluation** sections to `/exec`, `/qa`, and `/fullsolve` skills
- Forces the LLM to honestly assess its own work before completing each phase
- Self-evaluation output is visible and auditable in responses

## Changes

Each skill now includes a self-evaluation section with questions like:
- "Did anything not work as expected?"
- "If this feature broke, would tests catch it?"
- "What's the weakest part of this implementation?"
- "Am I reporting success honestly, or just because checks passed?"

The evaluation must be included in the output, making concerns visible to reviewers.

## Test plan

- [x] `npm test` - 363 tests pass
- [x] `npm run build` - Build succeeds
- [ ] Manual: Run `/exec` on a real issue and verify self-evaluation section appears
- [ ] Manual: Run `/qa` on a real issue and verify self-evaluation section appears

## AC Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | `/exec` includes self-evaluation before completion | MET |
| AC-2 | `/qa` includes self-evaluation before verdict | MET |
| AC-3 | `/fullsolve` includes self-evaluation before closing | MET |
| AC-4 | Checkpoint loops until concerns addressed | MET (via instructions) |
| AC-5 | Test efficacy reduced to single question | MET |

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)