### PR TITLE
feat(#87): warn when running from local node_modules

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
 import { readFileSync } from "fs";
 import { initCommand } from "../src/commands/init.js";
+import { isLocalNodeModulesInstall } from "../src/lib/version-check.js";
 
 // Read version from package.json dynamically
 // Works from both source (bin/) and compiled (dist/bin/) locations
@@ -45,6 +46,18 @@ const program = new Command();
 // Handle --no-color before parsing
 if (process.argv.includes("--no-color")) {
   process.env.FORCE_COLOR = "0";
+}
+
+// Warn if running from local node_modules (not npx cache or global)
+// This helps users who accidentally have a stale local install
+if (!process.argv.includes("--quiet") && isLocalNodeModulesInstall()) {
+  console.warn(
+    chalk.yellow(
+      "⚠️  Running sequant from local node_modules\n" +
+        "   For latest version: npx sequant@latest\n" +
+        "   To remove local: npm uninstall sequant\n",
+    ),
+  );
 }
 
 program


### PR DESCRIPTION
## Summary

- Adds a startup warning when CLI runs from a project's local `node_modules` (not npx cache or global install)
- Warning is yellow/non-blocking - doesn't prevent execution
- Includes remediation steps: `npx sequant@latest` and `npm uninstall sequant`
- Respects `--quiet` flag for users who intentionally pin local versions

## AC Coverage

- [x] **AC-1:** Warning shown when running from `*/node_modules/sequant/*`
- [x] **AC-2:** Warning includes remediation steps (npx @latest, npm uninstall)
- [x] **AC-3:** Warning is yellow/non-blocking (doesn't prevent execution)
- [x] **AC-4:** Warning does NOT show when running from npx cache (`~/.npm/_npx/`)
- [x] **AC-5:** Warning does NOT show when running from global install

## Test plan

- [x] All 378 tests pass
- [x] Build succeeds
- [x] Detection logic already tested in `version-check.test.ts`

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)