### PR TITLE
feat(#89): add closed-issue verification to doctor

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -101,6 +101,7 @@ program
 program
   .command("doctor")
   .description("Check your Sequant installation for issues")
+  .option("--skip-issue-check", "Skip closed-issue verification check")
   .action(doctorCommand);
 
 program


### PR DESCRIPTION
## Summary

- Adds closed-issue verification check to `sequant doctor` that detects work lost due to manual issue closure without merging
- Warns if issues closed in the last 7 days have no corresponding commit in main branch
- Includes `--skip-issue-check` flag to disable the check
- Gracefully handles missing/unauthenticated gh CLI and skips issues with wontfix/duplicate labels

## Test plan

- [x] All 30 doctor tests pass including 10 new tests for closed-issue verification
- [x] Full test suite (538 tests) passes
- [x] Build succeeds
- [x] Manual testing confirms feature works:
  - `sequant doctor` shows warnings for issues without commits
  - `sequant doctor --skip-issue-check` skips the check
  - Issues with wontfix/duplicate labels are excluded

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)