### PR TITLE
feat(#111): update /fullsolve to invoke child skills and add --chain to /solve

### DIFF
--- a/.claude/skills/solve/SKILL.md
+++ b/.claude/skills/solve/SKILL.md
@@ -50,6 +50,43 @@ gh issue view <issue-number> --json labels --jq '.labels[].name'
 - Recommend `--quality-loop` flag for auto-retry on failures
 - Quality loop auto-enables for these labels in `sequant run`
 
+### Chain Mode Detection
+
+When analyzing multiple issues, determine if `--chain` flag should be recommended.
+
+**Check for chain indicators:**
+
+```bash
+# Check for dependency keywords in issue body
+gh issue view <issue-number> --json body --jq '.body' | grep -iE "(depends on|blocked by|requires|after #|builds on)"
+
+# Check for sequence labels
+gh issue view <issue-number> --json labels --jq '.labels[].name' | grep -iE "(part-[0-9]|step-[0-9]|phase-[0-9])"
+
+# Check for related issue references
+gh issue view <issue-number> --json body --jq '.body' | grep -oE "#[0-9]+"
+```
+
+**Recommend `--chain` when:**
+- Multiple issues have explicit dependencies (e.g., "depends on #123")
+- Issues are labeled as parts of a sequence (e.g., `part-1`, `part-2`)
+- Issue titles indicate sequence (e.g., "Part 1:", "Step 2:")
+- Issues reference each other in their bodies
+- Issues modify the same files in a specific order
+
+**Do NOT recommend `--chain` when:**
+- Single issue (chain requires 2+ issues)
+- Issues are independent (no shared files or dependencies)
+- Issues touch completely different areas of codebase
+- Parallel batch mode is more appropriate (unrelated issues)
+
+**Chain structure visualization:**
+```
+origin/main → #10 → #11 → #12
+              │      │      │
+              └──────┴──────┴── Each branch builds on previous
+```
+
 ## Output Format
 
 Provide a clear, actionable response with:
@@ -60,13 +97,18 @@ Provide a clear, actionable response with:
    - Labels
    - Recommended workflow
 
-2. **Recommended Commands** in order
+2. **Chain Mode Section** (for multiple issues):
+   - Whether `--chain` is recommended
+   - Why chain is/isn't recommended
+   - Chain structure visualization (if recommended)
 
-3. **CLI Command** - ALWAYS include `npx sequant run <issue>` for terminal/CI usage
+3. **Recommended Commands** in order
 
-4. **Explanation** of why this workflow was chosen
+4. **CLI Command** - ALWAYS include `npx sequant run <issue>` for terminal/CI usage
 
-### Example Output
+5. **Explanation** of why this workflow was chosen
+
+### Example Output (Independent Issues - No Chain)
 
 ```markdown
 ## Solve Workflow for Issues: 152, 153
@@ -77,6 +119,13 @@ Provide a clear, actionable response with:
 |-------|-------|--------|----------|
 | #152 | Add user dashboard | ui, enhancement | Full (with /test) |
 | #153 | Refactor auth module | backend, refactor | Standard + quality loop |
+
+### Chain Mode: ❌ Not Recommended
+
+These issues are **independent** and can be run in parallel:
+- #152 touches UI components
+- #153 touches backend auth module
+- No shared files or dependencies detected
 
 ### Recommended Workflow
 
@@ -99,7 +148,7 @@ Provide a clear, actionable response with:
 
 ### CLI Command
 
-Run from terminal:
+Run from terminal (parallel execution):
 ```bash
 npx sequant run 152 153
 ```
@@ -115,6 +164,59 @@ npx sequant run 153 --quality-loop   # Explicit (auto-enabled for refactor label
 - Issue #152 requires UI testing due to `ui` label
 - Issue #153 will auto-enable quality loop due to `refactor` label
 - Quality loop: auto-retries failed phases up to 3 times
+```
+
+### Example Output (Dependent Issues - Chain Recommended)
+
+```markdown
+## Solve Workflow for Issues: 10, 11, 12
+
+### Issue Analysis
+
+| Issue | Title | Labels | Workflow |
+|-------|-------|--------|----------|
+| #10 | Add auth middleware | backend, part-1 | Standard |
+| #11 | Add login page | ui, part-2 | Full (with /test) |
+| #12 | Add logout functionality | ui, part-3 | Full (with /test) |
+
+### Chain Mode: ✅ Recommended
+
+These issues form a **dependency chain**:
+- #11 body contains "depends on #10"
+- #12 body contains "depends on #11"
+- Issues are labeled as parts of a sequence (part-1, part-2, part-3)
+
+**Chain structure:**
+```
+origin/main → #10 → #11 → #12
+              │      │      │
+              auth   login  logout
+```
+
+### Recommended Workflow
+
+Run sequentially with `--chain`:
+```bash
+npx sequant run 10 11 12 --sequential --chain
+```
+
+This ensures:
+- #10 completes and merges before #11 starts
+- #11 branches from completed #10
+- #12 branches from completed #11
+
+### CLI Command
+
+```bash
+npx sequant run 10 11 12 --sequential --chain
+```
+
+> **Note:** The `--chain` flag ensures each issue builds on the previous. Without it, issues would branch from the same base.
+
+### Notes
+- Issues 10, 11, 12 form a dependency chain
+- Chain mode builds each branch on top of the previous
+- Order matters: run in dependency order (10 → 11 → 12)
 ```
 
 ## Workflow Selection Logic
@@ -179,6 +281,9 @@ npx sequant run 152 153 154
 # Sequential execution (respects dependencies)
 npx sequant run 152 153 --sequential
 
+# Chain mode (each issue branches from previous completed issue)
+npx sequant run 10 11 12 --sequential --chain
+
 # Custom phases
 npx sequant run 152 --phases spec,exec,qa
 
@@ -191,6 +296,28 @@ npx sequant run 152 --quality-loop --max-iterations 5
 # Dry run (shows what would execute)
 npx sequant run 152 --dry-run
 ```
+
+### Chain Mode Explained
+
+The `--chain` flag (requires `--sequential`) creates dependent branches:
+
+```
+Without --chain:          With --chain:
+origin/main               origin/main
+    ├── #10                   └── #10 (merged)
+    ├── #11                       └── #11 (merged)
+    └── #12                           └── #12
+```
+
+**Use `--chain` when:**
+- Issues have explicit dependencies
+- Later issues build on earlier implementations
+- Order matters for correctness
+
+**Do NOT use `--chain` when:**
+- Issues are independent
+- Parallel execution is appropriate
+- Issues can be merged in any order
 
 > **Tip:** Install globally with `npm install -g sequant` to omit the `npx` prefix.
 
@@ -229,6 +356,7 @@ If issues depend on each other:
 **Before responding, verify your output includes ALL of these:**
 
 - [ ] **Issue Summary Table** - Table with Issue, Title, Labels, Workflow columns
+- [ ] **Chain Mode Section** - (for 2+ issues) Whether chain is recommended and why
 - [ ] **Recommended Workflow** - Slash commands in order for each issue
 - [ ] **CLI Command** - `npx sequant run <issue-numbers>` command (REQUIRED)
 - [ ] **Explanation** - Brief notes explaining workflow choices
@@ -248,6 +376,22 @@ You MUST use this exact structure:
 |-------|-------|--------|----------|
 <!-- FILL: one row per issue. For complex/refactor/breaking/major labels, add "+ quality loop" to Workflow -->
 
+<!-- IF 2+ issues, ALWAYS include Chain Mode section: -->
+### Chain Mode: ✅ Recommended / ❌ Not Recommended
+
+<!-- IF chain recommended: -->
+These issues form a **dependency chain**:
+- [List dependency indicators found]
+
+**Chain structure:**
+\`\`\`
+origin/main → #<first> → #<second> → #<third>
+\`\`\`
+
+<!-- IF chain NOT recommended: -->
+These issues are **independent** and can be run in parallel:
+- [List reasons: different areas, no shared files, no dependencies]
+
 ### Recommended Workflow
 
 **For #<N> (<type>):**
@@ -260,6 +404,13 @@ You MUST use this exact structure:
 
 ### CLI Command
 
+<!-- IF chain recommended: -->
+Run with chain mode:
+\`\`\`bash
+npx sequant run <ISSUE_NUMBERS> --sequential --chain
+\`\`\`
+
+<!-- IF chain NOT recommended (parallel OK): -->
 Run from terminal:
 \`\`\`bash
 npx sequant run <ISSUE_NUMBERS>
@@ -275,5 +426,6 @@ npx sequant run <ISSUE_NUMBER> --quality-loop   # Explicit (auto-enabled for <la
 
 ### Notes
 <!-- FILL: explanation of workflow choices -->
+<!-- Include note about chain mode if applicable -->
 <!-- Include note about quality loop auto-enabling if applicable -->
 ```


### PR DESCRIPTION
## Summary

- Updates `/fullsolve` skill to invoke child skills (`/spec`, `/exec`, `/test`, `/qa`) via the `Skill` tool instead of running phases inline
- Adds `--chain` flag recommendations to `/solve` skill for dependent issues

## Changes

### /fullsolve improvements
- **Skill invocation:** Each phase now uses `Skill(skill: "...", args: "<issue>")` instead of inline implementation
- **Orchestration context:** Environment variables (`SEQUANT_ORCHESTRATOR`, `SEQUANT_PHASE`, etc.) passed to child skills
- **Failure handling:** Graceful error handling with iteration loops for each phase
- **Quality loops:** Preserved iteration logic between skill calls (max 3 for exec/test, max 2 for QA)

### /solve --chain recommendations
- **Chain Mode section:** Output now includes chain recommendation for 2+ issues
- **Detection logic:** Checks for dependency keywords, sequence labels, related issue references
- **Visualization:** Shows chain structure diagram (`origin/main → #10 → #11 → #12`)
- **CLI documentation:** Updated with `--chain` flag examples and explanation

## Test plan
- [x] All existing tests pass (378 passed)
- [x] Build succeeds
- [x] No type safety issues
- [x] No deleted tests
- [ ] Manual verification: Run `/fullsolve` on a test issue
- [ ] Manual verification: Run `/solve` with multiple issues

## AC Coverage

| AC | Status |
|----|--------|
| Use Skill tool for child skills | ✅ MET |
| Maintain orchestration context | ✅ MET |
| Handle skill failures gracefully | ✅ MET |
| Preserve quality loop iteration logic | ✅ MET |
| Recommend --chain when appropriate | ✅ MET |
| Do NOT recommend --chain when inappropriate | ✅ MET |
| Add Chain Mode section with visualization | ✅ MET |

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)