### PR TITLE
feat(#144): register sequant state command in CLI

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -41,6 +41,11 @@ import { runCommand } from "../src/commands/run.js";
 import { logsCommand } from "../src/commands/logs.js";
 import { statsCommand } from "../src/commands/stats.js";
 import { dashboardCommand } from "../src/commands/dashboard.js";
+import {
+  stateInitCommand,
+  stateRebuildCommand,
+  stateCleanCommand,
+} from "../src/commands/state.js";
 
 const program = new Command();
 
@@ -182,6 +187,36 @@ program
   .option("--no-open", "Don't automatically open browser")
   .option("-v, --verbose", "Enable verbose logging")
   .action(dashboardCommand);
+
+// State management command with subcommands
+const stateCmd = program
+  .command("state")
+  .description("Manage workflow state for worktrees");
+
+stateCmd
+  .command("init")
+  .description("Populate state for untracked worktrees")
+  .option("--json", "Output as JSON")
+  .option("-v, --verbose", "Enable verbose output")
+  .action(stateInitCommand);
+
+stateCmd
+  .command("rebuild")
+  .description("Recreate state from logs and worktrees")
+  .option("--json", "Output as JSON")
+  .option("-v, --verbose", "Enable verbose output")
+  .option("-f, --force", "Force rebuild without confirmation")
+  .action(stateRebuildCommand);
+
+stateCmd
+  .command("clean")
+  .description("Remove entries for deleted worktrees")
+  .option("--json", "Output as JSON")
+  .option("-v, --verbose", "Enable verbose output")
+  .option("-d, --dry-run", "Preview cleanup without changes")
+  .option("--max-age <days>", "Remove entries older than N days", parseInt)
+  .option("--all", "Remove all orphaned entries (merged and abandoned)")
+  .action(stateCleanCommand);
 
 // Parse and execute
 program.parse();


### PR DESCRIPTION
## Summary

- Register `sequant state` command in `bin/cli.ts` with init, rebuild, and clean subcommands
- Users can now access the full state management interface via `sequant state <subcommand>`

### Before
```bash
$ sequant state clean --dry-run
error: unknown command 'state'
(Did you mean stats?)
```

### After
```bash
$ sequant state clean --dry-run
🧹 Cleanup preview (dry run)...
✓ No orphaned entries found
```

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (496 tests)
- [x] `npm run lint` passes
- [x] `sequant state --help` shows all subcommands
- [x] `sequant state init --help` shows options
- [x] `sequant state rebuild --help` shows options  
- [x] `sequant state clean --help` shows options
- [x] `sequant state clean --dry-run` works as expected

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)