### PR TITLE
feat(#178): Add CI status awareness to QA verdict logic

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -288,11 +288,22 @@ Identify AC items that depend on CI by matching these patterns:
 - "Build succeeds in CI"
 - "GitHub Actions pass"
 - "Pipeline passes"
+- "Workflow passes"
+- "Checks pass"
+- "Actions succeed"
+- "CI/CD passes"
 
 ```bash
 # Example: Check if any AC mentions CI
-ci_ac_patterns="CI|pipeline|GitHub Actions|build succeeds|tests pass in CI"
+ci_ac_patterns="CI|pipeline|GitHub Actions|build succeeds|tests pass in CI|workflow|checks pass|actions succeed"
 ```
+
+**Error Handling:**
+
+If `gh pr checks` fails or returns unexpected results:
+- **Network/auth error** → Treat as N/A with note: "CI status unavailable (gh command failed)"
+- **No PR exists** → Skip CI status section entirely
+- **Empty response** → No CI configured (not an error)
 
 **Output Format:**
 

--- a/.claude/skills/qa/references/quality-gates.md
+++ b/.claude/skills/qa/references/quality-gates.md
@@ -167,6 +167,17 @@ Identify AC items that depend on CI by matching patterns:
 - "Build succeeds in CI"
 - "GitHub Actions pass"
 - "Pipeline passes"
+- "Workflow passes"
+- "Checks pass"
+- "Actions succeed"
+- "CI/CD passes"
+
+### Error Handling
+
+If `gh pr checks` fails:
+- **Network/auth error** → Treat as N/A with note: "CI status unavailable"
+- **No PR exists** → Skip CI check entirely
+- **Empty response** → No CI configured (not an error)
 
 ### CI Verdict Rules
 


### PR DESCRIPTION
## Summary

- Add CI status checking to QA skill via `gh pr checks` command
- Map CI states (success, failure, pending) to AC statuses (MET, NOT_MET, PENDING)
- Integrate CI status into AC coverage table and verdict determination
- When CI is pending, verdict becomes `NEEDS_VERIFICATION` instead of `READY_FOR_MERGE`
- When no CI is configured, CI-related AC items are marked `N/A`

## Test plan

- [ ] Run `/qa` on an issue with a PR where CI is still running - verify verdict is `NEEDS_VERIFICATION`
- [ ] Run `/qa` on an issue with a PR where CI has passed - verify CI-related AC marked `MET`
- [ ] Run `/qa` on an issue with a PR where CI failed - verify CI-related AC marked `NOT_MET`
- [ ] Run `/qa` on an issue without a PR - verify output shows "No PR exists yet"
- [ ] Run `/qa` on a repo without CI configured - verify CI-related AC marked `N/A`

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)