### PR TITLE
feat(#116): add sequant dashboard CLI command

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -40,6 +40,7 @@ import { statusCommand } from "../src/commands/status.js";
 import { runCommand } from "../src/commands/run.js";
 import { logsCommand } from "../src/commands/logs.js";
 import { statsCommand } from "../src/commands/stats.js";
+import { dashboardCommand } from "../src/commands/dashboard.js";
 
 const program = new Command();
 
@@ -168,6 +169,14 @@ program
   .option("--csv", "Output as CSV")
   .option("--json", "Output as JSON")
   .action(statsCommand);
+
+program
+  .command("dashboard")
+  .description("Start local dashboard web server for workflow visualization")
+  .option("-p, --port <port>", "Custom port (default: 3456)", parseInt)
+  .option("--no-open", "Don't auto-open browser")
+  .option("-v, --verbose", "Verbose output")
+  .action(dashboardCommand);
 
 // Parse and execute
 program.parse();

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -1,0 +1,676 @@
+/**
+ * Dashboard server for Sequant workflow visualization
+ *
+ * Uses Hono for the server, htmx for reactive updates, and Pico CSS for styling.
+ * File watching via chokidar provides live state updates through SSE.
+ *
+ * @example
+ * ```typescript
+ * import { createDashboardServer, startDashboard } from './dashboard/server';
+ *
+ * // Start with defaults
+ * await startDashboard();
+ *
+ * // Or create server for testing
+ * const app = createDashboardServer({ statePath: '.sequant/state.json' });
+ * ```
+ */
+
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { serve } from "@hono/node-server";
+import * as chokidar from "chokidar";
+import * as fs from "fs";
+import * as path from "path";
+import open from "open";
+import {
+  type WorkflowState,
+  type IssueState,
+  type Phase,
+  WORKFLOW_PHASES,
+  STATE_FILE_PATH,
+} from "../src/lib/workflow/state-schema.js";
+
+export interface DashboardOptions {
+  /** Port to run on (default: 3456) */
+  port?: number;
+  /** Path to state.json (default: .sequant/state.json) */
+  statePath?: string;
+  /** Auto-open browser (default: true) */
+  openBrowser?: boolean;
+  /** Verbose logging (default: false) */
+  verbose?: boolean;
+}
+
+interface SSEClient {
+  id: string;
+  send: (data: string) => void;
+}
+
+const clients = new Map<string, SSEClient>();
+let watcher: chokidar.FSWatcher | null = null;
+
+/**
+ * Read and parse the state file
+ */
+function readStateFile(statePath: string): WorkflowState | null {
+  try {
+    if (!fs.existsSync(statePath)) {
+      return null;
+    }
+    const content = fs.readFileSync(statePath, "utf-8");
+    return JSON.parse(content) as WorkflowState;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get phase status class for styling
+ */
+function getPhaseClass(issue: IssueState, phase: Phase): string {
+  const phaseState = issue.phases[phase];
+  if (!phaseState) return "pending";
+  return phaseState.status;
+}
+
+/**
+ * Get phase status icon
+ */
+function getPhaseIcon(issue: IssueState, phase: Phase): string {
+  const phaseState = issue.phases[phase];
+  if (!phaseState) return "○";
+
+  switch (phaseState.status) {
+    case "completed":
+      return "✓";
+    case "in_progress":
+      return "●";
+    case "failed":
+      return "✗";
+    case "skipped":
+      return "−";
+    default:
+      return "○";
+  }
+}
+
+/**
+ * Get status badge color
+ */
+function getStatusColor(status: string): string {
+  switch (status) {
+    case "in_progress":
+      return "var(--pico-primary)";
+    case "ready_for_merge":
+      return "var(--pico-ins-color)";
+    case "merged":
+      return "var(--pico-color-green-550)";
+    case "blocked":
+      return "var(--pico-del-color)";
+    case "abandoned":
+      return "var(--pico-muted-color)";
+    default:
+      return "var(--pico-secondary)";
+  }
+}
+
+/**
+ * Escape HTML entities
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
+ * Format relative time
+ */
+function formatRelativeTime(isoDate: string): string {
+  const now = new Date();
+  const date = new Date(isoDate);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+/**
+ * Render summary cards
+ */
+function renderSummary(issues: IssueState[]): string {
+  const total = issues.length;
+  const inProgress = issues.filter((i) => i.status === "in_progress").length;
+  const readyForMerge = issues.filter(
+    (i) => i.status === "ready_for_merge",
+  ).length;
+  const blocked = issues.filter((i) => i.status === "blocked").length;
+
+  return `
+    <div class="summary-cards">
+      <div class="summary-card">
+        <div class="summary-value">${total}</div>
+        <div class="summary-label">Total Issues</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-value">${inProgress}</div>
+        <div class="summary-label">In Progress</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-value">${readyForMerge}</div>
+        <div class="summary-label">Ready to Merge</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-value">${blocked}</div>
+        <div class="summary-label">Blocked</div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render a single issue card
+ */
+function renderIssueCard(issue: IssueState): string {
+  // Show main phases (excluding security-review and loop for cleaner UI)
+  const phases = WORKFLOW_PHASES.filter(
+    (p) => p !== "security-review" && p !== "loop",
+  );
+
+  const phaseItems = phases
+    .map(
+      (phase) => `
+      <div class="phase-item ${getPhaseClass(issue, phase)}">
+        <span class="phase-icon">${getPhaseIcon(issue, phase)}</span>
+        <span class="phase-label">${phase}</span>
+      </div>
+    `,
+    )
+    .join("");
+
+  const lastActivity = new Date(issue.lastActivity).toLocaleString();
+  const prLink = issue.pr
+    ? `<a href="${issue.pr.url}" class="pr-link" target="_blank">PR #${issue.pr.number}</a>`
+    : "No PR";
+
+  return `
+    <article class="issue-card">
+      <div class="issue-header">
+        <span class="issue-number">#${issue.number}</span>
+        <span class="status-badge" style="background: ${getStatusColor(issue.status)}; color: white;">
+          ${issue.status.replace(/_/g, " ")}
+        </span>
+      </div>
+      <h3 class="issue-title">${escapeHtml(issue.title)}</h3>
+      <div class="phase-bar">
+        ${phaseItems}
+      </div>
+      <div class="meta-row">
+        <span>${prLink}</span>
+        <span title="${lastActivity}">Updated ${formatRelativeTime(issue.lastActivity)}</span>
+      </div>
+    </article>
+  `;
+}
+
+/**
+ * Render the main dashboard HTML
+ */
+function renderDashboard(state: WorkflowState | null): string {
+  const issues = state ? Object.values(state.issues) : [];
+  const sortedIssues = issues.sort(
+    (a, b) =>
+      new Date(b.lastActivity).getTime() - new Date(a.lastActivity).getTime(),
+  );
+
+  const issueCards = sortedIssues
+    .map((issue) => renderIssueCard(issue))
+    .join("");
+
+  const emptyState = `
+    <article>
+      <header>
+        <h3>No Issues Tracked</h3>
+      </header>
+      <p>Run <code>sequant run &lt;issue&gt;</code> to start tracking workflow progress.</p>
+    </article>
+  `;
+
+  return `<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sequant Dashboard</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/sse.js"></script>
+  <style>
+    :root {
+      --phase-pending: var(--pico-secondary);
+      --phase-in_progress: var(--pico-primary);
+      --phase-completed: var(--pico-ins-color);
+      --phase-failed: var(--pico-del-color);
+      --phase-skipped: var(--pico-muted-color);
+    }
+
+    .header-bar {
+      background: var(--pico-background-color);
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      padding: 1rem 0;
+      margin-bottom: 2rem;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .header-content {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 0 1rem;
+    }
+
+    .header-title {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    .header-status {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.875rem;
+      color: var(--pico-muted-color);
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--pico-ins-color);
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    .issue-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .issue-card {
+      margin: 0;
+    }
+
+    .issue-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 0;
+    }
+
+    .issue-number {
+      font-weight: bold;
+      color: var(--pico-primary);
+    }
+
+    .issue-title {
+      margin: 0.5rem 0 1rem;
+      font-size: 1rem;
+      font-weight: 500;
+    }
+
+    .status-badge {
+      font-size: 0.75rem;
+      padding: 0.25rem 0.5rem;
+      border-radius: var(--pico-border-radius);
+      text-transform: uppercase;
+      font-weight: 600;
+    }
+
+    .phase-bar {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .phase-item {
+      flex: 1;
+      text-align: center;
+      padding: 0.5rem 0.25rem;
+      border-radius: var(--pico-border-radius);
+      font-size: 0.75rem;
+      transition: all 0.2s;
+    }
+
+    .phase-item.pending {
+      background: var(--pico-secondary-background);
+      color: var(--pico-secondary);
+    }
+
+    .phase-item.in_progress {
+      background: color-mix(in srgb, var(--pico-primary) 20%, transparent);
+      color: var(--pico-primary);
+      font-weight: 600;
+    }
+
+    .phase-item.completed {
+      background: color-mix(in srgb, var(--pico-ins-color) 20%, transparent);
+      color: var(--pico-ins-color);
+    }
+
+    .phase-item.failed {
+      background: color-mix(in srgb, var(--pico-del-color) 20%, transparent);
+      color: var(--pico-del-color);
+    }
+
+    .phase-item.skipped {
+      background: var(--pico-secondary-background);
+      color: var(--pico-muted-color);
+      text-decoration: line-through;
+    }
+
+    .phase-icon {
+      display: block;
+      font-size: 1rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .phase-label {
+      display: block;
+      font-size: 0.625rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .meta-row {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.75rem;
+      color: var(--pico-muted-color);
+      margin-top: 1rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid var(--pico-muted-border-color);
+    }
+
+    .pr-link {
+      color: var(--pico-primary);
+    }
+
+    .summary-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+
+    .summary-card {
+      text-align: center;
+      padding: 1rem;
+      background: var(--pico-card-background-color);
+      border-radius: var(--pico-border-radius);
+      border: 1px solid var(--pico-muted-border-color);
+    }
+
+    .summary-value {
+      font-size: 2rem;
+      font-weight: bold;
+      color: var(--pico-primary);
+    }
+
+    .summary-label {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      color: var(--pico-muted-color);
+    }
+
+    .container {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 0 1rem 2rem;
+    }
+  </style>
+</head>
+<body hx-ext="sse" sse-connect="/events" sse-swap="state-update">
+  <header class="header-bar">
+    <div class="header-content">
+      <h1 class="header-title">⚗️ Sequant Dashboard</h1>
+      <div class="header-status">
+        <span class="status-dot"></span>
+        <span>Live</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="container" id="dashboard-content">
+    ${renderSummary(sortedIssues)}
+    <div class="issue-grid" id="issue-list">
+      ${issueCards || emptyState}
+    </div>
+  </main>
+
+  <script>
+    // Handle theme toggle based on system preference
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+    if (prefersDark.matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    }
+    prefersDark.addEventListener('change', (e) => {
+      document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+    });
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * Create the Hono dashboard server
+ */
+export function createDashboardServer(options: DashboardOptions = {}): Hono {
+  const statePath = options.statePath ?? STATE_FILE_PATH;
+  const verbose = options.verbose ?? false;
+
+  const app = new Hono();
+
+  // Main dashboard route
+  app.get("/", (c) => {
+    const state = readStateFile(statePath);
+    return c.html(renderDashboard(state));
+  });
+
+  // API endpoint for current state (JSON)
+  app.get("/api/state", (c) => {
+    const state = readStateFile(statePath);
+    return c.json(state ?? { version: 1, lastUpdated: null, issues: {} });
+  });
+
+  // SSE endpoint for live updates
+  app.get("/events", async (c) => {
+    return streamSSE(c, async (stream) => {
+      const clientId = crypto.randomUUID();
+
+      if (verbose) {
+        console.log(`[Dashboard] SSE client connected: ${clientId}`);
+      }
+
+      // Store client for broadcasting
+      clients.set(clientId, {
+        id: clientId,
+        send: (data: string) => {
+          stream.writeSSE({ event: "state-update", data });
+        },
+      });
+
+      // Send initial state
+      const state = readStateFile(statePath);
+      const content = renderDashboard(state);
+      await stream.writeSSE({
+        event: "state-update",
+        data: content,
+      });
+
+      // Keep connection alive with heartbeat
+      const heartbeat = setInterval(async () => {
+        try {
+          await stream.writeSSE({ event: "heartbeat", data: "ping" });
+        } catch {
+          // Connection closed
+          clearInterval(heartbeat);
+        }
+      }, 30000);
+
+      // Cleanup on disconnect
+      stream.onAbort(() => {
+        if (verbose) {
+          console.log(`[Dashboard] SSE client disconnected: ${clientId}`);
+        }
+        clients.delete(clientId);
+        clearInterval(heartbeat);
+      });
+
+      // Keep the stream open
+      while (true) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    });
+  });
+
+  // Partial endpoint for htmx swaps
+  app.get("/partials/issues", (c) => {
+    const state = readStateFile(statePath);
+    const issues = state ? Object.values(state.issues) : [];
+    const sortedIssues = issues.sort(
+      (a, b) =>
+        new Date(b.lastActivity).getTime() - new Date(a.lastActivity).getTime(),
+    );
+
+    const issueCards = sortedIssues
+      .map((issue) => renderIssueCard(issue))
+      .join("");
+
+    const emptyState = `
+      <article>
+        <header>
+          <h3>No Issues Tracked</h3>
+        </header>
+        <p>Run <code>sequant run &lt;issue&gt;</code> to start tracking workflow progress.</p>
+      </article>
+    `;
+
+    return c.html(`
+      ${renderSummary(sortedIssues)}
+      <div class="issue-grid" id="issue-list">
+        ${issueCards || emptyState}
+      </div>
+    `);
+  });
+
+  return app;
+}
+
+/**
+ * Broadcast state update to all connected SSE clients
+ */
+function broadcastStateUpdate(statePath: string): void {
+  const state = readStateFile(statePath);
+  const content = renderDashboard(state);
+
+  for (const client of clients.values()) {
+    try {
+      client.send(content);
+    } catch {
+      // Client disconnected
+      clients.delete(client.id);
+    }
+  }
+}
+
+/**
+ * Start the dashboard server with file watching
+ */
+export async function startDashboard(
+  options: DashboardOptions = {},
+): Promise<void> {
+  const port = options.port ?? 3456;
+  const statePath = options.statePath ?? STATE_FILE_PATH;
+  const openBrowser = options.openBrowser ?? true;
+  const verbose = options.verbose ?? false;
+
+  const app = createDashboardServer(options);
+
+  // Ensure state directory exists for file watcher
+  const stateDir = path.dirname(statePath);
+  if (!fs.existsSync(stateDir)) {
+    fs.mkdirSync(stateDir, { recursive: true });
+  }
+
+  // Start file watcher for live updates
+  watcher = chokidar.watch(statePath, {
+    persistent: true,
+    ignoreInitial: true,
+  });
+
+  watcher.on("change", () => {
+    if (verbose) {
+      console.log("[Dashboard] State file changed, broadcasting update");
+    }
+    broadcastStateUpdate(statePath);
+  });
+
+  watcher.on("add", () => {
+    if (verbose) {
+      console.log("[Dashboard] State file created, broadcasting update");
+    }
+    broadcastStateUpdate(statePath);
+  });
+
+  // Start server
+  console.log(`\n⚗️  Sequant Dashboard starting on http://localhost:${port}\n`);
+
+  serve({
+    fetch: app.fetch,
+    port,
+  });
+
+  if (openBrowser) {
+    await open(`http://localhost:${port}`);
+  }
+
+  console.log("Press Ctrl+C to stop\n");
+
+  // Handle graceful shutdown
+  process.on("SIGINT", () => {
+    console.log("\n[Dashboard] Shutting down...");
+    if (watcher) {
+      watcher.close();
+    }
+    process.exit(0);
+  });
+}
+
+/**
+ * Stop the dashboard (for testing)
+ */
+export function stopDashboard(): void {
+  if (watcher) {
+    watcher.close();
+    watcher = null;
+  }
+  clients.clear();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.11",
+        "@hono/node-server": "^1.19.9",
         "chalk": "^5.3.0",
+        "chokidar": "^5.0.0",
         "commander": "^12.1.0",
         "diff": "^7.0.0",
+        "hono": "^4.11.4",
         "inquirer": "^12.3.2",
+        "open": "^11.0.0",
         "yaml": "^2.7.0",
         "zod": "^4.3.5"
       },
@@ -702,6 +706,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2248,6 +2264,21 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2311,6 +2342,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cli-width": {
@@ -2405,6 +2451,46 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
+      "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -2888,6 +2974,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
@@ -2967,6 +3062,21 @@
         }
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2997,6 +3107,51 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3169,6 +3324,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3318,6 +3493,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3336,6 +3523,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/resolve-from": {
@@ -3401,6 +3601,18 @@
         "@rollup/rollup-win32-x64-gnu": "4.55.1",
         "@rollup/rollup-win32-x64-msvc": "4.55.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-async": {
@@ -3965,6 +4177,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,14 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.11",
+    "@hono/node-server": "^1.19.9",
     "chalk": "^5.3.0",
+    "chokidar": "^5.0.0",
     "commander": "^12.1.0",
     "diff": "^7.0.0",
+    "hono": "^4.11.4",
     "inquirer": "^12.3.2",
+    "open": "^11.0.0",
     "yaml": "^2.7.0",
     "zod": "^4.3.5"
   },

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the dashboard command
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { dashboardCommand } from "./dashboard.js";
+
+// Mock the dashboard server module
+vi.mock("../../dashboard/server.js", () => ({
+  startDashboard: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("dashboardCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should start dashboard with default options", async () => {
+    const { startDashboard } = await import("../../dashboard/server.js");
+
+    // Don't actually start server - the mock will intercept
+    await dashboardCommand({});
+
+    expect(startDashboard).toHaveBeenCalledWith({
+      port: 3456,
+      openBrowser: true,
+      verbose: false,
+    });
+  });
+
+  it("should respect custom port option", async () => {
+    const { startDashboard } = await import("../../dashboard/server.js");
+
+    await dashboardCommand({ port: 8080 });
+
+    expect(startDashboard).toHaveBeenCalledWith({
+      port: 8080,
+      openBrowser: true,
+      verbose: false,
+    });
+  });
+
+  it("should respect --no-open option", async () => {
+    const { startDashboard } = await import("../../dashboard/server.js");
+
+    await dashboardCommand({ noOpen: true });
+
+    expect(startDashboard).toHaveBeenCalledWith({
+      port: 3456,
+      openBrowser: false,
+      verbose: false,
+    });
+  });
+
+  it("should respect verbose option", async () => {
+    const { startDashboard } = await import("../../dashboard/server.js");
+
+    await dashboardCommand({ verbose: true });
+
+    expect(startDashboard).toHaveBeenCalledWith({
+      port: 3456,
+      openBrowser: true,
+      verbose: true,
+    });
+  });
+
+  it("should combine multiple options", async () => {
+    const { startDashboard } = await import("../../dashboard/server.js");
+
+    await dashboardCommand({ port: 9000, noOpen: true, verbose: true });
+
+    expect(startDashboard).toHaveBeenCalledWith({
+      port: 9000,
+      openBrowser: false,
+      verbose: true,
+    });
+  });
+});

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,0 +1,40 @@
+/**
+ * Dashboard command - Visual workflow status in browser
+ *
+ * Starts a local web server with live-updating dashboard showing
+ * all tracked issues and their workflow phase status.
+ */
+
+import chalk from "chalk";
+
+export interface DashboardCommandOptions {
+  /** Custom port (default: 3456) */
+  port?: number;
+  /** Skip browser auto-open (default: false) */
+  noOpen?: boolean;
+  /** Verbose output (default: false) */
+  verbose?: boolean;
+}
+
+export async function dashboardCommand(
+  options: DashboardCommandOptions,
+): Promise<void> {
+  const { startDashboard } = await import("../../dashboard/server.js");
+
+  console.log(chalk.cyan("\n⚗️  Starting Sequant Dashboard...\n"));
+
+  try {
+    await startDashboard({
+      port: options.port ?? 3456,
+      openBrowser: !options.noOpen,
+      verbose: options.verbose ?? false,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(chalk.red(`Failed to start dashboard: ${error.message}`));
+    } else {
+      console.error(chalk.red("Failed to start dashboard"));
+    }
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `sequant dashboard` CLI command to start a local web server for workflow visualization
- Dashboard displays all tracked issues with their workflow phase status
- Supports real-time updates via Server-Sent Events (SSE)

## Features
- `sequant dashboard` - starts server on localhost:3456 and opens browser
- `--port <port>` - use custom port
- `--no-open` - skip browser auto-open
- `-v, --verbose` - enable verbose logging
- Graceful shutdown on Ctrl+C with cleanup

## Test plan
- [x] `npm test` passes (444 tests)
- [x] `npm run build` passes
- [x] `sequant dashboard --help` shows correct options
- [ ] Manual: `sequant dashboard` starts server and opens browser
- [ ] Manual: `sequant dashboard --port 8080` uses custom port
- [ ] Manual: `sequant dashboard --no-open` doesn't open browser
- [ ] Manual: Ctrl+C shuts down gracefully

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)