### PR TITLE
fix(#109): /qa detects templates/scripts/ changes for verification

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -427,7 +427,7 @@ If verdict is `READY_FOR_MERGE` or `AC_MET_BUT_NOT_A_PLUS`:
 
 **Detection:**
 ```bash
-scripts_changed=$(git diff main...HEAD --name-only | grep "^scripts/" | wc -l | xargs)
+scripts_changed=$(git diff main...HEAD --name-only | grep -E "^(scripts/|templates/scripts/)" | wc -l | xargs)
 if [[ $scripts_changed -gt 0 ]]; then
   echo "Script changes detected. Run /verify before READY_FOR_MERGE"
 fi
@@ -450,7 +450,7 @@ fi
 
 **Example workflow:**
 ```bash
-# QA detects scripts/ changes
+# QA detects scripts/ or templates/scripts/ changes
 # -> Prompt: "Run /verify before READY_FOR_MERGE"
 
 /verify 558 --command "npx tsx scripts/migrate.ts --dry-run"


### PR DESCRIPTION
## Summary

- Updates `/qa` script detection pattern to include `templates/scripts/` in addition to `scripts/`
- This ensures changes to template scripts (the canonical script location) trigger the `/verify` requirement before `READY_FOR_MERGE` verdict
- Fixes gap discovered in #103 where template script changes passed QA without verification

## Test plan

- [ ] Verify that changes to `templates/scripts/` files are detected by `/qa`
- [ ] Verify that `/qa` prompts for `/verify` when template scripts are modified
- [ ] Verify that `READY_FOR_MERGE` is withheld without execution verification for template script changes

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)