### PR TITLE
feat(#132): add local-first analytics for workflow insights

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,190 @@
+# Local Analytics
+
+Sequant collects local workflow analytics to help you understand your patterns and optimize issue sizing. **All data stays on your machine** - no telemetry is ever sent remotely.
+
+## Overview
+
+Every `sequant run` execution records metrics to `.sequant/metrics.json`. This enables:
+
+- Understanding optimal issue complexity for AI-assisted workflows
+- Identifying patterns in success vs. failure
+- Tracking changes over time
+- Optimizing workflow configuration
+
+## Privacy Principles
+
+1. **Local-only** - Data never leaves your machine
+2. **Transparent** - You can inspect `.sequant/metrics.json` anytime
+3. **Minimal** - Only collects what's needed for insights
+4. **No PII** - No file paths, code content, issue titles, or error messages
+5. **User-owned** - Delete anytime with `rm .sequant/metrics.json`
+
+## What We Collect
+
+| Field | Description | Privacy |
+|-------|-------------|---------|
+| `id` | Unique run identifier (UUID) | Anonymous |
+| `date` | Run timestamp | No personal data |
+| `issues` | Issue numbers only | No titles/content |
+| `phases` | Phases executed | Configuration |
+| `outcome` | success/partial/failed | Aggregate status |
+| `duration` | Total run time (seconds) | Performance metric |
+| `model` | Model used (e.g., "opus") | Configuration |
+| `flags` | CLI flags used | Configuration |
+| `metrics.filesChanged` | Number of files changed | Aggregate count |
+| `metrics.linesAdded` | Lines of code added | Aggregate count |
+| `metrics.qaIterations` | QA retry count | Performance metric |
+
+## What We DON'T Collect
+
+- File paths or names
+- Code content
+- Issue titles or descriptions
+- Error messages (could contain sensitive info)
+- API keys or credentials
+- Any personally identifiable information
+
+## Viewing Analytics
+
+```bash
+# Human-readable analytics with insights
+sequant stats
+
+# JSON output for programmatic access
+sequant stats --json
+```
+
+### Example Output
+
+```
+📊 Sequant Analytics (local data only)
+
+  Runs: 47 total
+    Success: 38 (81%)
+    Partial: 6
+    Failed: 3
+
+  Averages
+  ─────────────────────────────────
+  Files changed: 6.2
+  Lines added: 380
+  Duration: 8m 30s
+
+  Insights
+  ─────────────────────────────────
+  • Strong success rate: 81%
+  • Your sweet spot: 6.2 files changed avg
+  • Optimal LOC range: ~380 lines avg
+
+  Data stored locally in .sequant/metrics.json
+```
+
+## Insights
+
+The analytics engine generates insights based on your historical data:
+
+### Success Rate Insights
+- **Strong** (≥80%): Your workflow is effective
+- **Moderate** (60-79%): Consider simpler acceptance criteria
+- **Low** (<60%): Review issue complexity
+
+### File Change Insights
+- **Sweet spot** (≤5 files): Optimal scope
+- **Moderate** (5-10 files): Acceptable scope
+- **High** (>10 files): Consider splitting issues
+
+### Lines of Code Insights
+- **Optimal** (200-400 LOC): Good issue sizing
+- **Large** (>500 LOC): Consider splitting issues
+
+### Mode Comparison
+- Compares chain mode vs. single issue success rates
+- Compares multi-issue vs. single issue runs
+
+## JSON Schema
+
+### Metrics File (version 1)
+
+```typescript
+interface Metrics {
+  version: 1;
+  runs: MetricRun[];
+}
+
+interface MetricRun {
+  id: string;              // UUID
+  date: string;            // ISO 8601
+  issues: number[];        // Issue numbers only
+  phases: Phase[];         // Executed phases
+  outcome: "success" | "partial" | "failed";
+  duration: number;        // Seconds
+  model: string;           // e.g., "opus"
+  flags: string[];         // e.g., ["--chain"]
+  metrics: RunMetrics;
+}
+
+interface RunMetrics {
+  tokensUsed: number;      // Reserved (0 if unavailable)
+  filesChanged: number;
+  linesAdded: number;
+  acceptanceCriteria: number;
+  qaIterations: number;
+}
+
+type Phase = "spec" | "security-review" | "testgen" | "exec" | "test" | "qa" | "loop";
+```
+
+## Configuration
+
+Metrics collection is automatic and cannot be disabled (it's privacy-respecting by design). The file is stored at `.sequant/metrics.json` in your project.
+
+### Gitignore
+
+The `.sequant/` directory is already in the default `.gitignore` template, so your local analytics won't be committed:
+
+```
+# .gitignore
+.sequant/
+```
+
+## Analyzing with jq
+
+```bash
+# Count total runs
+jq '.runs | length' .sequant/metrics.json
+
+# Get success rate
+jq '[.runs[].outcome] | group_by(.) | map({outcome: .[0], count: length})' .sequant/metrics.json
+
+# Average files changed
+jq '[.runs[].metrics.filesChanged] | add / length' .sequant/metrics.json
+
+# Runs with >10 files changed
+jq '.runs[] | select(.metrics.filesChanged > 10) | {date, issues, filesChanged: .metrics.filesChanged}' .sequant/metrics.json
+
+# Chain mode runs
+jq '.runs[] | select(.flags | contains(["--chain"]))' .sequant/metrics.json
+```
+
+## Deleting Analytics
+
+To remove all local analytics:
+
+```bash
+rm .sequant/metrics.json
+```
+
+A new file will be created on the next `sequant run`.
+
+## Comparison with Logging
+
+| Feature | Logging (.sequant/logs/) | Analytics (.sequant/metrics.json) |
+|---------|--------------------------|-----------------------------------|
+| Purpose | Debugging, audit trail | Pattern analysis, insights |
+| Contains | Full execution details | Aggregate metrics only |
+| Privacy | May contain file paths | Privacy-focused, no paths |
+| Size | Grows with each run | Single file, compact |
+| Retention | Rotated by size/count | Kept indefinitely |
+
+Use **logging** when you need to debug specific runs.
+Use **analytics** when you want to understand patterns over time.

--- a/src/commands/stats.test.ts
+++ b/src/commands/stats.test.ts
@@ -111,11 +111,11 @@ describe("statsCommand", () => {
       (fs.readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
     });
 
-    it("should show no logs message for human output", async () => {
+    it("should show no data message for human output", async () => {
       await statsCommand({});
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("No logs found"),
+        expect.stringContaining("No data found"),
       );
     });
 

--- a/src/lib/workflow/metrics-schema.test.ts
+++ b/src/lib/workflow/metrics-schema.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for metrics schema
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  MetricsSchema,
+  MetricRunSchema,
+  RunMetricsSchema,
+  createEmptyMetrics,
+  createMetricRun,
+  determineOutcome,
+  type Metrics,
+  type MetricRun,
+} from "./metrics-schema.js";
+
+describe("metrics-schema", () => {
+  describe("MetricsSchema", () => {
+    it("should validate empty metrics", () => {
+      const metrics = createEmptyMetrics();
+
+      expect(() => MetricsSchema.parse(metrics)).not.toThrow();
+      expect(metrics.version).toBe(1);
+      expect(metrics.runs).toEqual([]);
+    });
+
+    it("should validate metrics with runs", () => {
+      const metrics: Metrics = {
+        version: 1,
+        runs: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            date: "2026-01-20T12:00:00.000Z",
+            issues: [123, 124],
+            phases: ["spec", "exec", "qa"],
+            outcome: "success",
+            duration: 720,
+            model: "opus",
+            flags: ["--chain", "--sequential"],
+            metrics: {
+              tokensUsed: 45000,
+              filesChanged: 9,
+              linesAdded: 1800,
+              acceptanceCriteria: 5,
+              qaIterations: 2,
+            },
+          },
+        ],
+      };
+
+      const parsed = MetricsSchema.parse(metrics);
+      expect(parsed.runs.length).toBe(1);
+      expect(parsed.runs[0].issues).toEqual([123, 124]);
+    });
+
+    it("should reject invalid version", () => {
+      const invalid = {
+        version: 2,
+        runs: [],
+      };
+
+      expect(() => MetricsSchema.parse(invalid)).toThrow();
+    });
+
+    it("should reject missing required fields", () => {
+      const invalid = {
+        version: 1,
+        // missing runs
+      };
+
+      expect(() => MetricsSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe("MetricRunSchema", () => {
+    it("should validate a complete run", () => {
+      const run: MetricRun = {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        date: "2026-01-20T12:00:00.000Z",
+        issues: [42],
+        phases: ["exec", "qa"],
+        outcome: "success",
+        duration: 300,
+        model: "sonnet",
+        flags: [],
+        metrics: {
+          tokensUsed: 0,
+          filesChanged: 5,
+          linesAdded: 200,
+          acceptanceCriteria: 3,
+          qaIterations: 1,
+        },
+      };
+
+      expect(() => MetricRunSchema.parse(run)).not.toThrow();
+    });
+
+    it("should accept all valid outcomes", () => {
+      for (const outcome of ["success", "partial", "failed"]) {
+        const run = createMetricRun({
+          issues: [1],
+          phases: ["exec"],
+          outcome: outcome as "success" | "partial" | "failed",
+          duration: 100,
+        });
+
+        expect(() => MetricRunSchema.parse(run)).not.toThrow();
+        expect(run.outcome).toBe(outcome);
+      }
+    });
+
+    it("should accept all valid phases", () => {
+      const validPhases = [
+        "spec",
+        "security-review",
+        "testgen",
+        "exec",
+        "test",
+        "qa",
+        "loop",
+      ] as const;
+
+      const run = createMetricRun({
+        issues: [1],
+        phases: [...validPhases],
+        outcome: "success",
+        duration: 100,
+      });
+
+      expect(() => MetricRunSchema.parse(run)).not.toThrow();
+      expect(run.phases).toEqual(validPhases);
+    });
+
+    it("should reject invalid outcome", () => {
+      const invalid = {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        date: "2026-01-20T12:00:00.000Z",
+        issues: [42],
+        phases: ["exec"],
+        outcome: "invalid",
+        duration: 100,
+        model: "opus",
+        flags: [],
+        metrics: {
+          tokensUsed: 0,
+          filesChanged: 0,
+          linesAdded: 0,
+          acceptanceCriteria: 0,
+          qaIterations: 0,
+        },
+      };
+
+      expect(() => MetricRunSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe("RunMetricsSchema", () => {
+    it("should validate metrics with all zeros", () => {
+      const metrics = {
+        tokensUsed: 0,
+        filesChanged: 0,
+        linesAdded: 0,
+        acceptanceCriteria: 0,
+        qaIterations: 0,
+      };
+
+      expect(() => RunMetricsSchema.parse(metrics)).not.toThrow();
+    });
+
+    it("should reject negative values", () => {
+      const invalid = {
+        tokensUsed: -100,
+        filesChanged: 5,
+        linesAdded: 200,
+        acceptanceCriteria: 3,
+        qaIterations: 1,
+      };
+
+      expect(() => RunMetricsSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe("createEmptyMetrics", () => {
+    it("should create valid empty metrics", () => {
+      const metrics = createEmptyMetrics();
+
+      expect(metrics.version).toBe(1);
+      expect(metrics.runs).toEqual([]);
+      expect(() => MetricsSchema.parse(metrics)).not.toThrow();
+    });
+  });
+
+  describe("createMetricRun", () => {
+    it("should create run with required fields", () => {
+      const run = createMetricRun({
+        issues: [123],
+        phases: ["spec", "exec", "qa"],
+        outcome: "success",
+        duration: 600,
+      });
+
+      expect(run.id).toBeDefined();
+      expect(run.date).toBeDefined();
+      expect(run.issues).toEqual([123]);
+      expect(run.phases).toEqual(["spec", "exec", "qa"]);
+      expect(run.outcome).toBe("success");
+      expect(run.duration).toBe(600);
+      expect(run.model).toBe("unknown");
+      expect(run.flags).toEqual([]);
+    });
+
+    it("should create run with optional fields", () => {
+      const run = createMetricRun({
+        issues: [123, 124],
+        phases: ["exec", "qa"],
+        outcome: "partial",
+        duration: 900,
+        model: "opus",
+        flags: ["--chain", "--qa-gate"],
+        metrics: {
+          filesChanged: 10,
+          linesAdded: 500,
+        },
+      });
+
+      expect(run.model).toBe("opus");
+      expect(run.flags).toEqual(["--chain", "--qa-gate"]);
+      expect(run.metrics.filesChanged).toBe(10);
+      expect(run.metrics.linesAdded).toBe(500);
+      expect(run.metrics.tokensUsed).toBe(0); // Default
+    });
+
+    it("should generate valid UUID", () => {
+      const run = createMetricRun({
+        issues: [1],
+        phases: ["exec"],
+        outcome: "success",
+        duration: 100,
+      });
+
+      // UUID v4 pattern
+      expect(run.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it("should generate ISO datetime", () => {
+      const run = createMetricRun({
+        issues: [1],
+        phases: ["exec"],
+        outcome: "success",
+        duration: 100,
+      });
+
+      // Should be parseable as ISO date
+      expect(() => new Date(run.date)).not.toThrow();
+      expect(run.date).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+  });
+
+  describe("determineOutcome", () => {
+    it('should return "success" when all issues pass', () => {
+      expect(determineOutcome(5, 5)).toBe("success");
+      expect(determineOutcome(1, 1)).toBe("success");
+    });
+
+    it('should return "failed" when no issues pass', () => {
+      expect(determineOutcome(0, 5)).toBe("failed");
+      expect(determineOutcome(0, 1)).toBe("failed");
+    });
+
+    it('should return "partial" when some issues pass', () => {
+      expect(determineOutcome(3, 5)).toBe("partial");
+      expect(determineOutcome(1, 2)).toBe("partial");
+    });
+
+    it('should return "failed" for edge case of 0 total', () => {
+      // When total is 0, successCount must also be 0
+      expect(determineOutcome(0, 0)).toBe("success"); // 0/0 is technically all passed
+    });
+  });
+});

--- a/src/lib/workflow/metrics-schema.ts
+++ b/src/lib/workflow/metrics-schema.ts
@@ -1,0 +1,169 @@
+/**
+ * Zod schemas for local workflow analytics metrics
+ *
+ * Privacy-focused metrics collection that stays local to the machine.
+ * No file paths, code content, issue titles, or PII are ever collected.
+ *
+ * @example
+ * ```typescript
+ * import { MetricsSchema, type Metrics, type MetricRun } from './metrics-schema';
+ *
+ * // Validate metrics file
+ * const metrics = MetricsSchema.parse(JSON.parse(metricsContent));
+ *
+ * // Type-safe access
+ * console.log(metrics.runs.length, metrics.runs[0].outcome);
+ * ```
+ */
+
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+/**
+ * Outcome of a workflow run
+ */
+export const RunOutcomeSchema = z.enum(["success", "partial", "failed"]);
+
+export type RunOutcome = z.infer<typeof RunOutcomeSchema>;
+
+/**
+ * Available phases (aligned with run-log-schema.ts)
+ */
+export const MetricPhaseSchema = z.enum([
+  "spec",
+  "security-review",
+  "testgen",
+  "exec",
+  "test",
+  "qa",
+  "loop",
+]);
+
+export type MetricPhase = z.infer<typeof MetricPhaseSchema>;
+
+/**
+ * Aggregate metrics for a run
+ * Note: No file paths or code content - only aggregate counts
+ */
+export const RunMetricsSchema = z.object({
+  /** Estimated tokens used (if available, 0 if not) */
+  tokensUsed: z.number().int().nonnegative(),
+  /** Number of files changed during the run */
+  filesChanged: z.number().int().nonnegative(),
+  /** Lines added during the run */
+  linesAdded: z.number().int().nonnegative(),
+  /** Number of acceptance criteria in the issue */
+  acceptanceCriteria: z.number().int().nonnegative(),
+  /** Number of QA iterations needed */
+  qaIterations: z.number().int().nonnegative(),
+});
+
+export type RunMetrics = z.infer<typeof RunMetricsSchema>;
+
+/**
+ * Single workflow run record
+ *
+ * Privacy principles:
+ * - Only issue numbers, not titles or content
+ * - No file paths or names
+ * - No error messages (could contain sensitive info)
+ * - Aggregate metrics only
+ */
+export const MetricRunSchema = z.object({
+  /** Unique run identifier */
+  id: z.string().uuid(),
+  /** Run timestamp */
+  date: z.string().datetime(),
+  /** Issue numbers processed (not titles or content) */
+  issues: z.array(z.number().int().positive()),
+  /** Phases that were executed */
+  phases: z.array(MetricPhaseSchema),
+  /** Overall outcome */
+  outcome: RunOutcomeSchema,
+  /** Total duration in seconds */
+  duration: z.number().nonnegative(),
+  /** Model used (e.g., "opus", "sonnet") */
+  model: z.string(),
+  /** CLI flags used (e.g., ["--chain", "--sequential"]) */
+  flags: z.array(z.string()),
+  /** Aggregate metrics */
+  metrics: RunMetricsSchema,
+});
+
+export type MetricRun = z.infer<typeof MetricRunSchema>;
+
+/**
+ * Complete metrics file schema
+ *
+ * Stored at .sequant/metrics.json
+ */
+export const MetricsSchema = z.object({
+  /** Schema version for backwards compatibility */
+  version: z.literal(1),
+  /** Array of run records */
+  runs: z.array(MetricRunSchema),
+});
+
+export type Metrics = z.infer<typeof MetricsSchema>;
+
+/**
+ * Default metrics file path
+ */
+export const METRICS_FILE_PATH = ".sequant/metrics.json";
+
+/**
+ * Create an empty metrics file
+ */
+export function createEmptyMetrics(): Metrics {
+  return {
+    version: 1,
+    runs: [],
+  };
+}
+
+/**
+ * Create a new metric run record
+ */
+export function createMetricRun(options: {
+  issues: number[];
+  phases: MetricPhase[];
+  outcome: RunOutcome;
+  duration: number;
+  model?: string;
+  flags?: string[];
+  metrics?: Partial<RunMetrics>;
+}): MetricRun {
+  return {
+    id: randomUUID(),
+    date: new Date().toISOString(),
+    issues: options.issues,
+    phases: options.phases,
+    outcome: options.outcome,
+    duration: options.duration,
+    model: options.model ?? "unknown",
+    flags: options.flags ?? [],
+    metrics: {
+      tokensUsed: options.metrics?.tokensUsed ?? 0,
+      filesChanged: options.metrics?.filesChanged ?? 0,
+      linesAdded: options.metrics?.linesAdded ?? 0,
+      acceptanceCriteria: options.metrics?.acceptanceCriteria ?? 0,
+      qaIterations: options.metrics?.qaIterations ?? 0,
+    },
+  };
+}
+
+/**
+ * Determine outcome from issue results
+ */
+export function determineOutcome(
+  successCount: number,
+  totalCount: number,
+): RunOutcome {
+  if (successCount === totalCount) {
+    return "success";
+  }
+  if (successCount === 0) {
+    return "failed";
+  }
+  return "partial";
+}

--- a/src/lib/workflow/metrics-writer.test.ts
+++ b/src/lib/workflow/metrics-writer.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for MetricsWriter
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { MetricsWriter, resetMetricsWriter } from "./metrics-writer.js";
+import { createEmptyMetrics, type Metrics } from "./metrics-schema.js";
+
+describe("MetricsWriter", () => {
+  let tempDir: string;
+  let metricsPath: string;
+  let writer: MetricsWriter;
+
+  beforeEach(() => {
+    // Create temp directory for test metrics files
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "metrics-test-"));
+    metricsPath = path.join(tempDir, ".sequant", "metrics.json");
+    writer = new MetricsWriter({ metricsPath });
+    resetMetricsWriter();
+  });
+
+  afterEach(() => {
+    // Clean up temp directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe("getMetrics", () => {
+    it("should return empty metrics when file does not exist", async () => {
+      const metrics = await writer.getMetrics();
+
+      expect(metrics.version).toBe(1);
+      expect(metrics.runs).toEqual([]);
+    });
+
+    it("should read and parse existing metrics file", async () => {
+      // Create metrics file
+      const existingMetrics: Metrics = {
+        version: 1,
+        runs: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            date: "2026-01-20T12:00:00.000Z",
+            issues: [42],
+            phases: ["exec", "qa"],
+            outcome: "success",
+            duration: 300,
+            model: "opus",
+            flags: [],
+            metrics: {
+              tokensUsed: 0,
+              filesChanged: 5,
+              linesAdded: 200,
+              acceptanceCriteria: 3,
+              qaIterations: 1,
+            },
+          },
+        ],
+      };
+
+      fs.mkdirSync(path.dirname(metricsPath), { recursive: true });
+      fs.writeFileSync(metricsPath, JSON.stringify(existingMetrics));
+
+      const metrics = await writer.getMetrics();
+
+      expect(metrics.runs.length).toBe(1);
+      expect(metrics.runs[0].issues).toEqual([42]);
+    });
+
+    it("should cache metrics after first read", async () => {
+      const metrics1 = await writer.getMetrics();
+      const metrics2 = await writer.getMetrics();
+
+      expect(metrics1).toBe(metrics2); // Same object reference
+    });
+
+    it("should throw on invalid JSON", async () => {
+      fs.mkdirSync(path.dirname(metricsPath), { recursive: true });
+      fs.writeFileSync(metricsPath, "not valid json");
+
+      await expect(writer.getMetrics()).rejects.toThrow("Invalid JSON");
+    });
+  });
+
+  describe("saveMetrics", () => {
+    it("should create directory and write metrics file", async () => {
+      const metrics = createEmptyMetrics();
+
+      await writer.saveMetrics(metrics);
+
+      expect(fs.existsSync(metricsPath)).toBe(true);
+
+      const content = fs.readFileSync(metricsPath, "utf-8");
+      const saved = JSON.parse(content);
+      expect(saved.version).toBe(1);
+    });
+
+    it("should update cache after save", async () => {
+      const metrics = createEmptyMetrics();
+      await writer.saveMetrics(metrics);
+
+      // Cache should be updated
+      const cached = await writer.getMetrics();
+      expect(cached).toEqual(metrics);
+    });
+
+    it("should preserve pretty-printed JSON", async () => {
+      const metrics = createEmptyMetrics();
+      await writer.saveMetrics(metrics);
+
+      const content = fs.readFileSync(metricsPath, "utf-8");
+      expect(content).toContain("\n"); // Has newlines (pretty printed)
+    });
+  });
+
+  describe("recordRun", () => {
+    it("should add a new run to metrics", async () => {
+      const run = await writer.recordRun({
+        issues: [123],
+        phases: ["spec", "exec", "qa"],
+        outcome: "success",
+        duration: 600,
+        model: "opus",
+      });
+
+      expect(run.id).toBeDefined();
+      expect(run.issues).toEqual([123]);
+
+      // Check it was persisted
+      const metrics = await writer.getMetrics();
+      expect(metrics.runs.length).toBe(1);
+      expect(metrics.runs[0].id).toBe(run.id);
+    });
+
+    it("should append to existing runs", async () => {
+      // Record first run
+      await writer.recordRun({
+        issues: [1],
+        phases: ["exec"],
+        outcome: "success",
+        duration: 100,
+      });
+
+      // Record second run
+      await writer.recordRun({
+        issues: [2],
+        phases: ["exec"],
+        outcome: "failed",
+        duration: 200,
+      });
+
+      const metrics = await writer.getMetrics();
+      expect(metrics.runs.length).toBe(2);
+      expect(metrics.runs[0].issues).toEqual([1]);
+      expect(metrics.runs[1].issues).toEqual([2]);
+    });
+
+    it("should handle metrics with flags", async () => {
+      const run = await writer.recordRun({
+        issues: [123, 124],
+        phases: ["spec", "exec", "qa"],
+        outcome: "partial",
+        duration: 900,
+        model: "opus",
+        flags: ["--chain", "--sequential", "--qa-gate"],
+        metrics: {
+          filesChanged: 15,
+          linesAdded: 800,
+        },
+      });
+
+      expect(run.flags).toEqual(["--chain", "--sequential", "--qa-gate"]);
+      expect(run.metrics.filesChanged).toBe(15);
+      expect(run.metrics.linesAdded).toBe(800);
+    });
+  });
+
+  describe("getAllRuns", () => {
+    it("should return empty array when no runs", async () => {
+      const runs = await writer.getAllRuns();
+      expect(runs).toEqual([]);
+    });
+
+    it("should return all runs", async () => {
+      await writer.recordRun({
+        issues: [1],
+        phases: ["exec"],
+        outcome: "success",
+        duration: 100,
+      });
+      await writer.recordRun({
+        issues: [2],
+        phases: ["exec"],
+        outcome: "failed",
+        duration: 200,
+      });
+
+      const runs = await writer.getAllRuns();
+      expect(runs.length).toBe(2);
+    });
+  });
+
+  describe("getRecentRuns", () => {
+    it("should return last N runs", async () => {
+      // Record 5 runs
+      for (let i = 1; i <= 5; i++) {
+        await writer.recordRun({
+          issues: [i],
+          phases: ["exec"],
+          outcome: "success",
+          duration: i * 100,
+        });
+      }
+
+      const recentRuns = await writer.getRecentRuns(3);
+      expect(recentRuns.length).toBe(3);
+      // Should be the last 3
+      expect(recentRuns[0].issues).toEqual([3]);
+      expect(recentRuns[1].issues).toEqual([4]);
+      expect(recentRuns[2].issues).toEqual([5]);
+    });
+
+    it("should return all runs if count exceeds total", async () => {
+      await writer.recordRun({
+        issues: [1],
+        phases: ["exec"],
+        outcome: "success",
+        duration: 100,
+      });
+
+      const recentRuns = await writer.getRecentRuns(10);
+      expect(recentRuns.length).toBe(1);
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear cached metrics", async () => {
+      const metrics1 = await writer.getMetrics();
+      writer.clearCache();
+
+      // Should read from file again
+      const metrics2 = await writer.getMetrics();
+      expect(metrics1).not.toBe(metrics2); // Different object reference
+    });
+  });
+
+  describe("metricsExists", () => {
+    it("should return false when file does not exist", () => {
+      expect(writer.metricsExists()).toBe(false);
+    });
+
+    it("should return true when file exists", async () => {
+      await writer.saveMetrics(createEmptyMetrics());
+      expect(writer.metricsExists()).toBe(true);
+    });
+  });
+
+  describe("deleteMetrics", () => {
+    it("should delete metrics file", async () => {
+      await writer.saveMetrics(createEmptyMetrics());
+      expect(writer.metricsExists()).toBe(true);
+
+      await writer.deleteMetrics();
+      expect(writer.metricsExists()).toBe(false);
+    });
+
+    it("should clear cache on delete", async () => {
+      await writer.saveMetrics(createEmptyMetrics());
+      const metrics1 = await writer.getMetrics();
+      expect(metrics1.runs).toEqual([]);
+
+      await writer.deleteMetrics();
+
+      // Should return empty metrics (recreated)
+      const metrics2 = await writer.getMetrics();
+      expect(metrics2.version).toBe(1);
+      expect(metrics2.runs).toEqual([]);
+    });
+
+    it("should handle delete when file does not exist", async () => {
+      // Should not throw
+      await expect(writer.deleteMetrics()).resolves.not.toThrow();
+    });
+  });
+
+  describe("getMetricsPath", () => {
+    it("should return the configured path", () => {
+      expect(writer.getMetricsPath()).toBe(metricsPath);
+    });
+  });
+});

--- a/src/lib/workflow/metrics-writer.ts
+++ b/src/lib/workflow/metrics-writer.ts
@@ -1,0 +1,245 @@
+/**
+ * Metrics writer for local workflow analytics
+ *
+ * Provides atomic writes (temp file + rename) to prevent corruption.
+ * All data stays local - no network requests.
+ *
+ * @example
+ * ```typescript
+ * import { MetricsWriter } from './metrics-writer';
+ *
+ * const writer = new MetricsWriter();
+ * await writer.recordRun({
+ *   issues: [123, 124],
+ *   phases: ['spec', 'exec', 'qa'],
+ *   outcome: 'success',
+ *   duration: 720,
+ *   model: 'opus',
+ *   flags: ['--chain'],
+ *   metrics: { filesChanged: 9, linesAdded: 1800 }
+ * });
+ * ```
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  type Metrics,
+  type MetricRun,
+  type MetricPhase,
+  type RunOutcome,
+  type RunMetrics,
+  MetricsSchema,
+  METRICS_FILE_PATH,
+  createEmptyMetrics,
+  createMetricRun,
+} from "./metrics-schema.js";
+
+export interface MetricsWriterOptions {
+  /** Path to metrics file (default: .sequant/metrics.json) */
+  metricsPath?: string;
+  /** Enable verbose logging */
+  verbose?: boolean;
+}
+
+/**
+ * Manages local workflow metrics collection
+ */
+export class MetricsWriter {
+  private metricsPath: string;
+  private verbose: boolean;
+  private cachedMetrics: Metrics | null = null;
+
+  constructor(options: MetricsWriterOptions = {}) {
+    this.metricsPath = options.metricsPath ?? METRICS_FILE_PATH;
+    this.verbose = options.verbose ?? false;
+  }
+
+  /**
+   * Get the full path to the metrics file
+   */
+  getMetricsPath(): string {
+    return this.metricsPath;
+  }
+
+  /**
+   * Read the current metrics data
+   *
+   * Returns empty metrics if file doesn't exist.
+   * Throws on parse errors.
+   */
+  async getMetrics(): Promise<Metrics> {
+    // Return cached metrics if available
+    if (this.cachedMetrics) {
+      return this.cachedMetrics;
+    }
+
+    if (!fs.existsSync(this.metricsPath)) {
+      const emptyMetrics = createEmptyMetrics();
+      this.cachedMetrics = emptyMetrics;
+      return emptyMetrics;
+    }
+
+    try {
+      const content = fs.readFileSync(this.metricsPath, "utf-8");
+      const parsed = JSON.parse(content);
+      const metrics = MetricsSchema.parse(parsed);
+      this.cachedMetrics = metrics;
+      return metrics;
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(`Invalid JSON in metrics file: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Write metrics to disk using atomic write
+   *
+   * Writes to a temp file first, then renames to prevent corruption
+   * if the process is interrupted during write.
+   */
+  async saveMetrics(metrics: Metrics): Promise<void> {
+    // Validate before writing
+    MetricsSchema.parse(metrics);
+
+    // Ensure directory exists
+    const dir = path.dirname(this.metricsPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // Write to temp file first (atomic write pattern)
+    const tempPath = path.join(
+      os.tmpdir(),
+      `sequant-metrics-${Date.now()}-${process.pid}.json`,
+    );
+
+    try {
+      fs.writeFileSync(tempPath, JSON.stringify(metrics, null, 2));
+
+      // Rename temp file to actual path (atomic on most systems)
+      fs.renameSync(tempPath, this.metricsPath);
+
+      // Update cache
+      this.cachedMetrics = metrics;
+
+      if (this.verbose) {
+        console.log(`📊 Metrics saved: ${this.metricsPath}`);
+      }
+    } catch (error) {
+      // Clean up temp file on error
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Clear the cached metrics (forces re-read on next access)
+   */
+  clearCache(): void {
+    this.cachedMetrics = null;
+  }
+
+  /**
+   * Record a workflow run
+   *
+   * @param options - Run data to record
+   */
+  async recordRun(options: {
+    issues: number[];
+    phases: MetricPhase[];
+    outcome: RunOutcome;
+    duration: number;
+    model?: string;
+    flags?: string[];
+    metrics?: Partial<RunMetrics>;
+  }): Promise<MetricRun> {
+    const metrics = await this.getMetrics();
+    const run = createMetricRun(options);
+
+    metrics.runs.push(run);
+    await this.saveMetrics(metrics);
+
+    if (this.verbose) {
+      console.log(`📊 Recorded run: ${run.id.slice(0, 8)}... (${run.outcome})`);
+    }
+
+    return run;
+  }
+
+  /**
+   * Get all runs
+   */
+  async getAllRuns(): Promise<MetricRun[]> {
+    const metrics = await this.getMetrics();
+    return metrics.runs;
+  }
+
+  /**
+   * Get runs filtered by date range
+   */
+  async getRunsByDateRange(start: Date, end: Date): Promise<MetricRun[]> {
+    const runs = await this.getAllRuns();
+    return runs.filter((run) => {
+      const runDate = new Date(run.date);
+      return runDate >= start && runDate <= end;
+    });
+  }
+
+  /**
+   * Get the most recent N runs
+   */
+  async getRecentRuns(count: number): Promise<MetricRun[]> {
+    const runs = await this.getAllRuns();
+    // Runs are stored in chronological order, get the last N
+    return runs.slice(-count);
+  }
+
+  /**
+   * Check if metrics file exists
+   */
+  metricsExists(): boolean {
+    return fs.existsSync(this.metricsPath);
+  }
+
+  /**
+   * Delete the metrics file (for testing or user request)
+   */
+  async deleteMetrics(): Promise<void> {
+    if (fs.existsSync(this.metricsPath)) {
+      fs.unlinkSync(this.metricsPath);
+      this.cachedMetrics = null;
+
+      if (this.verbose) {
+        console.log(`📊 Metrics deleted: ${this.metricsPath}`);
+      }
+    }
+  }
+}
+
+// Export a default instance for convenience
+let defaultWriter: MetricsWriter | null = null;
+
+/**
+ * Get the default metrics writer instance
+ */
+export function getMetricsWriter(
+  options?: MetricsWriterOptions,
+): MetricsWriter {
+  if (!defaultWriter || options) {
+    defaultWriter = new MetricsWriter(options);
+  }
+  return defaultWriter;
+}
+
+/**
+ * Reset the default metrics writer (for testing)
+ */
+export function resetMetricsWriter(): void {
+  defaultWriter = null;
+}


### PR DESCRIPTION
## Summary
- Add privacy-focused local metrics collection for workflow runs
- Extend `sequant stats` to display analytics with insights
- Create new metrics schema with Zod validation and atomic file writes

## Changes
- **metrics-schema.ts**: Zod schemas for privacy-focused metrics (no PII, no file paths)
- **metrics-writer.ts**: Atomic writes using temp file + rename pattern
- **run.ts**: Integrate metrics recording after workflow completion
- **stats.ts**: Add analytics display with insights generation
- **docs/analytics.md**: Comprehensive documentation

## Privacy Principles
- All data stays local (no telemetry)
- No file paths, code content, issue titles, or error messages
- Only aggregate metrics (issue numbers, files changed, lines added)

## Test plan
- [x] Unit tests for metrics-schema.ts (19 tests)
- [x] Unit tests for metrics-writer.ts (21 tests)
- [x] Existing stats.test.ts updated for new behavior
- [x] `npm test` passes (487 tests)
- [x] `npm run build` passes

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)