### PR TITLE
feat(#198): Improve hook error message for merge commits

### DIFF
--- a/hooks/pre-tool.sh
+++ b/hooks/pre-tool.sh
@@ -310,6 +310,12 @@ if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; t
             {
                 echo "HOOK_BLOCKED: Commit must follow conventional commits format"
                 echo "  Expected: type(scope): description"
+                # AC-1 & AC-2 (Issue #198): Detect merge commits and provide helpful suggestion
+                if [[ "$MSG" == Merge\ * ]]; then
+                    echo ""
+                    echo "  💡 For merge commits, use: chore: merge main into feature branch"
+                    echo ""
+                fi
                 echo "  Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf"
                 echo "  Got: $MSG"
             } | tee -a /tmp/claude-hook.log >&2

--- a/templates/hooks/pre-tool.sh
+++ b/templates/hooks/pre-tool.sh
@@ -309,6 +309,12 @@ if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; t
             {
                 echo "HOOK_BLOCKED: Commit must follow conventional commits format"
                 echo "  Expected: type(scope): description"
+                # AC-1 & AC-2 (Issue #198): Detect merge commits and provide helpful suggestion
+                if [[ "$MSG" == Merge\ * ]]; then
+                    echo ""
+                    echo "  💡 For merge commits, use: chore: merge main into feature branch"
+                    echo ""
+                fi
                 echo "  Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf"
                 echo "  Got: $MSG"
             } | tee -a /tmp/claude-hook.log >&2


### PR DESCRIPTION
## Summary

- Detects when commit message starts with "Merge " (indicating a merge conflict resolution)
- Provides helpful suggestion to use `chore: merge main into feature branch` format
- Existing conventional commit validation unchanged

**New error output for merge commits:**
```
HOOK_BLOCKED: Commit must follow conventional commits format
  Expected: type(scope): description

  💡 For merge commits, use: chore: merge main into feature branch

  Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf
  Got: Merge origin/main into feature/...
```

## Test plan

- [x] Merge commit messages show helpful suggestion
- [x] Valid conventional commits still pass
- [x] Invalid non-merge commits blocked without merge suggestion
- [x] `chore: merge...` format passes validation
- [x] Build passes (`npm run build`)

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)