### PR TITLE
feat(#201): Add AC linting to /spec to catch vague acceptance criteria

### DIFF
--- a/src/lib/ac-linter.test.ts
+++ b/src/lib/ac-linter.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Tests for AC Linter
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  lintAcceptanceCriterion,
+  lintAcceptanceCriteria,
+  formatACLintResults,
+  getDefaultLintPatterns,
+  createLintPatterns,
+  type ACLintIssueType,
+} from "./ac-linter.js";
+import { createAcceptanceCriterion } from "./workflow/state-schema.js";
+
+describe("AC Linter", () => {
+  describe("lintAcceptanceCriterion", () => {
+    describe("vague patterns", () => {
+      it("should flag 'should work' as vague", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "System should work after deployment",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues).toHaveLength(1);
+        expect(result.issues[0].type).toBe("vague");
+        expect(result.issues[0].matchedPattern).toBe("should work");
+      });
+
+      it("should flag 'works properly' as vague", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Feature works properly in production",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues.some((i) => i.type === "vague")).toBe(true);
+      });
+
+      it("should flag 'correctly' as vague", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Button correctly updates state",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].matchedPattern).toBe("correctly");
+      });
+
+      it("should flag 'as expected' as vague", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Function behaves as expected",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].matchedPattern).toBe("as expected");
+      });
+    });
+
+    describe("unmeasurable patterns", () => {
+      it("should flag 'fast' as unmeasurable", () => {
+        const ac = createAcceptanceCriterion("AC-1", "Page loads fast");
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("unmeasurable");
+        expect(result.issues[0].matchedPattern).toBe("fast");
+      });
+
+      it("should not flag 'fast forward' as unmeasurable", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "User can fast forward the video",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        // Should not flag "fast forward" as an unmeasurable performance term
+        expect(
+          result.issues.filter((i) => i.matchedPattern === "fast"),
+        ).toHaveLength(0);
+      });
+
+      it("should flag 'performant' as unmeasurable", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Application is performant under load",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("unmeasurable");
+      });
+
+      it("should flag 'quickly' as unmeasurable", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Data should sync quickly",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("unmeasurable");
+      });
+
+      it("should flag 'responsive' as unmeasurable", () => {
+        const ac = createAcceptanceCriterion("AC-1", "UI is responsive");
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("unmeasurable");
+      });
+
+      it("should flag 'scalable' as unmeasurable", () => {
+        const ac = createAcceptanceCriterion("AC-1", "System is scalable");
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("unmeasurable");
+      });
+    });
+
+    describe("incomplete patterns", () => {
+      it("should flag 'handle errors' as incomplete", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "System should handle errors gracefully",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues.some((i) => i.type === "incomplete")).toBe(true);
+      });
+
+      it("should flag 'edge cases' as incomplete", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Function handles edge cases",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("incomplete");
+      });
+
+      it("should flag 'corner cases' as incomplete", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Module covers corner cases",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("incomplete");
+      });
+
+      it("should flag 'all scenarios' as incomplete", () => {
+        const ac = createAcceptanceCriterion("AC-1", "Works in all scenarios");
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("incomplete");
+      });
+    });
+
+    describe("open-ended patterns", () => {
+      it("should flag 'etc.' as open-ended", () => {
+        const ac = createAcceptanceCriterion("AC-1", "Supports PNG, JPG, etc.");
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("open_ended");
+        // Regex captures "etc" (word boundary doesn't include the period)
+        expect(result.issues[0].matchedPattern.toLowerCase()).toBe("etc");
+      });
+
+      it("should flag 'and more' as open-ended", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Supports dark mode and more",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("open_ended");
+      });
+
+      it("should flag 'such as' as open-ended", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Handles formats such as JSON and XML",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("open_ended");
+      });
+
+      it("should flag 'including but not limited to' as open-ended", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Supports browsers including but not limited to Chrome",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("open_ended");
+      });
+
+      it("should flag 'for example' as open-ended", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Shows metrics for example CPU and memory",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues[0].type).toBe("open_ended");
+      });
+    });
+
+    describe("clear criteria", () => {
+      it("should pass clear and specific AC", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Login form returns 400 status with error message for invalid email format",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(true);
+        expect(result.issues).toHaveLength(0);
+      });
+
+      it("should pass AC with specific threshold", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Page loads in under 2 seconds on 3G connection",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it("should pass AC with enumerated list", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Supports PNG, JPG, and WebP image formats",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it("should pass AC with specific error handling", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "Returns 404 for missing resources and 503 when database is unavailable",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(true);
+      });
+    });
+
+    describe("multiple issues", () => {
+      it("should detect multiple issues in one AC", () => {
+        const ac = createAcceptanceCriterion(
+          "AC-1",
+          "System should work properly and be fast",
+        );
+        const result = lintAcceptanceCriterion(ac);
+
+        expect(result.passed).toBe(false);
+        expect(result.issues.length).toBeGreaterThan(1);
+        expect(result.issues.some((i) => i.type === "vague")).toBe(true);
+        expect(result.issues.some((i) => i.type === "unmeasurable")).toBe(true);
+      });
+    });
+  });
+
+  describe("lintAcceptanceCriteria", () => {
+    it("should lint multiple criteria and return summary", () => {
+      const criteria = [
+        createAcceptanceCriterion("AC-1", "User can login with email"),
+        createAcceptanceCriterion("AC-2", "System should work properly"),
+        createAcceptanceCriterion("AC-3", "Page loads in <2s"),
+        createAcceptanceCriterion("AC-4", "Handles edge cases"),
+      ];
+
+      const results = lintAcceptanceCriteria(criteria);
+
+      expect(results.summary.total).toBe(4);
+      expect(results.summary.passed).toBe(2);
+      expect(results.summary.flagged).toBe(2);
+      expect(results.hasIssues).toBe(true);
+    });
+
+    it("should return no issues for all clear criteria", () => {
+      const criteria = [
+        createAcceptanceCriterion("AC-1", "User can login with email"),
+        createAcceptanceCriterion(
+          "AC-2",
+          "Login returns 400 for invalid input",
+        ),
+        createAcceptanceCriterion("AC-3", "Session expires after 30 minutes"),
+      ];
+
+      const results = lintAcceptanceCriteria(criteria);
+
+      expect(results.summary.total).toBe(3);
+      expect(results.summary.passed).toBe(3);
+      expect(results.summary.flagged).toBe(0);
+      expect(results.hasIssues).toBe(false);
+    });
+
+    it("should handle empty criteria array", () => {
+      const results = lintAcceptanceCriteria([]);
+
+      expect(results.summary.total).toBe(0);
+      expect(results.summary.passed).toBe(0);
+      expect(results.summary.flagged).toBe(0);
+      expect(results.hasIssues).toBe(false);
+    });
+  });
+
+  describe("formatACLintResults", () => {
+    it("should format results with issues", () => {
+      const criteria = [
+        createAcceptanceCriterion("AC-1", "User can login"),
+        createAcceptanceCriterion("AC-2", "System should work properly"),
+        createAcceptanceCriterion("AC-3", "Page loads fast"),
+      ];
+      const results = lintAcceptanceCriteria(criteria);
+      const output = formatACLintResults(results);
+
+      expect(output).toContain("## AC Quality Check");
+      expect(output).toContain("⚠️ **AC-2:**");
+      expect(output).toContain("⚠️ **AC-3:**");
+      expect(output).toContain("✅ AC-1: Clear and testable");
+      expect(output).toContain("2/3 AC items flagged for review");
+    });
+
+    it("should format results without issues", () => {
+      const criteria = [
+        createAcceptanceCriterion("AC-1", "User can login with email"),
+        createAcceptanceCriterion(
+          "AC-2",
+          "Login returns 400 for invalid input",
+        ),
+      ];
+      const results = lintAcceptanceCriteria(criteria);
+      const output = formatACLintResults(results);
+
+      expect(output).toContain("## AC Quality Check");
+      expect(output).toContain(
+        "✅ All 2 acceptance criteria are clear and testable",
+      );
+      expect(output).not.toContain("⚠️");
+    });
+
+    it("should handle no criteria", () => {
+      const results = lintAcceptanceCriteria([]);
+      const output = formatACLintResults(results);
+
+      expect(output).toContain("## AC Quality Check");
+      expect(output).toContain("No acceptance criteria found to lint");
+    });
+
+    it("should include problem and suggestion for each issue", () => {
+      const criteria = [
+        createAcceptanceCriterion(
+          "AC-1",
+          "System should handle errors gracefully",
+        ),
+      ];
+      const results = lintAcceptanceCriteria(criteria);
+      const output = formatACLintResults(results);
+
+      expect(output).toContain("→");
+      expect(output).toContain("Suggest:");
+    });
+  });
+
+  describe("getDefaultLintPatterns", () => {
+    it("should return a copy of default patterns", () => {
+      const patterns1 = getDefaultLintPatterns();
+      const patterns2 = getDefaultLintPatterns();
+
+      expect(patterns1).not.toBe(patterns2);
+      expect(patterns1.length).toBe(patterns2.length);
+      expect(patterns1.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("createLintPatterns", () => {
+    it("should create custom patterns from config", () => {
+      const config = [
+        {
+          pattern: "\\bmagic\\b",
+          type: "vague" as ACLintIssueType,
+          problem: 'Custom: "magic" is not specific',
+          suggestion: "Specify the actual mechanism",
+        },
+      ];
+
+      const patterns = createLintPatterns(config);
+
+      expect(patterns).toHaveLength(1);
+      expect(patterns[0].regex.test("It works like magic")).toBe(true);
+      expect(patterns[0].type).toBe("vague");
+    });
+
+    it("should use custom patterns in linting", () => {
+      const config = [
+        {
+          pattern: "\\bmagic\\b",
+          type: "vague" as ACLintIssueType,
+          problem: 'Custom: "magic" is not specific',
+          suggestion: "Specify the actual mechanism",
+        },
+      ];
+
+      const patterns = createLintPatterns(config);
+      const ac = createAcceptanceCriterion("AC-1", "It works like magic");
+      const result = lintAcceptanceCriterion(ac, patterns);
+
+      expect(result.passed).toBe(false);
+      expect(result.issues[0].problem).toContain("magic");
+    });
+  });
+});

--- a/src/lib/ac-linter.ts
+++ b/src/lib/ac-linter.ts
@@ -1,0 +1,409 @@
+/**
+ * Acceptance Criteria Linter
+ *
+ * Static analysis of acceptance criteria to flag vague, untestable,
+ * or incomplete requirements before implementation begins.
+ *
+ * @example
+ * ```typescript
+ * import { lintAcceptanceCriteria } from './ac-linter';
+ * import { parseAcceptanceCriteria } from './ac-parser';
+ *
+ * const criteria = parseAcceptanceCriteria(issueBody);
+ * const lintResults = lintAcceptanceCriteria(criteria);
+ *
+ * console.log(formatACLintResults(lintResults));
+ * ```
+ */
+
+import type { AcceptanceCriterion } from "./workflow/state-schema.js";
+
+/**
+ * Types of issues that can be flagged in AC
+ */
+export type ACLintIssueType =
+  | "vague"
+  | "unmeasurable"
+  | "incomplete"
+  | "open_ended";
+
+/**
+ * A lint issue found in an acceptance criterion
+ */
+export interface ACLintIssue {
+  /** Type of issue detected */
+  type: ACLintIssueType;
+  /** The matched pattern that triggered this issue */
+  matchedPattern: string;
+  /** Human-readable description of the problem */
+  problem: string;
+  /** Suggested improvement */
+  suggestion: string;
+}
+
+/**
+ * Lint result for a single acceptance criterion
+ */
+export interface ACLintResult {
+  /** The AC being linted */
+  ac: AcceptanceCriterion;
+  /** Issues found (empty if AC is clear) */
+  issues: ACLintIssue[];
+  /** Whether this AC passed linting (no issues) */
+  passed: boolean;
+}
+
+/**
+ * Overall lint results for all acceptance criteria
+ */
+export interface ACLintResults {
+  /** Results for each AC */
+  results: ACLintResult[];
+  /** Summary counts */
+  summary: {
+    total: number;
+    passed: number;
+    flagged: number;
+  };
+  /** Whether any issues were found */
+  hasIssues: boolean;
+}
+
+/**
+ * Pattern definition for detecting issues
+ */
+interface LintPattern {
+  /** Regular expression to match (case-insensitive) */
+  regex: RegExp;
+  /** Type of issue this pattern indicates */
+  type: ACLintIssueType;
+  /** Problem description */
+  problem: string;
+  /** Suggested fix */
+  suggestion: string;
+}
+
+/**
+ * Default lint patterns organized by issue type
+ *
+ * Patterns are checked in order, with longer/more specific patterns first
+ */
+const DEFAULT_LINT_PATTERNS: LintPattern[] = [
+  // Vague patterns
+  {
+    regex: /\bshould work\b/i,
+    type: "vague",
+    problem: 'Vague: "should work" is not specific',
+    suggestion: "Specify the expected behavior and success criteria",
+  },
+  {
+    regex: /\bwork(?:s|ing)? (?:properly|correctly|well|nicely)\b/i,
+    type: "vague",
+    problem: "Vague: adverb does not define expected behavior",
+    suggestion: "Define specific, measurable outcomes",
+  },
+  {
+    regex: /\bproperly\b/i,
+    type: "vague",
+    problem: 'Vague: "properly" is subjective',
+    suggestion: "Specify what correct behavior looks like",
+  },
+  {
+    regex: /\bcorrectly\b/i,
+    type: "vague",
+    problem: 'Vague: "correctly" is subjective',
+    suggestion: "Define the expected output or behavior",
+  },
+  {
+    regex: /\bnicely\b/i,
+    type: "vague",
+    problem: 'Vague: "nicely" is subjective',
+    suggestion: "Specify concrete UX requirements",
+  },
+  {
+    regex: /\bgood\b(?!\s+(?:practice|pattern|reason))/i,
+    type: "vague",
+    problem: 'Vague: "good" is subjective without context',
+    suggestion: "Define measurable quality criteria",
+  },
+  {
+    regex: /\bas expected\b/i,
+    type: "vague",
+    problem: 'Vague: "as expected" requires explicit expectations',
+    suggestion: "Define what the expected behavior is",
+  },
+  {
+    regex: /\bshould be fine\b/i,
+    type: "vague",
+    problem: 'Vague: "should be fine" is not a testable criterion',
+    suggestion: "Specify the acceptance threshold",
+  },
+
+  // Unmeasurable patterns (performance-related)
+  {
+    regex: /\bfast(?:er)?\b(?!\s+forward)/i,
+    type: "unmeasurable",
+    problem: 'Unmeasurable: "fast" has no threshold',
+    suggestion: "Add latency threshold (e.g., <2 seconds, <100ms)",
+  },
+  {
+    regex: /\bslow(?:er)?\b/i,
+    type: "unmeasurable",
+    problem: 'Unmeasurable: "slow" has no threshold',
+    suggestion: "Define specific timing or threshold",
+  },
+  {
+    regex: /\bperformant\b/i,
+    type: "unmeasurable",
+    problem: 'Unmeasurable: "performant" has no threshold',
+    suggestion: "Add specific performance metrics (latency, throughput)",
+  },
+  {
+    regex: /\befficient(?:ly)?\b/i,
+    type: "unmeasurable",
+    problem: 'Unmeasurable: "efficient" has no threshold',
+    suggestion: "Define resource usage limits or benchmarks",
+  },
+  {
+    regex: /\bresponsive\b/i,
+    type: "unmeasurable",
+    problem: 'Unmeasurable: "responsive" has no threshold',
+    suggestion: "Add response time target (e.g., <100ms interaction, <3s load)",
+  },
+  {
+    regex: /\bquick(?:ly)?\b/i,
+    type: "unmeasurable",
+    problem: 'Unmeasurable: "quickly" has no threshold',
+    suggestion: "Specify time limit (e.g., completes in <5 seconds)",
+  },
+  {
+    regex: /\bscalable\b/i,
+    type: "unmeasurable",
+    problem: 'Unmeasurable: "scalable" needs concrete bounds',
+    suggestion: "Define load targets (e.g., handles 1000 concurrent users)",
+  },
+
+  // Incomplete patterns (error handling, edge cases)
+  {
+    regex: /\bhandle(?:s)? errors?\b/i,
+    type: "incomplete",
+    problem: "Incomplete: error types not specified",
+    suggestion:
+      "List specific error types and expected responses (e.g., 400 for invalid input, 503 for service unavailable)",
+  },
+  {
+    regex: /\berror handling\b/i,
+    type: "incomplete",
+    problem: "Incomplete: error scenarios not specified",
+    suggestion: "Enumerate error conditions and recovery behaviors",
+  },
+  {
+    regex: /\bedge cases?\b/i,
+    type: "incomplete",
+    problem: "Incomplete: edge cases not enumerated",
+    suggestion: "List the specific edge cases to handle",
+  },
+  {
+    regex: /\bcorner cases?\b/i,
+    type: "incomplete",
+    problem: "Incomplete: corner cases not enumerated",
+    suggestion: "List the specific corner cases to handle",
+  },
+  {
+    regex: /\ball (?:cases|scenarios|situations)\b/i,
+    type: "incomplete",
+    problem: 'Incomplete: "all" cases cannot be verified',
+    suggestion: "Enumerate the specific cases to test",
+  },
+  {
+    regex: /\bappropriate(?:ly)?\b/i,
+    type: "incomplete",
+    problem: 'Incomplete: "appropriate" behavior not defined',
+    suggestion: "Specify what the appropriate response is",
+  },
+
+  // Open-ended patterns
+  {
+    regex: /\betc\.?\b/i,
+    type: "open_ended",
+    problem: 'Open-ended: "etc." leaves scope undefined',
+    suggestion: "Enumerate all items explicitly",
+  },
+  {
+    regex: /\band more\b/i,
+    type: "open_ended",
+    problem: 'Open-ended: "and more" leaves scope undefined',
+    suggestion: "List all items explicitly",
+  },
+  {
+    regex: /\bsuch as\b/i,
+    type: "open_ended",
+    problem: 'Open-ended: "such as" implies incomplete list',
+    suggestion: "Provide exhaustive list or define boundaries",
+  },
+  {
+    regex: /\bincluding but not limited to\b/i,
+    type: "open_ended",
+    problem: "Open-ended: scope is unbounded",
+    suggestion: "Define explicit boundaries or enumerate all items",
+  },
+  {
+    regex: /\bfor example\b/i,
+    type: "open_ended",
+    problem: 'Open-ended: "for example" implies other cases exist',
+    suggestion: "List all cases or define scope boundaries",
+  },
+  {
+    regex: /\bvarious\b/i,
+    type: "open_ended",
+    problem: 'Open-ended: "various" items not specified',
+    suggestion: "Enumerate the specific items",
+  },
+  {
+    regex: /\bother(?:s)?\b(?!\s+(?:than|hand|words|side))/i,
+    type: "open_ended",
+    problem: 'Open-ended: "other" items not specified',
+    suggestion: "List all items explicitly or define boundaries",
+  },
+];
+
+/**
+ * Lint a single acceptance criterion against all patterns
+ *
+ * @param ac - The acceptance criterion to lint
+ * @param patterns - Optional custom patterns (defaults to DEFAULT_LINT_PATTERNS)
+ * @returns Lint result with any issues found
+ */
+export function lintAcceptanceCriterion(
+  ac: AcceptanceCriterion,
+  patterns: LintPattern[] = DEFAULT_LINT_PATTERNS,
+): ACLintResult {
+  const issues: ACLintIssue[] = [];
+  const description = ac.description;
+
+  for (const pattern of patterns) {
+    const match = description.match(pattern.regex);
+    if (match) {
+      issues.push({
+        type: pattern.type,
+        matchedPattern: match[0],
+        problem: pattern.problem,
+        suggestion: pattern.suggestion,
+      });
+    }
+  }
+
+  return {
+    ac,
+    issues,
+    passed: issues.length === 0,
+  };
+}
+
+/**
+ * Lint all acceptance criteria
+ *
+ * @param criteria - Array of acceptance criteria to lint
+ * @param patterns - Optional custom patterns
+ * @returns Complete lint results with summary
+ */
+export function lintAcceptanceCriteria(
+  criteria: AcceptanceCriterion[],
+  patterns?: LintPattern[],
+): ACLintResults {
+  const results = criteria.map((ac) => lintAcceptanceCriterion(ac, patterns));
+
+  const passed = results.filter((r) => r.passed).length;
+  const flagged = results.filter((r) => !r.passed).length;
+
+  return {
+    results,
+    summary: {
+      total: criteria.length,
+      passed,
+      flagged,
+    },
+    hasIssues: flagged > 0,
+  };
+}
+
+/**
+ * Format lint results as markdown for the spec output
+ *
+ * @param results - Lint results to format
+ * @returns Markdown-formatted output string
+ */
+export function formatACLintResults(results: ACLintResults): string {
+  if (results.summary.total === 0) {
+    return "## AC Quality Check\n\nNo acceptance criteria found to lint.";
+  }
+
+  const lines: string[] = ["## AC Quality Check", ""];
+
+  // Add summary line
+  if (!results.hasIssues) {
+    lines.push(
+      `✅ All ${results.summary.total} acceptance criteria are clear and testable.`,
+    );
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  // Add issues
+  for (const result of results.results) {
+    if (!result.passed) {
+      lines.push(`⚠️ **${result.ac.id}:** "${result.ac.description}"`);
+      for (const issue of result.issues) {
+        lines.push(`   → ${issue.problem}`);
+        lines.push(`   → Suggest: ${issue.suggestion}`);
+      }
+      lines.push("");
+    }
+  }
+
+  // Add passed ACs summary
+  const passedIds = results.results.filter((r) => r.passed).map((r) => r.ac.id);
+
+  if (passedIds.length > 0) {
+    lines.push(`✅ ${passedIds.join(", ")}: Clear and testable`);
+    lines.push("");
+  }
+
+  // Add summary
+  lines.push(
+    `**Summary:** ${results.summary.flagged}/${results.summary.total} AC items flagged for review`,
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Get the default lint patterns
+ *
+ * @returns Copy of the default lint patterns
+ */
+export function getDefaultLintPatterns(): LintPattern[] {
+  return [...DEFAULT_LINT_PATTERNS];
+}
+
+/**
+ * Create custom lint patterns from a simplified configuration
+ *
+ * @param config - Array of pattern configurations
+ * @returns Array of LintPattern objects
+ */
+export function createLintPatterns(
+  config: Array<{
+    pattern: string;
+    type: ACLintIssueType;
+    problem: string;
+    suggestion: string;
+  }>,
+): LintPattern[] {
+  return config.map((c) => ({
+    regex: new RegExp(c.pattern, "i"),
+    type: c.type,
+    problem: c.problem,
+    suggestion: c.suggestion,
+  }));
+}


### PR DESCRIPTION
## Summary

- Adds static analysis of acceptance criteria in `/spec` to flag vague, untestable, or incomplete requirements
- Creates pattern detection for common issues (vague terms, unmeasurable metrics, incomplete specs, open-ended lists)
- Warning-only approach - surfaces issues but doesn't block plan generation
- Includes `--skip-ac-lint` flag for cases where linting should be bypassed

## Test plan

- [x] All 34 new AC linter tests pass
- [x] Build compiles successfully
- [x] Lint passes
- [ ] Manual test: Run `/spec` on an issue with vague AC to verify flagging
- [ ] Manual test: Run `/spec --skip-ac-lint` to verify skip behavior

## Files changed

| File | Description |
|------|-------------|
| `src/lib/ac-linter.ts` | Core AC linter module with pattern detection |
| `src/lib/ac-linter.test.ts` | Comprehensive test coverage (34 tests) |
| `.claude/skills/spec/SKILL.md` | Updated with AC Quality Check section |
| `templates/skills/spec/SKILL.md` | Template sync with skill updates |

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)