### PR TITLE
docs(#120): add VS Code extension documentation

### DIFF
--- a/docs/features/vscode-extension.md
+++ b/docs/features/vscode-extension.md
@@ -1,0 +1,150 @@
+# VS Code Extension for Workflow Visualization
+
+The Sequant Explorer VS Code extension provides real-time workflow visualization directly in your IDE sidebar.
+
+## Overview
+
+Instead of switching to a browser-based dashboard, the VS Code extension shows issue status and workflow phases where you already work. It reads the same `.sequant/state.json` file used by the CLI.
+
+## Features
+
+### Tree View
+
+The extension adds a Sequant panel to the Activity Bar showing:
+
+- **Issues** sorted by status priority (in-progress first, then ready-for-merge, blocked, etc.)
+- **Phases** as expandable children under each issue
+- **Status icons** with color coding:
+  - Blue spinning: in progress
+  - Green check: ready for merge / completed
+  - Yellow warning: blocked
+  - Red X: abandoned / failed
+
+### Actions
+
+Right-click or use inline buttons on issues:
+
+| Action | Description |
+|--------|-------------|
+| Open Worktree | Opens a terminal at the issue's worktree directory |
+| Open on GitHub | Opens the issue in your browser |
+| Refresh | Manually refresh the tree view |
+
+### Auto-Refresh
+
+The extension watches `.sequant/state.json` for changes and automatically updates the tree view when:
+- A phase starts or completes
+- Issue status changes
+- New issues are added
+
+## Installation
+
+### From VSIX (Recommended)
+
+1. Build the extension:
+   ```bash
+   cd vscode-extension
+   npm install
+   npm run compile
+   npx vsce package
+   ```
+
+2. Install in VS Code:
+   - Open Command Palette (Cmd+Shift+P)
+   - Run "Extensions: Install from VSIX..."
+   - Select the generated `.vsix` file
+
+### For Development
+
+1. Open `vscode-extension/` folder in VS Code
+2. Press F5 to launch Extension Development Host
+3. Open a workspace containing `.sequant/state.json`
+
+## Activation
+
+The extension activates automatically when:
+- A workspace contains `.sequant/state.json`
+
+No manual activation required.
+
+## Spike Findings
+
+This section documents the exploration results for issue #120.
+
+### Effort Assessment
+
+| Metric | Value |
+|--------|-------|
+| Lines of Code | ~500 LOC TypeScript |
+| Files | 3 (package.json, extension.ts, tsconfig.json) |
+| Dependencies | 0 runtime, 3 dev (@types/node, @types/vscode, typescript) |
+| Build Time | ~2 seconds |
+
+The implementation was straightforward using VS Code's built-in APIs.
+
+### Limitations
+
+1. **Tree-Only UI**: VS Code TreeDataProvider only supports hierarchical tree layouts. No grids, cards, or custom layouts without Webview panels.
+
+2. **No Custom Styling**: Limited to VS Code's theme colors and built-in icons. Cannot match custom brand colors.
+
+3. **Distribution**: Must be packaged as VSIX and installed manually, or published to VS Code Marketplace (requires publisher account).
+
+4. **Single Workspace**: Shows state for the current workspace only. Cannot aggregate across multiple repositories.
+
+5. **Read-Only**: Current implementation only displays state. Running phases would require terminal integration or task providers.
+
+### UX Comparison: VS Code Extension vs Web Dashboard
+
+| Aspect | VS Code Extension | Web Dashboard |
+|--------|-------------------|---------------|
+| **Context Switching** | None - in IDE | Must open browser |
+| **Always Visible** | Yes - sidebar panel | No - separate tab |
+| **Custom UI** | Limited (tree only) | Full flexibility |
+| **Multi-Repo View** | No | Possible |
+| **Installation** | VSIX per machine | URL (no install) |
+| **Offline Access** | Yes | Local server needed |
+| **Actions** | Open worktree, GitHub | Could be more interactive |
+| **Filtering/Search** | Basic (VS Code tree filter) | Full search/filter UI |
+
+### Recommendation
+
+**Use the VS Code extension when:**
+- Working on a single repository
+- Prefer minimal context switching
+- Want quick glance at status while coding
+
+**Use the web dashboard when:**
+- Need rich filtering/search
+- Working across multiple repositories
+- Want detailed analytics or history
+
+Both options read the same state file, so they can be used together.
+
+## Configuration
+
+Currently no configuration options. Future enhancements could include:
+- Custom refresh interval
+- Filter by status
+- Keyboard shortcuts for actions
+
+## Troubleshooting
+
+### Extension not activating
+
+1. Verify `.sequant/state.json` exists in workspace root
+2. Check VS Code's Extension Host logs (Help > Toggle Developer Tools)
+3. Try manual refresh via Command Palette: "Sequant: Refresh"
+
+### Tree view empty
+
+1. Check that state.json contains issues
+2. Verify JSON is valid: `cat .sequant/state.json | jq`
+3. Check for errors in Developer Tools console
+
+## Related
+
+- [Workflow Phases](../concepts/workflow-phases.md)
+- [State Command](../state-command.md)
+- Issue #114 - Web Dashboard (Option A)
+- Issue #120 - VS Code Extension (Option C)

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,70 @@
+# Sequant Explorer VS Code Extension
+
+Visualize Sequant workflow state directly in VS Code.
+
+## Quick Start
+
+```bash
+# Install dependencies
+npm install
+
+# Compile
+npm run compile
+
+# Watch mode (for development)
+npm run watch
+```
+
+## Development
+
+1. Open this folder in VS Code
+2. Press F5 to launch Extension Development Host
+3. In the new window, open a workspace with `.sequant/state.json`
+4. The Sequant panel appears in the Activity Bar
+
+## Building VSIX
+
+```bash
+# Install vsce if needed
+npm install -g @vscode/vsce
+
+# Package
+npx vsce package
+
+# Creates sequant-explorer-0.0.1.vsix
+```
+
+## Installing VSIX
+
+In VS Code:
+1. Cmd+Shift+P → "Extensions: Install from VSIX..."
+2. Select the `.vsix` file
+
+Or via CLI:
+```bash
+code --install-extension sequant-explorer-0.0.1.vsix
+```
+
+## Features
+
+- Tree view of issues and phases
+- Auto-refresh on state changes
+- Open worktree in terminal
+- Open issue on GitHub
+
+## Project Structure
+
+```
+vscode-extension/
+├── package.json      # Extension manifest
+├── tsconfig.json     # TypeScript config
+├── src/
+│   └── extension.ts  # Main extension code
+└── out/              # Compiled output (gitignored)
+```
+
+## VS Code API Reference
+
+- [TreeDataProvider](https://code.visualstudio.com/api/references/vscode-api#TreeDataProvider)
+- [FileSystemWatcher](https://code.visualstudio.com/api/references/vscode-api#FileSystemWatcher)
+- [Extension Anatomy](https://code.visualstudio.com/api/get-started/extension-anatomy)


### PR DESCRIPTION
## Summary

- Add documentation for the VS Code extension (Sequant Explorer)
- Complete spike exploration for issue #120 (Option C)

## Changes

- `docs/features/vscode-extension.md`: Full documentation with:
  - Feature overview and installation guide
  - Effort assessment (~500 LOC, 3 files, 0 runtime deps)
  - Limitations (tree-only UI, VSIX distribution, single workspace)
  - UX comparison: VS Code extension vs web dashboard (#114)
  
- `vscode-extension/README.md`: Developer quick-start guide

## AC Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | Extension activates in sequant workspaces | ✅ MET |
| AC-2 | Tree view shows issues and phase status | ✅ MET |
| AC-3 | Auto-refreshes when state.json changes | ✅ MET |
| AC-4 | At least one action works (open worktree) | ✅ MET |
| AC-5 | Document findings | ✅ MET |

## Test plan

- [x] Extension compiles: `cd vscode-extension && npm run compile`
- [x] Main build passes: `npm run build`
- [x] Tests pass: `npm test` (567 passing)
- [ ] Manual: Verify docs render correctly on GitHub

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)