### PR TITLE
feat(#145): Record PR info in state when /exec creates a PR

### DIFF
--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -350,6 +350,16 @@ After implementation is complete and all checks pass, create and verify the PR:
    - If PR exists: Record the URL from `gh pr view` output
    - If PR creation failed: Record the error and include manual creation instructions
 
+6. **Record PR info in workflow state:**
+   ```bash
+   # Extract PR number and URL from gh pr view output, then update state
+   PR_INFO=$(gh pr view --json number,url)
+   PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
+   PR_URL=$(echo "$PR_INFO" | jq -r '.url')
+   npx tsx scripts/state/update.ts pr <issue-number> "$PR_NUMBER" "$PR_URL"
+   ```
+   This enables `--cleanup` to detect merged PRs and auto-remove state entries.
+
 **PR Verification Failure Handling:**
 
 If `gh pr view` fails after retry:


### PR DESCRIPTION
## Summary

- Add `pr` command to `scripts/state/update.ts` CLI for recording PR info in workflow state
- Update `/exec` skill documentation to record PR info after creating a PR
- Enables `--cleanup` to detect merged PRs and auto-remove orphaned state entries

## Changes

### `scripts/state/update.ts`
- New command: `npx tsx scripts/state/update.ts pr <issue> <pr-number> <pr-url>`
- Validates URL format before saving
- Uses existing `StateManager.updatePRInfo()` method

### `.claude/skills/exec/SKILL.md`
- Added step 6 to PR Creation and Verification section
- Documents how to extract PR info and record it in state

## Test plan

- [x] All 495 existing tests pass
- [x] Build succeeds
- [x] Manual test: `pr` command correctly records PR info in state
- [x] Manual test: URL validation rejects invalid URLs

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)