### PR TITLE
feat(#200): Add Semgrep integration to /qa for static analysis

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -16,6 +16,9 @@ allowed-tools:
   - Bash(gh pr view:*)
   - Bash(gh pr diff:*)
   - Bash(gh pr comment:*)
+  - Bash(semgrep:*)
+  - Bash(npx semgrep:*)
+  - Bash(npx tsx scripts/semgrep-scan.ts:*)
   - Task
   - AgentOutputTool
 ---

--- a/.claude/skills/qa/references/semgrep-rules.md
+++ b/.claude/skills/qa/references/semgrep-rules.md
@@ -1,0 +1,207 @@
+# Semgrep Integration Guide
+
+This guide explains how to configure and use Semgrep static analysis in the `/qa` workflow.
+
+## Overview
+
+Semgrep is a fast, open-source static analysis tool that finds bugs and enforces code standards. The `/qa` skill integrates Semgrep to automatically scan code changes for security vulnerabilities and anti-patterns.
+
+## Installation
+
+Semgrep is **optional**. If not installed, the `/qa` skill will gracefully skip Semgrep analysis.
+
+### Install Semgrep
+
+```bash
+# Using pip (recommended)
+pip install semgrep
+
+# Using Homebrew (macOS)
+brew install semgrep
+
+# Using npm (via npx - no install required)
+npx semgrep --version
+```
+
+### Verify Installation
+
+```bash
+semgrep --version
+# Or
+npx semgrep --version
+```
+
+## How It Works
+
+1. During `/qa`, the quality checks script detects if Semgrep is installed
+2. If installed, it runs Semgrep with stack-appropriate rulesets
+3. Findings are categorized by severity (critical, warning, info)
+4. Critical findings block the merge verdict (`AC_NOT_MET`)
+5. Warnings are noted but don't block merges
+
+## Default Rulesets
+
+Semgrep uses stack-specific rulesets for targeted analysis:
+
+| Stack | Rulesets Applied |
+|-------|------------------|
+| **Next.js** | p/typescript, p/javascript, p/react, p/security-audit, p/secrets |
+| **Astro** | p/typescript, p/javascript, p/security-audit, p/secrets |
+| **SvelteKit** | p/typescript, p/javascript, p/security-audit, p/secrets |
+| **Remix** | p/typescript, p/javascript, p/react, p/security-audit, p/secrets |
+| **Nuxt** | p/typescript, p/javascript, p/security-audit, p/secrets |
+| **Python** | p/python, p/django, p/flask, p/security-audit, p/secrets |
+| **Go** | p/golang, p/security-audit, p/secrets |
+| **Rust** | p/rust, p/security-audit, p/secrets |
+| **Generic** | p/security-audit, p/secrets |
+
+## Custom Rules
+
+You can add project-specific rules by creating `.sequant/semgrep-rules.yaml` in your project root.
+
+### Getting Started
+
+Copy the example template to your project:
+
+```bash
+# Copy the example template
+cp docs/examples/semgrep-rules.example.yaml .sequant/semgrep-rules.yaml
+```
+
+### Custom Rules File Location
+
+```
+your-project/
+├── .sequant/
+│   └── semgrep-rules.yaml    # Your custom rules
+├── src/
+└── package.json
+```
+
+### Example Custom Rules
+
+```yaml
+rules:
+  # Prevent console.log in production code
+  - id: no-console-log
+    pattern: console.log(...)
+    message: "Remove console.log before merging"
+    severity: WARNING
+    languages: [typescript, javascript]
+    paths:
+      exclude:
+        - "**/*.test.*"
+        - "**/__tests__/**"
+
+  # Require explicit return types on exported functions
+  - id: explicit-return-type
+    pattern: |
+      export function $FUNC(...): $RET { ... }
+    pattern-not: |
+      export function $FUNC(...): void { ... }
+    message: "Exported functions should have explicit return types"
+    severity: INFO
+    languages: [typescript]
+
+  # Detect potential SQL injection
+  - id: sql-injection-risk
+    patterns:
+      - pattern: $DB.query($SQL + ...)
+      - pattern: $DB.query(`...${...}...`)
+    message: "Potential SQL injection - use parameterized queries"
+    severity: ERROR
+    languages: [typescript, javascript]
+
+  # Prevent hardcoded API keys
+  - id: no-hardcoded-api-key
+    pattern-regex: "(api[_-]?key|apikey|secret[_-]?key)\\s*[:=]\\s*['\"][^'\"]{8,}['\"]"
+    message: "Don't hardcode API keys - use environment variables"
+    severity: ERROR
+    languages: [typescript, javascript, python]
+```
+
+### Rule Severity Levels
+
+| Severity | Verdict Impact | Description |
+|----------|----------------|-------------|
+| `ERROR` | **Blocking** | Critical issues that must be fixed |
+| `WARNING` | Non-blocking | Issues that should be reviewed |
+| `INFO` | Non-blocking | Style suggestions |
+
+## Running Semgrep Manually
+
+You can run Semgrep manually using the provided script:
+
+```bash
+# Scan entire project with auto-detected stack
+npx tsx scripts/semgrep-scan.ts
+
+# Scan only changed files (faster, recommended)
+npx tsx scripts/semgrep-scan.ts --changed-only
+
+# Scan specific directories
+npx tsx scripts/semgrep-scan.ts src/api/ src/lib/
+
+# Override detected stack
+npx tsx scripts/semgrep-scan.ts --stack python
+
+# Get JSON output
+npx tsx scripts/semgrep-scan.ts --json > semgrep-results.json
+```
+
+## Interpreting Results
+
+### Clean Output
+
+```
+## Static Analysis (Semgrep)
+
+✅ No security issues found
+```
+
+### Issues Found
+
+```
+## Static Analysis (Semgrep)
+
+❌ 1 critical finding(s)
+⚠️  2 warning(s)
+
+### ❌ Critical Issues
+
+- `src/api/users.ts:47` - Potential SQL injection (user input in query) (security.sql-injection)
+
+### ⚠️ Warnings
+
+- `src/utils/exec.ts:12` - Command injection risk (unsanitized shell arg) (security.command-injection)
+- `src/lib/logger.ts:8` - Remove console.log before merging (custom.no-console-log)
+```
+
+## Troubleshooting
+
+### Semgrep Not Running
+
+1. Check if Semgrep is installed: `semgrep --version`
+2. If not installed, install it or use `npx semgrep`
+3. Check for error messages in the quality checks output
+
+### False Positives
+
+If a rule produces false positives:
+
+1. Add a `# nosemgrep: rule-id` comment to ignore specific lines
+2. Create custom rules that exclude specific patterns
+3. Use path exclusions in your custom rules
+
+### Performance
+
+- Semgrep only scans changed files by default (via `--changed-only`)
+- Large codebases may take longer on first scan
+- Results are not cached between runs
+
+## Resources
+
+- [Semgrep Documentation](https://semgrep.dev/docs/)
+- [Semgrep Rule Registry](https://semgrep.dev/r)
+- [Writing Custom Rules](https://semgrep.dev/docs/writing-rules/overview/)
+- [Rule Syntax Reference](https://semgrep.dev/docs/writing-rules/rule-syntax/)

--- a/docs/examples/semgrep-rules.example.yaml
+++ b/docs/examples/semgrep-rules.example.yaml
@@ -1,0 +1,109 @@
+# Custom Semgrep Rules for Your Project
+#
+# This file contains project-specific Semgrep rules that run alongside
+# the default stack-aware rulesets during /qa.
+#
+# To use: Copy this file to .sequant/semgrep-rules.yaml in your project root.
+#
+# Rule Reference: https://semgrep.dev/docs/writing-rules/rule-syntax/
+# Rule Registry: https://semgrep.dev/r (browse existing rules for inspiration)
+
+rules:
+  # ============================================================
+  # SECURITY RULES (severity: ERROR = blocking)
+  # ============================================================
+
+  # Prevent hardcoded secrets
+  - id: no-hardcoded-secrets
+    patterns:
+      - pattern-regex: "(password|secret|api[_-]?key|token)\\s*[:=]\\s*['\"][^'\"]{8,}['\"]"
+    message: "Potential hardcoded secret detected. Use environment variables instead."
+    severity: ERROR
+    languages: [typescript, javascript, python]
+    paths:
+      exclude:
+        - "**/*.test.*"
+        - "**/__tests__/**"
+        - "**/fixtures/**"
+
+  # Detect potential SQL injection
+  - id: sql-injection-template-literal
+    patterns:
+      - pattern: $DB.query(`...${$VAR}...`)
+      - pattern: $DB.raw(`...${$VAR}...`)
+    message: "Potential SQL injection via template literal. Use parameterized queries."
+    severity: ERROR
+    languages: [typescript, javascript]
+
+  # ============================================================
+  # CODE QUALITY RULES (severity: WARNING = non-blocking)
+  # ============================================================
+
+  # No console.log in production code
+  - id: no-console-log
+    pattern: console.log(...)
+    message: "Remove console.log before merging. Use a proper logger instead."
+    severity: WARNING
+    languages: [typescript, javascript]
+    paths:
+      exclude:
+        - "**/*.test.*"
+        - "**/__tests__/**"
+        - "**/scripts/**"
+
+  # Avoid any type
+  - id: no-explicit-any
+    pattern: |
+      $X: any
+    message: "Avoid using 'any' type. Consider using 'unknown' or a specific type."
+    severity: WARNING
+    languages: [typescript]
+    paths:
+      exclude:
+        - "**/*.d.ts"
+
+  # ============================================================
+  # STYLE RULES (severity: INFO = suggestions)
+  # ============================================================
+
+  # Prefer const over let when not reassigned
+  # (Note: This is better handled by ESLint, shown as example)
+  # - id: prefer-const
+  #   pattern: let $VAR = $INIT;
+  #   message: "Consider using 'const' if the variable is not reassigned."
+  #   severity: INFO
+  #   languages: [typescript, javascript]
+
+  # ============================================================
+  # PROJECT-SPECIFIC RULES
+  # ============================================================
+
+  # Example: Require error handling for async operations
+  # - id: async-requires-try-catch
+  #   pattern: |
+  #     async function $FUNC(...) {
+  #       ...
+  #       await $EXPR
+  #       ...
+  #     }
+  #   pattern-not: |
+  #     async function $FUNC(...) {
+  #       ...
+  #       try { ... } catch (...) { ... }
+  #       ...
+  #     }
+  #   message: "Async functions should include error handling."
+  #   severity: WARNING
+  #   languages: [typescript, javascript]
+
+  # Example: Enforce use of project utilities
+  # - id: use-project-logger
+  #   patterns:
+  #     - pattern: console.error(...)
+  #     - pattern: console.warn(...)
+  #   message: "Use the project logger from '@/lib/logger' instead of console methods."
+  #   severity: INFO
+  #   languages: [typescript, javascript]
+  #   paths:
+  #     exclude:
+  #       - "**/lib/logger.ts"

--- a/scripts/semgrep-scan.ts
+++ b/scripts/semgrep-scan.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env npx tsx
+/**
+ * Semgrep Scan Runner
+ *
+ * Runs Semgrep static analysis with stack-aware rulesets.
+ * Integrates with the /qa skill workflow.
+ *
+ * Usage:
+ *   npx tsx scripts/semgrep-scan.ts [options] [files...]
+ *
+ * Options:
+ *   --stack <name>    Override detected stack (nextjs, python, go, etc.)
+ *   --json            Output raw JSON format
+ *   --changed-only    Only scan files changed from main branch
+ *   --help            Show this help message
+ *
+ * Examples:
+ *   npx tsx scripts/semgrep-scan.ts
+ *   npx tsx scripts/semgrep-scan.ts --changed-only
+ *   npx tsx scripts/semgrep-scan.ts --stack python src/
+ *   npx tsx scripts/semgrep-scan.ts src/api/ src/lib/
+ */
+
+import { execSync } from "child_process";
+
+import {
+  checkSemgrepAvailability,
+  formatFindingsForDisplay,
+  getCustomRulesPath,
+  getRulesForStack,
+  getSemgrepVerdictContribution,
+  hasCustomRules,
+  runSemgrepScan,
+} from "../src/lib/semgrep.js";
+import { detectStack } from "../src/lib/stacks.js";
+
+interface CliOptions {
+  stack?: string;
+  json: boolean;
+  changedOnly: boolean;
+  help: boolean;
+  targets: string[];
+}
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    json: false,
+    changedOnly: false,
+    help: false,
+    targets: [],
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === "--stack" && i + 1 < args.length) {
+      options.stack = args[i + 1];
+      i += 2;
+    } else if (arg === "--json") {
+      options.json = true;
+      i++;
+    } else if (arg === "--changed-only") {
+      options.changedOnly = true;
+      i++;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      i++;
+    } else if (!arg.startsWith("-")) {
+      options.targets.push(arg);
+      i++;
+    } else {
+      console.error(`Unknown option: ${arg}`);
+      process.exit(1);
+    }
+  }
+
+  return options;
+}
+
+function showHelp(): void {
+  console.log(`
+Semgrep Scan Runner - Static analysis with stack-aware rulesets
+
+Usage:
+  npx tsx scripts/semgrep-scan.ts [options] [files...]
+
+Options:
+  --stack <name>    Override detected stack (nextjs, python, go, rust, etc.)
+  --json            Output raw JSON format
+  --changed-only    Only scan files changed from main branch
+  --help, -h        Show this help message
+
+Supported Stacks:
+  nextjs, astro, sveltekit, remix, nuxt, rust, python, go, generic
+
+Custom Rules:
+  Place custom Semgrep rules in .sequant/semgrep-rules.yaml
+  They will be automatically loaded alongside stack rules.
+
+Examples:
+  # Scan entire project with auto-detected stack
+  npx tsx scripts/semgrep-scan.ts
+
+  # Scan only changed files
+  npx tsx scripts/semgrep-scan.ts --changed-only
+
+  # Scan specific directories with explicit stack
+  npx tsx scripts/semgrep-scan.ts --stack python src/api/
+
+  # Get JSON output for programmatic use
+  npx tsx scripts/semgrep-scan.ts --json > results.json
+`);
+}
+
+function getChangedFiles(): string[] {
+  try {
+    const output = execSync("git diff main...HEAD --name-only", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return output
+      .split("\n")
+      .filter((f) => f.trim())
+      .filter(
+        (f) =>
+          f.endsWith(".ts") ||
+          f.endsWith(".tsx") ||
+          f.endsWith(".js") ||
+          f.endsWith(".jsx") ||
+          f.endsWith(".py") ||
+          f.endsWith(".go") ||
+          f.endsWith(".rs"),
+      );
+  } catch {
+    console.error("Warning: Could not get changed files from git");
+    return [];
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const options = parseArgs(args);
+
+  if (options.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  // Check Semgrep availability first
+  console.log("🔍 Checking Semgrep availability...");
+  const availability = await checkSemgrepAvailability();
+
+  if (!availability.available) {
+    console.log("⚠️  Semgrep not installed");
+    console.log("");
+    console.log("To install Semgrep:");
+    console.log("  pip install semgrep");
+    console.log("  # or");
+    console.log("  brew install semgrep");
+    console.log("");
+    console.log("Semgrep scan skipped (graceful degradation)");
+
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          success: true,
+          skipped: true,
+          skipReason: "Semgrep not installed",
+          findings: [],
+          criticalCount: 0,
+          warningCount: 0,
+          infoCount: 0,
+        }),
+      );
+    }
+    process.exit(0);
+  }
+
+  const useNpxNote = availability.useNpx ? " (via npx)" : "";
+  console.log(`✅ Semgrep available${useNpxNote}`);
+  console.log("");
+
+  // Detect or use specified stack
+  const stack = options.stack || (await detectStack());
+  const ruleset = getRulesForStack(stack);
+  console.log(`📚 Stack: ${ruleset.name}`);
+  console.log(`   Rules: ${ruleset.rules.join(", ")}`);
+
+  // Check for custom rules
+  if (hasCustomRules()) {
+    const customPath = getCustomRulesPath();
+    console.log(`   Custom rules: ${customPath}`);
+  }
+  console.log("");
+
+  // Determine targets
+  let targets = options.targets;
+  if (targets.length === 0) {
+    if (options.changedOnly) {
+      targets = getChangedFiles();
+      if (targets.length === 0) {
+        console.log("No changed files to scan");
+        if (options.json) {
+          console.log(
+            JSON.stringify({
+              success: true,
+              findings: [],
+              criticalCount: 0,
+              warningCount: 0,
+              infoCount: 0,
+            }),
+          );
+        }
+        process.exit(0);
+      }
+      console.log(`Scanning ${targets.length} changed file(s)...`);
+    } else {
+      // Default to current directory
+      targets = ["."];
+      console.log("Scanning entire project...");
+    }
+  } else {
+    console.log(`Scanning: ${targets.join(", ")}...`);
+  }
+  console.log("");
+
+  // Run the scan
+  const result = await runSemgrepScan({
+    targets,
+    stack,
+    useCustomRules: true,
+  });
+
+  // Output results
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log("## Static Analysis (Semgrep)");
+    console.log("");
+
+    if (result.skipped) {
+      console.log(`⚠️  Skipped: ${result.skipReason}`);
+    } else if (!result.success) {
+      console.log(`❌ Error: ${result.error}`);
+    } else {
+      // Summary line
+      if (result.criticalCount === 0 && result.warningCount === 0) {
+        console.log("✅ No security issues found");
+      } else {
+        if (result.criticalCount > 0) {
+          console.log(`❌ ${result.criticalCount} critical finding(s)`);
+        }
+        if (result.warningCount > 0) {
+          console.log(`⚠️  ${result.warningCount} warning(s)`);
+        }
+        if (result.infoCount > 0) {
+          console.log(`ℹ️  ${result.infoCount} info finding(s)`);
+        }
+      }
+
+      // Detailed findings
+      if (result.findings.length > 0) {
+        console.log("");
+        console.log(formatFindingsForDisplay(result.findings));
+      }
+
+      // Verdict contribution
+      console.log("");
+      const verdict = getSemgrepVerdictContribution(result);
+      if (verdict.blocking) {
+        console.log(`🚫 Verdict: BLOCKING - ${verdict.reason}`);
+      } else {
+        console.log(`✅ Verdict: ${verdict.reason}`);
+      }
+    }
+  }
+
+  // Exit with appropriate code
+  if (result.criticalCount > 0) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/src/lib/semgrep.test.ts
+++ b/src/lib/semgrep.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for Semgrep integration
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  countFindingsBySeverity,
+  formatFindingsForDisplay,
+  getRulesForStack,
+  getSemgrepVerdictContribution,
+  hasCustomRules,
+  parseSemgrepOutput,
+  SemgrepFinding,
+  SemgrepResult,
+  STACK_RULESETS,
+} from "./semgrep.js";
+
+describe("semgrep", () => {
+  describe("getRulesForStack", () => {
+    it("returns Next.js rules for nextjs stack", () => {
+      const ruleset = getRulesForStack("nextjs");
+      expect(ruleset.name).toBe("Next.js");
+      expect(ruleset.rules).toContain("p/typescript");
+      expect(ruleset.rules).toContain("p/react");
+      expect(ruleset.rules).toContain("p/security-audit");
+    });
+
+    it("returns Python rules for python stack", () => {
+      const ruleset = getRulesForStack("python");
+      expect(ruleset.name).toBe("Python");
+      expect(ruleset.rules).toContain("p/python");
+      expect(ruleset.rules).toContain("p/django");
+      expect(ruleset.rules).toContain("p/flask");
+    });
+
+    it("returns Go rules for go stack", () => {
+      const ruleset = getRulesForStack("go");
+      expect(ruleset.name).toBe("Go");
+      expect(ruleset.rules).toContain("p/golang");
+    });
+
+    it("returns Rust rules for rust stack", () => {
+      const ruleset = getRulesForStack("rust");
+      expect(ruleset.name).toBe("Rust");
+      expect(ruleset.rules).toContain("p/rust");
+    });
+
+    it("returns generic rules for unknown stack", () => {
+      const ruleset = getRulesForStack("unknown");
+      expect(ruleset.name).toBe("Generic");
+      expect(ruleset.rules).toContain("p/security-audit");
+    });
+
+    it("returns generic rules for null stack", () => {
+      const ruleset = getRulesForStack(null);
+      expect(ruleset.name).toBe("Generic");
+    });
+
+    it("all stacks include security-audit and secrets rules", () => {
+      for (const [stackName, ruleset] of Object.entries(STACK_RULESETS)) {
+        expect(
+          ruleset.rules,
+          `${stackName} should include security-audit`,
+        ).toContain("p/security-audit");
+        expect(ruleset.rules, `${stackName} should include secrets`).toContain(
+          "p/secrets",
+        );
+      }
+    });
+  });
+
+  describe("parseSemgrepOutput", () => {
+    it("parses valid JSON output with results", () => {
+      const output = JSON.stringify({
+        results: [
+          {
+            path: "src/app.ts",
+            start: { line: 10, col: 5 },
+            end: { line: 10, col: 20 },
+            extra: {
+              message: "Potential SQL injection",
+              severity: "error",
+              metadata: { category: "security" },
+            },
+            check_id: "typescript.security.sql-injection",
+          },
+        ],
+      });
+
+      const findings = parseSemgrepOutput(output);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toEqual({
+        path: "src/app.ts",
+        line: 10,
+        column: 5,
+        endLine: 10,
+        endColumn: 20,
+        message: "Potential SQL injection",
+        ruleId: "typescript.security.sql-injection",
+        severity: "error",
+        category: "security",
+      });
+    });
+
+    it("handles empty results array", () => {
+      const output = JSON.stringify({ results: [] });
+      const findings = parseSemgrepOutput(output);
+      expect(findings).toHaveLength(0);
+    });
+
+    it("handles invalid JSON gracefully", () => {
+      const findings = parseSemgrepOutput("not valid json");
+      expect(findings).toHaveLength(0);
+    });
+
+    it("maps severity levels correctly", () => {
+      const makeResult = (severity: string) =>
+        JSON.stringify({
+          results: [
+            {
+              path: "test.ts",
+              start: { line: 1 },
+              extra: { message: "test", severity },
+              check_id: "test",
+            },
+          ],
+        });
+
+      expect(parseSemgrepOutput(makeResult("error"))[0].severity).toBe("error");
+      expect(parseSemgrepOutput(makeResult("critical"))[0].severity).toBe(
+        "error",
+      );
+      expect(parseSemgrepOutput(makeResult("high"))[0].severity).toBe("error");
+      expect(parseSemgrepOutput(makeResult("warning"))[0].severity).toBe(
+        "warning",
+      );
+      expect(parseSemgrepOutput(makeResult("medium"))[0].severity).toBe(
+        "warning",
+      );
+      expect(parseSemgrepOutput(makeResult("info"))[0].severity).toBe("info");
+      expect(parseSemgrepOutput(makeResult("low"))[0].severity).toBe("info");
+    });
+  });
+
+  describe("countFindingsBySeverity", () => {
+    it("counts findings correctly", () => {
+      const findings: SemgrepFinding[] = [
+        {
+          path: "a.ts",
+          line: 1,
+          message: "critical",
+          ruleId: "r1",
+          severity: "error",
+        },
+        {
+          path: "b.ts",
+          line: 2,
+          message: "critical2",
+          ruleId: "r2",
+          severity: "error",
+        },
+        {
+          path: "c.ts",
+          line: 3,
+          message: "warning",
+          ruleId: "r3",
+          severity: "warning",
+        },
+        {
+          path: "d.ts",
+          line: 4,
+          message: "info",
+          ruleId: "r4",
+          severity: "info",
+        },
+      ];
+
+      const counts = countFindingsBySeverity(findings);
+      expect(counts.critical).toBe(2);
+      expect(counts.warning).toBe(1);
+      expect(counts.info).toBe(1);
+    });
+
+    it("returns zeros for empty array", () => {
+      const counts = countFindingsBySeverity([]);
+      expect(counts.critical).toBe(0);
+      expect(counts.warning).toBe(0);
+      expect(counts.info).toBe(0);
+    });
+  });
+
+  describe("formatFindingsForDisplay", () => {
+    it("returns success message for no findings", () => {
+      const output = formatFindingsForDisplay([]);
+      expect(output).toBe("✅ No findings");
+    });
+
+    it("formats critical findings with correct heading", () => {
+      const findings: SemgrepFinding[] = [
+        {
+          path: "src/api.ts",
+          line: 42,
+          message: "SQL injection vulnerability",
+          ruleId: "security.sql-injection",
+          severity: "error",
+        },
+      ];
+
+      const output = formatFindingsForDisplay(findings);
+      expect(output).toContain("### ❌ Critical Issues");
+      expect(output).toContain("`src/api.ts:42`");
+      expect(output).toContain("SQL injection vulnerability");
+    });
+
+    it("formats warnings with correct heading", () => {
+      const findings: SemgrepFinding[] = [
+        {
+          path: "src/utils.ts",
+          line: 10,
+          message: "Potential memory leak",
+          ruleId: "performance.memory-leak",
+          severity: "warning",
+        },
+      ];
+
+      const output = formatFindingsForDisplay(findings);
+      expect(output).toContain("### ⚠️ Warnings");
+      expect(output).toContain("`src/utils.ts:10`");
+    });
+
+    it("groups findings by severity", () => {
+      const findings: SemgrepFinding[] = [
+        {
+          path: "a.ts",
+          line: 1,
+          message: "critical",
+          ruleId: "r1",
+          severity: "error",
+        },
+        {
+          path: "b.ts",
+          line: 2,
+          message: "warning",
+          ruleId: "r2",
+          severity: "warning",
+        },
+        {
+          path: "c.ts",
+          line: 3,
+          message: "info",
+          ruleId: "r3",
+          severity: "info",
+        },
+      ];
+
+      const output = formatFindingsForDisplay(findings);
+      const criticalIndex = output.indexOf("### ❌ Critical Issues");
+      const warningIndex = output.indexOf("### ⚠️ Warnings");
+      const infoIndex = output.indexOf("### ℹ️ Info");
+
+      expect(criticalIndex).toBeLessThan(warningIndex);
+      expect(warningIndex).toBeLessThan(infoIndex);
+    });
+  });
+
+  describe("getSemgrepVerdictContribution", () => {
+    it("returns blocking for critical findings", () => {
+      const result: SemgrepResult = {
+        success: true,
+        findings: [],
+        criticalCount: 2,
+        warningCount: 0,
+        infoCount: 0,
+      };
+
+      const verdict = getSemgrepVerdictContribution(result);
+      expect(verdict.blocking).toBe(true);
+      expect(verdict.reason).toContain("2 critical");
+    });
+
+    it("returns non-blocking for warnings only", () => {
+      const result: SemgrepResult = {
+        success: true,
+        findings: [],
+        criticalCount: 0,
+        warningCount: 3,
+        infoCount: 0,
+      };
+
+      const verdict = getSemgrepVerdictContribution(result);
+      expect(verdict.blocking).toBe(false);
+      expect(verdict.reason).toContain("3 warning(s)");
+    });
+
+    it("returns non-blocking when skipped", () => {
+      const result: SemgrepResult = {
+        success: true,
+        findings: [],
+        criticalCount: 0,
+        warningCount: 0,
+        infoCount: 0,
+        skipped: true,
+        skipReason: "Semgrep not installed",
+      };
+
+      const verdict = getSemgrepVerdictContribution(result);
+      expect(verdict.blocking).toBe(false);
+      expect(verdict.reason).toContain("skipped");
+    });
+
+    it("returns non-blocking on error", () => {
+      const result: SemgrepResult = {
+        success: false,
+        findings: [],
+        criticalCount: 0,
+        warningCount: 0,
+        infoCount: 0,
+        error: "Network error",
+      };
+
+      const verdict = getSemgrepVerdictContribution(result);
+      expect(verdict.blocking).toBe(false);
+      expect(verdict.reason).toContain("error");
+    });
+
+    it("returns clean result when no issues", () => {
+      const result: SemgrepResult = {
+        success: true,
+        findings: [],
+        criticalCount: 0,
+        warningCount: 0,
+        infoCount: 0,
+      };
+
+      const verdict = getSemgrepVerdictContribution(result);
+      expect(verdict.blocking).toBe(false);
+      expect(verdict.reason).toContain("No security issues");
+    });
+  });
+
+  describe("hasCustomRules", () => {
+    it("returns false for non-existent path", () => {
+      const result = hasCustomRules("/non/existent/path");
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/lib/semgrep.ts
+++ b/src/lib/semgrep.ts
@@ -1,0 +1,523 @@
+/**
+ * Semgrep integration for static analysis
+ *
+ * Provides stack-aware ruleset mapping and execution utilities
+ * for integrating Semgrep into the /qa workflow.
+ */
+
+import { spawn } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Semgrep finding severity levels
+ */
+export type SemgrepSeverity = "error" | "warning" | "info";
+
+/**
+ * A single Semgrep finding
+ */
+export interface SemgrepFinding {
+  path: string;
+  line: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+  message: string;
+  ruleId: string;
+  severity: SemgrepSeverity;
+  category?: string;
+}
+
+/**
+ * Result of a Semgrep scan
+ */
+export interface SemgrepResult {
+  success: boolean;
+  findings: SemgrepFinding[];
+  criticalCount: number;
+  warningCount: number;
+  infoCount: number;
+  error?: string;
+  skipped?: boolean;
+  skipReason?: string;
+}
+
+/**
+ * Semgrep ruleset configuration
+ */
+export interface SemgrepRuleset {
+  name: string;
+  description: string;
+  rules: string[]; // Semgrep rule identifiers (e.g., "p/typescript", "p/security-audit")
+}
+
+/**
+ * Stack-to-ruleset mapping
+ *
+ * Maps detected stacks to appropriate Semgrep rulesets.
+ * Uses Semgrep's public rule registry identifiers.
+ */
+export const STACK_RULESETS: Record<string, SemgrepRuleset> = {
+  nextjs: {
+    name: "Next.js",
+    description:
+      "TypeScript/JavaScript security and best practices for Next.js",
+    rules: [
+      "p/typescript",
+      "p/javascript",
+      "p/react",
+      "p/security-audit",
+      "p/secrets",
+    ],
+  },
+  astro: {
+    name: "Astro",
+    description: "TypeScript/JavaScript security for Astro projects",
+    rules: ["p/typescript", "p/javascript", "p/security-audit", "p/secrets"],
+  },
+  sveltekit: {
+    name: "SvelteKit",
+    description: "TypeScript/JavaScript security for SvelteKit",
+    rules: ["p/typescript", "p/javascript", "p/security-audit", "p/secrets"],
+  },
+  remix: {
+    name: "Remix",
+    description: "TypeScript/JavaScript security for Remix",
+    rules: [
+      "p/typescript",
+      "p/javascript",
+      "p/react",
+      "p/security-audit",
+      "p/secrets",
+    ],
+  },
+  nuxt: {
+    name: "Nuxt",
+    description: "TypeScript/JavaScript security for Nuxt/Vue",
+    rules: ["p/typescript", "p/javascript", "p/security-audit", "p/secrets"],
+  },
+  rust: {
+    name: "Rust",
+    description: "Rust security and best practices",
+    rules: ["p/rust", "p/security-audit", "p/secrets"],
+  },
+  python: {
+    name: "Python",
+    description: "Python security and best practices",
+    rules: ["p/python", "p/django", "p/flask", "p/security-audit", "p/secrets"],
+  },
+  go: {
+    name: "Go",
+    description: "Go security and best practices",
+    rules: ["p/golang", "p/security-audit", "p/secrets"],
+  },
+  generic: {
+    name: "Generic",
+    description: "General security rules for any codebase",
+    rules: ["p/security-audit", "p/secrets"],
+  },
+};
+
+/**
+ * Get the appropriate Semgrep ruleset for a detected stack
+ *
+ * @param stack - The detected stack name (e.g., "nextjs", "python")
+ * @returns The ruleset configuration for the stack
+ */
+export function getRulesForStack(stack: string | null): SemgrepRuleset {
+  if (!stack) {
+    return STACK_RULESETS.generic;
+  }
+  return STACK_RULESETS[stack] || STACK_RULESETS.generic;
+}
+
+/**
+ * Path to custom rules file
+ */
+export const CUSTOM_RULES_PATH = ".sequant/semgrep-rules.yaml";
+
+/**
+ * Check if custom rules file exists
+ *
+ * @param projectRoot - Root directory of the project
+ * @returns true if custom rules file exists
+ */
+export function hasCustomRules(projectRoot: string = process.cwd()): boolean {
+  return existsSync(join(projectRoot, CUSTOM_RULES_PATH));
+}
+
+/**
+ * Get path to custom rules file if it exists
+ *
+ * @param projectRoot - Root directory of the project
+ * @returns Path to custom rules file, or null if it doesn't exist
+ */
+export function getCustomRulesPath(
+  projectRoot: string = process.cwd(),
+): string | null {
+  const customPath = join(projectRoot, CUSTOM_RULES_PATH);
+  return existsSync(customPath) ? customPath : null;
+}
+
+/**
+ * Check if Semgrep is available
+ *
+ * Checks for both 'semgrep' command and 'npx semgrep' fallback
+ *
+ * @returns Object with availability info and command to use
+ */
+export async function checkSemgrepAvailability(): Promise<{
+  available: boolean;
+  command: string;
+  useNpx: boolean;
+}> {
+  // First try native semgrep
+  try {
+    await executeCommand("semgrep", ["--version"]);
+    return { available: true, command: "semgrep", useNpx: false };
+  } catch {
+    // Native semgrep not available, try npx
+  }
+
+  // Try npx semgrep
+  try {
+    await executeCommand("npx", ["semgrep", "--version"]);
+    return { available: true, command: "npx", useNpx: true };
+  } catch {
+    // npx semgrep also not available
+  }
+
+  return { available: false, command: "", useNpx: false };
+}
+
+/**
+ * Execute a command and return stdout
+ *
+ * @param command - Command to execute
+ * @param args - Command arguments
+ * @returns stdout from the command
+ */
+function executeCommand(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32",
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(stderr || `Command exited with code ${code}`));
+      }
+    });
+
+    proc.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Parse Semgrep JSON output into findings
+ *
+ * @param output - Raw JSON output from Semgrep
+ * @returns Array of parsed findings
+ */
+export function parseSemgrepOutput(output: string): SemgrepFinding[] {
+  try {
+    const data = JSON.parse(output);
+    const results = data.results || [];
+
+    return results.map(
+      (result: {
+        path: string;
+        start: { line: number; col?: number };
+        end?: { line: number; col?: number };
+        extra: {
+          message: string;
+          severity?: string;
+          metadata?: { category?: string };
+        };
+        check_id: string;
+      }) => ({
+        path: result.path,
+        line: result.start.line,
+        column: result.start.col,
+        endLine: result.end?.line,
+        endColumn: result.end?.col,
+        message: result.extra.message,
+        ruleId: result.check_id,
+        severity: mapSeverity(result.extra.severity || "warning"),
+        category: result.extra.metadata?.category,
+      }),
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Map Semgrep severity to our internal severity type
+ */
+function mapSeverity(severity: string): SemgrepSeverity {
+  const lower = severity.toLowerCase();
+  if (lower === "error" || lower === "critical" || lower === "high") {
+    return "error";
+  }
+  if (lower === "warning" || lower === "medium") {
+    return "warning";
+  }
+  return "info";
+}
+
+/**
+ * Count findings by severity
+ *
+ * @param findings - Array of Semgrep findings
+ * @returns Object with counts by severity
+ */
+export function countFindingsBySeverity(findings: SemgrepFinding[]): {
+  critical: number;
+  warning: number;
+  info: number;
+} {
+  return findings.reduce(
+    (acc, finding) => {
+      if (finding.severity === "error") {
+        acc.critical++;
+      } else if (finding.severity === "warning") {
+        acc.warning++;
+      } else {
+        acc.info++;
+      }
+      return acc;
+    },
+    { critical: 0, warning: 0, info: 0 },
+  );
+}
+
+/**
+ * Run Semgrep scan on specified files or directories
+ *
+ * @param options - Scan options
+ * @returns Scan result with findings
+ */
+export async function runSemgrepScan(options: {
+  targets: string[];
+  stack?: string | null;
+  projectRoot?: string;
+  useCustomRules?: boolean;
+}): Promise<SemgrepResult> {
+  const { targets, stack = null, projectRoot = process.cwd() } = options;
+  const useCustomRules = options.useCustomRules ?? true;
+
+  // Check availability
+  const availability = await checkSemgrepAvailability();
+  if (!availability.available) {
+    return {
+      success: true,
+      findings: [],
+      criticalCount: 0,
+      warningCount: 0,
+      infoCount: 0,
+      skipped: true,
+      skipReason: "Semgrep not installed (install with: pip install semgrep)",
+    };
+  }
+
+  // Build command arguments
+  const args: string[] = [];
+
+  // If using npx, prepend 'semgrep' to args
+  if (availability.useNpx) {
+    args.push("semgrep");
+  }
+
+  // Add output format
+  args.push("--json");
+
+  // Add rules from stack
+  const ruleset = getRulesForStack(stack);
+  for (const rule of ruleset.rules) {
+    args.push("--config", rule);
+  }
+
+  // Add custom rules if available
+  if (useCustomRules) {
+    const customRulesPath = getCustomRulesPath(projectRoot);
+    if (customRulesPath) {
+      args.push("--config", customRulesPath);
+    }
+  }
+
+  // Add targets
+  args.push(...targets);
+
+  try {
+    const output = await executeCommand(availability.command, args);
+    const findings = parseSemgrepOutput(output);
+    const counts = countFindingsBySeverity(findings);
+
+    return {
+      success: true,
+      findings,
+      criticalCount: counts.critical,
+      warningCount: counts.warning,
+      infoCount: counts.info,
+    };
+  } catch (error) {
+    // Semgrep returns non-zero exit code when findings are present
+    // Try to parse the output anyway
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Check if this is just findings being reported (exit code 1 with JSON output)
+    try {
+      const findings = parseSemgrepOutput(errorMessage);
+      if (findings.length > 0) {
+        const counts = countFindingsBySeverity(findings);
+        return {
+          success: true,
+          findings,
+          criticalCount: counts.critical,
+          warningCount: counts.warning,
+          infoCount: counts.info,
+        };
+      }
+    } catch {
+      // Not valid JSON output, real error
+    }
+
+    return {
+      success: false,
+      findings: [],
+      criticalCount: 0,
+      warningCount: 0,
+      infoCount: 0,
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * Format findings for display in QA output
+ *
+ * @param findings - Array of findings to format
+ * @returns Formatted markdown string
+ */
+export function formatFindingsForDisplay(findings: SemgrepFinding[]): string {
+  if (findings.length === 0) {
+    return "✅ No findings";
+  }
+
+  const lines: string[] = [];
+  const grouped = groupFindingsBySeverity(findings);
+
+  if (grouped.critical.length > 0) {
+    lines.push("### ❌ Critical Issues");
+    lines.push("");
+    for (const finding of grouped.critical) {
+      lines.push(formatSingleFinding(finding));
+    }
+    lines.push("");
+  }
+
+  if (grouped.warning.length > 0) {
+    lines.push("### ⚠️ Warnings");
+    lines.push("");
+    for (const finding of grouped.warning) {
+      lines.push(formatSingleFinding(finding));
+    }
+    lines.push("");
+  }
+
+  if (grouped.info.length > 0) {
+    lines.push("### ℹ️ Info");
+    lines.push("");
+    for (const finding of grouped.info) {
+      lines.push(formatSingleFinding(finding));
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Group findings by severity
+ */
+function groupFindingsBySeverity(findings: SemgrepFinding[]): {
+  critical: SemgrepFinding[];
+  warning: SemgrepFinding[];
+  info: SemgrepFinding[];
+} {
+  return {
+    critical: findings.filter((f) => f.severity === "error"),
+    warning: findings.filter((f) => f.severity === "warning"),
+    info: findings.filter((f) => f.severity === "info"),
+  };
+}
+
+/**
+ * Format a single finding for display
+ */
+function formatSingleFinding(finding: SemgrepFinding): string {
+  const location = `${finding.path}:${finding.line}`;
+  return `- \`${location}\` - ${finding.message} (${finding.ruleId})`;
+}
+
+/**
+ * Generate QA verdict contribution from Semgrep results
+ *
+ * @param result - Semgrep scan result
+ * @returns Verdict contribution (blocking if critical findings)
+ */
+export function getSemgrepVerdictContribution(result: SemgrepResult): {
+  blocking: boolean;
+  reason: string;
+} {
+  if (result.skipped) {
+    return {
+      blocking: false,
+      reason: `Semgrep skipped: ${result.skipReason}`,
+    };
+  }
+
+  if (!result.success) {
+    return {
+      blocking: false,
+      reason: `Semgrep error: ${result.error}`,
+    };
+  }
+
+  if (result.criticalCount > 0) {
+    return {
+      blocking: true,
+      reason: `${result.criticalCount} critical security finding(s) detected`,
+    };
+  }
+
+  if (result.warningCount > 0) {
+    return {
+      blocking: false,
+      reason: `${result.warningCount} warning(s) detected (review recommended)`,
+    };
+  }
+
+  return {
+    blocking: false,
+    reason: "No security issues detected",
+  };
+}

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -16,6 +16,9 @@ allowed-tools:
   - Bash(gh pr view:*)
   - Bash(gh pr diff:*)
   - Bash(gh pr comment:*)
+  - Bash(semgrep:*)
+  - Bash(npx semgrep:*)
+  - Bash(npx tsx scripts/semgrep-scan.ts:*)
   - Task
   - AgentOutputTool
 ---

--- a/templates/skills/qa/references/semgrep-rules.md
+++ b/templates/skills/qa/references/semgrep-rules.md
@@ -1,0 +1,207 @@
+# Semgrep Integration Guide
+
+This guide explains how to configure and use Semgrep static analysis in the `/qa` workflow.
+
+## Overview
+
+Semgrep is a fast, open-source static analysis tool that finds bugs and enforces code standards. The `/qa` skill integrates Semgrep to automatically scan code changes for security vulnerabilities and anti-patterns.
+
+## Installation
+
+Semgrep is **optional**. If not installed, the `/qa` skill will gracefully skip Semgrep analysis.
+
+### Install Semgrep
+
+```bash
+# Using pip (recommended)
+pip install semgrep
+
+# Using Homebrew (macOS)
+brew install semgrep
+
+# Using npm (via npx - no install required)
+npx semgrep --version
+```
+
+### Verify Installation
+
+```bash
+semgrep --version
+# Or
+npx semgrep --version
+```
+
+## How It Works
+
+1. During `/qa`, the quality checks script detects if Semgrep is installed
+2. If installed, it runs Semgrep with stack-appropriate rulesets
+3. Findings are categorized by severity (critical, warning, info)
+4. Critical findings block the merge verdict (`AC_NOT_MET`)
+5. Warnings are noted but don't block merges
+
+## Default Rulesets
+
+Semgrep uses stack-specific rulesets for targeted analysis:
+
+| Stack | Rulesets Applied |
+|-------|------------------|
+| **Next.js** | p/typescript, p/javascript, p/react, p/security-audit, p/secrets |
+| **Astro** | p/typescript, p/javascript, p/security-audit, p/secrets |
+| **SvelteKit** | p/typescript, p/javascript, p/security-audit, p/secrets |
+| **Remix** | p/typescript, p/javascript, p/react, p/security-audit, p/secrets |
+| **Nuxt** | p/typescript, p/javascript, p/security-audit, p/secrets |
+| **Python** | p/python, p/django, p/flask, p/security-audit, p/secrets |
+| **Go** | p/golang, p/security-audit, p/secrets |
+| **Rust** | p/rust, p/security-audit, p/secrets |
+| **Generic** | p/security-audit, p/secrets |
+
+## Custom Rules
+
+You can add project-specific rules by creating `.sequant/semgrep-rules.yaml` in your project root.
+
+### Getting Started
+
+Copy the example template to your project:
+
+```bash
+# Copy the example template
+cp docs/examples/semgrep-rules.example.yaml .sequant/semgrep-rules.yaml
+```
+
+### Custom Rules File Location
+
+```
+your-project/
+├── .sequant/
+│   └── semgrep-rules.yaml    # Your custom rules
+├── src/
+└── package.json
+```
+
+### Example Custom Rules
+
+```yaml
+rules:
+  # Prevent console.log in production code
+  - id: no-console-log
+    pattern: console.log(...)
+    message: "Remove console.log before merging"
+    severity: WARNING
+    languages: [typescript, javascript]
+    paths:
+      exclude:
+        - "**/*.test.*"
+        - "**/__tests__/**"
+
+  # Require explicit return types on exported functions
+  - id: explicit-return-type
+    pattern: |
+      export function $FUNC(...): $RET { ... }
+    pattern-not: |
+      export function $FUNC(...): void { ... }
+    message: "Exported functions should have explicit return types"
+    severity: INFO
+    languages: [typescript]
+
+  # Detect potential SQL injection
+  - id: sql-injection-risk
+    patterns:
+      - pattern: $DB.query($SQL + ...)
+      - pattern: $DB.query(`...${...}...`)
+    message: "Potential SQL injection - use parameterized queries"
+    severity: ERROR
+    languages: [typescript, javascript]
+
+  # Prevent hardcoded API keys
+  - id: no-hardcoded-api-key
+    pattern-regex: "(api[_-]?key|apikey|secret[_-]?key)\\s*[:=]\\s*['\"][^'\"]{8,}['\"]"
+    message: "Don't hardcode API keys - use environment variables"
+    severity: ERROR
+    languages: [typescript, javascript, python]
+```
+
+### Rule Severity Levels
+
+| Severity | Verdict Impact | Description |
+|----------|----------------|-------------|
+| `ERROR` | **Blocking** | Critical issues that must be fixed |
+| `WARNING` | Non-blocking | Issues that should be reviewed |
+| `INFO` | Non-blocking | Style suggestions |
+
+## Running Semgrep Manually
+
+You can run Semgrep manually using the provided script:
+
+```bash
+# Scan entire project with auto-detected stack
+npx tsx scripts/semgrep-scan.ts
+
+# Scan only changed files (faster, recommended)
+npx tsx scripts/semgrep-scan.ts --changed-only
+
+# Scan specific directories
+npx tsx scripts/semgrep-scan.ts src/api/ src/lib/
+
+# Override detected stack
+npx tsx scripts/semgrep-scan.ts --stack python
+
+# Get JSON output
+npx tsx scripts/semgrep-scan.ts --json > semgrep-results.json
+```
+
+## Interpreting Results
+
+### Clean Output
+
+```
+## Static Analysis (Semgrep)
+
+✅ No security issues found
+```
+
+### Issues Found
+
+```
+## Static Analysis (Semgrep)
+
+❌ 1 critical finding(s)
+⚠️  2 warning(s)
+
+### ❌ Critical Issues
+
+- `src/api/users.ts:47` - Potential SQL injection (user input in query) (security.sql-injection)
+
+### ⚠️ Warnings
+
+- `src/utils/exec.ts:12` - Command injection risk (unsanitized shell arg) (security.command-injection)
+- `src/lib/logger.ts:8` - Remove console.log before merging (custom.no-console-log)
+```
+
+## Troubleshooting
+
+### Semgrep Not Running
+
+1. Check if Semgrep is installed: `semgrep --version`
+2. If not installed, install it or use `npx semgrep`
+3. Check for error messages in the quality checks output
+
+### False Positives
+
+If a rule produces false positives:
+
+1. Add a `# nosemgrep: rule-id` comment to ignore specific lines
+2. Create custom rules that exclude specific patterns
+3. Use path exclusions in your custom rules
+
+### Performance
+
+- Semgrep only scans changed files by default (via `--changed-only`)
+- Large codebases may take longer on first scan
+- Results are not cached between runs
+
+## Resources
+
+- [Semgrep Documentation](https://semgrep.dev/docs/)
+- [Semgrep Rule Registry](https://semgrep.dev/r)
+- [Writing Custom Rules](https://semgrep.dev/docs/writing-rules/overview/)
+- [Rule Syntax Reference](https://semgrep.dev/docs/writing-rules/rule-syntax/)


### PR DESCRIPTION
## Summary

- Add Semgrep static analysis integration to `/qa` skill with stack-aware rulesets
- Graceful degradation - skips if Semgrep not installed
- Critical findings block merge (`AC_NOT_MET`), warnings are noted but non-blocking
- Support custom rules from `.sequant/semgrep-rules.yaml`

## Changes

- **Core library** (`src/lib/semgrep.ts`): Stack-to-ruleset mapping, Semgrep execution, finding parsing
- **Runner script** (`scripts/semgrep-scan.ts`): CLI for manual Semgrep scans
- **Quality checks**: Updated `quality-checks.sh` with Semgrep step
- **Verdict mapping**: Updated `quality-gates.md` with Semgrep integration
- **Documentation**: New `references/semgrep-rules.md` guide
- **Template**: Example rules in `docs/examples/semgrep-rules.example.yaml`

## Test plan

- [x] Semgrep tests pass (`npm test -- src/lib/semgrep.test.ts`)
- [x] Build passes (`npm run build`)
- [x] Runner script works (`npx tsx scripts/semgrep-scan.ts --help`)
- [ ] Manual test: Run `/qa` with Semgrep installed - verify output
- [ ] Manual test: Run `/qa` without Semgrep - verify graceful skip

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)