### PR TITLE
docs(#108): add script locations guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,19 @@ sequant/
 └── docs/                   # Documentation
 ```
 
+### Script Locations
+
+Helper scripts exist in two locations:
+
+| Location | Purpose | Tracked |
+|----------|---------|---------|
+| `templates/scripts/` | Canonical source scripts | ✅ Yes |
+| `scripts/dev/` | Local copies from `sequant init` | ❌ No (gitignored) |
+
+**When modifying scripts:** Always change files in `templates/scripts/` — this is what gets committed and distributed to users.
+
+The `scripts/dev/` directory is created automatically when you run `sequant init`. It contains working copies for local use.
+
 ## Making Changes
 
 ### Adding a New Command


### PR DESCRIPTION
## Summary

- Add `### Script Locations` subsection to CONTRIBUTING.md after Project Structure
- Document the relationship between `templates/scripts/` (canonical source, tracked) and `scripts/dev/` (local copies, gitignored)
- Provide clear guidance that developers should always modify `templates/scripts/`

## Test plan

- [x] Build passes (`npm run build`)
- [x] Manual verification: Documentation is clear and follows the format from the spec

**Note:** 10 pre-existing test failures in `state-update-cli.test.ts` are unrelated to this documentation change.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)