### PR TITLE
docs(#185): complete AC-6 release and update process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,100 @@ jobs:
 
       - name: Type check
         run: npx tsc --noEmit
+
+  validate-plugin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Validate plugin.json structure
+        run: |
+          echo "Validating plugin.json..."
+
+          # Check plugin.json exists
+          if [ ! -f ".claude-plugin/plugin.json" ]; then
+            echo "Error: .claude-plugin/plugin.json not found"
+            exit 1
+          fi
+
+          # Validate JSON syntax
+          if ! node -e "JSON.parse(require('fs').readFileSync('.claude-plugin/plugin.json', 'utf8'))"; then
+            echo "Error: plugin.json is not valid JSON"
+            exit 1
+          fi
+
+          # Check required fields
+          node -e "
+            const plugin = JSON.parse(require('fs').readFileSync('.claude-plugin/plugin.json', 'utf8'));
+            const required = ['name', 'description'];
+            const missing = required.filter(f => !plugin[f]);
+            if (missing.length > 0) {
+              console.error('Missing required fields:', missing.join(', '));
+              process.exit(1);
+            }
+            console.log('Required fields present: name, description');
+          "
+
+          echo "plugin.json validated successfully!"
+
+      - name: Check version sync
+        run: |
+          echo "Checking version sync between package.json and plugin.json..."
+
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          PLUGIN_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+
+          echo "package.json version: $PKG_VERSION"
+          echo "plugin.json version: $PLUGIN_VERSION"
+
+          if [ "$PKG_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "Error: Version mismatch!"
+            echo "package.json: $PKG_VERSION"
+            echo "plugin.json: $PLUGIN_VERSION"
+            echo ""
+            echo "Run the following to sync:"
+            echo "  node -e \"const p=require('./.claude-plugin/plugin.json');p.version='$PKG_VERSION';require('fs').writeFileSync('./.claude-plugin/plugin.json',JSON.stringify(p,null,2)+'\\n')\""
+            exit 1
+          fi
+
+          echo "Versions are in sync!"
+
+      - name: Validate marketplace.json structure
+        run: |
+          echo "Validating marketplace.json..."
+
+          # Check marketplace.json exists
+          if [ ! -f ".claude-plugin/marketplace.json" ]; then
+            echo "Error: .claude-plugin/marketplace.json not found"
+            exit 1
+          fi
+
+          # Validate JSON syntax
+          if ! node -e "JSON.parse(require('fs').readFileSync('.claude-plugin/marketplace.json', 'utf8'))"; then
+            echo "Error: marketplace.json is not valid JSON"
+            exit 1
+          fi
+
+          # Check required fields
+          node -e "
+            const mp = JSON.parse(require('fs').readFileSync('.claude-plugin/marketplace.json', 'utf8'));
+            const required = ['name', 'description', 'plugins'];
+            const missing = required.filter(f => !mp[f]);
+            if (missing.length > 0) {
+              console.error('Missing required fields:', missing.join(', '));
+              process.exit(1);
+            }
+            if (!Array.isArray(mp.plugins) || mp.plugins.length === 0) {
+              console.error('plugins must be a non-empty array');
+              process.exit(1);
+            }
+            console.log('Required fields present: name, description, plugins');
+          "
+
+          echo "marketplace.json validated successfully!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,22 @@ jobs:
       - name: Update version in package.json
         run: npm version ${{ inputs.version }} --no-git-tag-version
 
+      - name: Sync plugin.json version
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pluginPath = './.claude-plugin/plugin.json';
+            const plugin = JSON.parse(fs.readFileSync(pluginPath, 'utf8'));
+            plugin.version = '${{ inputs.version }}';
+            fs.writeFileSync(pluginPath, JSON.stringify(plugin, null, 2) + '\n');
+            console.log('Updated plugin.json to version ${{ inputs.version }}');
+          "
+
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
+          git add package.json package-lock.json .claude-plugin/plugin.json
           git commit -m "chore: bump version to ${{ inputs.version }}"
           git push
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ See [Customization Guide](docs/customization.md) for all options.
 - [Run Command](docs/run-command.md)
 - [Feature Branch Workflows](docs/feature-branch-workflow.md)
 - [Customization](docs/customization.md)
+- [Plugin Updates & Versioning](docs/plugin-updates.md)
 - [Troubleshooting](docs/troubleshooting.md)
 
 Stack guides: [Next.js](docs/stacks/nextjs.md) · [Rust](docs/stacks/rust.md) · [Python](docs/stacks/python.md) · [Go](docs/stacks/go.md)

--- a/docs/plugin-updates.md
+++ b/docs/plugin-updates.md
@@ -1,0 +1,250 @@
+# Plugin Updates & Versioning
+
+This document explains how Sequant plugin updates work, the versioning strategy, and how to handle breaking changes.
+
+## Versioning Strategy
+
+Sequant uses **synchronized versioning** between npm and plugin releases:
+
+| Source | Version Location | Example |
+|--------|-----------------|---------|
+| npm package | `package.json` | `"version": "1.11.0"` |
+| Claude Code plugin | `.claude-plugin/plugin.json` | `"version": "1.11.0"` |
+
+**Both versions MUST match.** The CI pipeline enforces this check on every PR.
+
+We follow [Semantic Versioning](https://semver.org/):
+
+- **Patch** (1.11.0 → 1.11.1): Bug fixes, documentation updates
+- **Minor** (1.11.0 → 1.12.0): New features, new skills, backwards-compatible changes
+- **Major** (1.11.0 → 2.0.0): Breaking changes (see below)
+
+## How Plugin Updates Work
+
+### For Official Marketplaces (Default)
+
+Plugins from Anthropic's official marketplace auto-update by default. Since Sequant uses a third-party marketplace (`admarble/sequant`), updates work differently.
+
+### For Third-Party Marketplaces (Sequant)
+
+Auto-update is **disabled by default** for third-party plugins. Users get updates in two ways:
+
+#### 1. Manual Marketplace Update
+
+```bash
+# Update the marketplace catalog
+/plugin marketplace update admarble/sequant
+
+# Reinstall to get latest version
+/plugin install sequant
+```
+
+#### 2. Enable Auto-Updates
+
+Users can opt into auto-updates:
+
+```json
+// ~/.claude/settings.json
+{
+  "extraKnownMarketplaces": [
+    {
+      "source": "admarble/sequant",
+      "autoUpdate": true
+    }
+  ]
+}
+```
+
+With `autoUpdate: true`, the plugin will be updated when Claude Code restarts.
+
+## Update Notifications
+
+When a new version is available, users see a notification on Claude Code restart. This applies whether auto-update is enabled or not.
+
+To disable all update notifications:
+```bash
+export DISABLE_AUTOUPDATER=true
+```
+
+## Breaking Changes Policy
+
+### What Constitutes a Breaking Change
+
+- Removing a skill command (e.g., removing `/spec`)
+- Changing skill input format (e.g., `/spec 123` → `/spec --issue 123`)
+- Changing expected output format that other tools depend on
+- Removing or renaming hook events
+- Changing script interfaces in `scripts/`
+- Removing required environment variables
+
+### What Does NOT Constitute a Breaking Change
+
+- Adding new skills
+- Adding optional parameters to existing skills
+- Adding new hooks
+- Improving skill output (additional fields)
+- Bug fixes that change incorrect behavior
+- Documentation updates
+
+### Breaking Change Process
+
+1. **Major version bump** (1.x → 2.0)
+2. **Migration guide** in CHANGELOG.md
+3. **Deprecation period** when possible:
+   - Old behavior continues working for 1-2 minor versions
+   - Console warnings about upcoming removal
+   - Clear migration instructions
+
+### Example Migration Guide (CHANGELOG.md)
+
+```markdown
+## [2.0.0] - YYYY-MM-DD
+
+### Breaking Changes
+
+#### `/spec` output format changed
+
+**Before (v1.x):**
+```
+## Implementation Plan
+1. Step one
+```
+
+**After (v2.0):**
+```
+## Plan
+### Steps
+- Step one
+```
+
+**Migration:** Update any scripts that parse `/spec` output to use the new format.
+```
+
+## Changelog Automation
+
+The changelog is maintained manually following [Keep a Changelog](https://keepachangelog.com/) format. The `/release` skill assists by:
+
+1. Gathering commits since last tag
+2. Categorizing by conventional commit prefix
+3. Generating draft release notes
+4. **User reviews and edits before publishing**
+
+We intentionally avoid fully-automated changelogs because:
+- Commit messages often need human editing for clarity
+- Breaking changes need migration guides
+- Users deserve thoughtful release notes
+
+### Conventional Commits
+
+Use these prefixes for commits to assist changelog generation:
+
+| Prefix | Category | Example |
+|--------|----------|---------|
+| `feat:` | Added | `feat: add /security-review skill` |
+| `fix:` | Fixed | `fix: /qa false positive on test files` |
+| `docs:` | Documentation | `docs: update troubleshooting guide` |
+| `perf:` | Performance | `perf: reduce /spec planning time` |
+| `refactor:` | Changed | `refactor: simplify hook dispatch` |
+| `BREAKING CHANGE:` | Breaking | `BREAKING CHANGE: remove /old-skill` |
+
+## Plugin vs npm: When to Update Which
+
+| Scenario | npm Update | Plugin Update |
+|----------|------------|---------------|
+| New skill added | ✅ | ✅ |
+| Bug fix in skill | ✅ | ✅ |
+| CLI command change | ✅ | ❌ (CLI is npm-only) |
+| `sequant run` improvement | ✅ | ❌ |
+| Hook script fix | ✅ | ✅ |
+| TypeScript library change | ✅ | ❌ (library is npm-only) |
+
+**Note:** The plugin only includes skills, hooks, and scripts. The CLI (`sequant run`, `sequant doctor`, etc.) is npm-only.
+
+## Checking Your Version
+
+### Plugin Version
+
+In Claude Code:
+```
+/sequant:setup
+# Shows plugin version at startup
+```
+
+Or check the marketplace:
+```
+/plugin list
+# Shows installed version
+```
+
+### npm Version
+
+```bash
+npx sequant --version
+# or
+npx sequant status
+```
+
+## Troubleshooting Updates
+
+### Plugin Not Updating
+
+1. Verify marketplace is registered:
+   ```
+   /plugin marketplace list
+   ```
+
+2. Force marketplace refresh:
+   ```
+   /plugin marketplace update admarble/sequant
+   ```
+
+3. Reinstall plugin:
+   ```
+   /plugin uninstall sequant
+   /plugin install sequant
+   ```
+
+### Version Mismatch Between npm and Plugin
+
+If you have both installed, they may drift apart. This is fine — they're independent:
+
+- **Plugin** provides skills in Claude Code interactive sessions
+- **npm** provides CLI for headless operation (`sequant run`)
+
+Upgrade each independently:
+```bash
+# npm
+npm update -g sequant
+
+# Plugin (in Claude Code)
+/plugin marketplace update admarble/sequant
+/plugin install sequant
+```
+
+### Downgrading
+
+#### Plugin
+
+Remove and reinstall a specific version (if available in marketplace):
+```
+/plugin uninstall sequant
+/plugin install sequant@1.10.0
+```
+
+#### npm
+
+```bash
+npm install -g sequant@1.10.0
+```
+
+## Release Schedule
+
+Sequant does not follow a fixed release schedule. Releases happen when:
+
+- Critical bug fixes are ready
+- New features are complete and tested
+- Breaking changes have accumulated (for major versions)
+
+Subscribe to releases on GitHub for notifications:
+1. Go to https://github.com/admarble/sequant
+2. Click "Watch" → "Custom" → select "Releases"

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -16,6 +16,28 @@ Before tagging a release, verify:
 - [ ] CHANGELOG.md updated
 - [ ] No uncommitted changes: `git status`
 
+## Plugin Version Sync
+
+**Both npm and plugin must use the same version.**
+
+- [ ] `.claude-plugin/plugin.json` version matches `package.json`
+- [ ] Validate plugin manifest: `/plugin validate .` (in Claude Code)
+
+To update both versions together:
+```bash
+# Bump version in both files
+npm version patch --no-git-tag-version
+# Update plugin.json to match
+node -e "
+const pkg = require('./package.json');
+const plugin = require('./.claude-plugin/plugin.json');
+plugin.version = pkg.version;
+require('fs').writeFileSync('./.claude-plugin/plugin.json', JSON.stringify(plugin, null, 2) + '\n');
+"
+```
+
+Or use the `/release` skill which handles this automatically.
+
 ## Issue Integration
 
 Before merging, verify the full trail for each issue:
@@ -45,3 +67,16 @@ Before merging, verify the full trail for each issue:
 ## Smoke Test
 - [ ] `sequant init` works in a fresh directory
 - [ ] `sequant run <issue> --dry-run` works
+
+## Plugin Smoke Test
+
+After release, verify the plugin works for new users:
+
+```bash
+# In a fresh Claude Code session (different project)
+/plugin marketplace add admarble/sequant
+/plugin install sequant
+
+# Verify skills are available
+/sequant:setup
+```


### PR DESCRIPTION
## Summary

Completes AC-6 (Release & Update Process) for issue #185 (Publish Sequant as Claude Code Plugin).

- Add CI validation for plugin.json structure and version sync between package.json and plugin.json
- Update `/release` skill to automatically sync plugin.json version during releases
- Create comprehensive docs/plugin-updates.md documenting upgrade path, versioning strategy, and breaking change policy
- Update release.yml workflow to sync plugin version during GitHub Actions releases
- Update release-checklist.md with plugin-specific smoke tests

## AC-6 Checklist

- [x] Define versioning strategy (sync with npm package) - plugin.json version matches package.json
- [x] Create release checklist for plugin updates - updated docs/release-checklist.md
- [x] Set up CI to validate plugin.json on PRs - new `validate-plugin` job in ci.yml
- [x] Consider changelog automation for plugin releases - documented in plugin-updates.md (intentionally manual with /release assistance)
- [x] Document upgrade path - how users get updates, breaking change policy - comprehensive docs/plugin-updates.md

## Test plan

- [ ] CI passes (new validate-plugin job should run)
- [ ] Version sync validation catches mismatched versions
- [ ] /release skill documentation is clear about plugin sync

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)