### PR TITLE
feat(#244): Add animated spinners with elapsed time to sequant run

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -39,6 +39,7 @@ import {
   determineOutcome,
 } from "../lib/workflow/metrics-schema.js";
 import { ui, colors } from "../lib/cli-ui.js";
+import { PhaseSpinner } from "../lib/phase-spinner.js";
 
 /**
  * Worktree information for an issue
@@ -896,6 +897,7 @@ async function executePhase(
   sessionId?: string,
   worktreePath?: string,
   shutdownManager?: ShutdownManager,
+  spinner?: PhaseSpinner,
 ): Promise<PhaseResult & { sessionId?: string }> {
   const startTime = Date.now();
 
@@ -1020,7 +1022,10 @@ async function executePhase(
           capturedOutput += textContent;
           // Show streaming output in verbose mode
           if (config.verbose) {
+            // Pause spinner during verbose streaming to avoid terminal corruption
+            spinner?.pause();
             process.stdout.write(chalk.gray(textContent));
+            spinner?.resume();
           }
         }
       }
@@ -2172,7 +2177,15 @@ async function runIssueWithLogging(
     } else {
       // Run spec first to get recommended workflow
       console.log(chalk.gray(`    Running spec to determine workflow...`));
-      console.log(chalk.gray(`    ⏳ spec...`));
+
+      // Create spinner for spec phase (1 of estimated 3: spec, exec, qa)
+      const specSpinner = new PhaseSpinner({
+        phase: "spec",
+        phaseIndex: 1,
+        totalPhases: 3, // Estimate; will be refined after spec
+        shutdownManager,
+      });
+      specSpinner.start();
 
       // Track spec phase start in state
       if (stateManager) {
@@ -2196,6 +2209,7 @@ async function runIssueWithLogging(
         sessionId,
         worktreePath, // Will be ignored for spec (non-isolated phase)
         shutdownManager,
+        specSpinner,
       );
       const specEndTime = new Date();
 
@@ -2252,7 +2266,7 @@ async function runIssueWithLogging(
       }
 
       if (!specResult.success) {
-        console.log(chalk.red(`    ✗ spec: ${specResult.error}`));
+        specSpinner.fail(specResult.error);
         const durationSeconds = (Date.now() - startTime) / 1000;
         return {
           issueNumber,
@@ -2263,10 +2277,7 @@ async function runIssueWithLogging(
         };
       }
 
-      const duration = specResult.durationSeconds
-        ? ` (${formatDuration(specResult.durationSeconds)})`
-        : "";
-      console.log(chalk.green(`    ✓ spec${duration}`));
+      specSpinner.succeed();
 
       // Parse recommended workflow from spec output
       const parsedWorkflow = specResult.output
@@ -2339,8 +2350,24 @@ async function runIssueWithLogging(
 
     let phasesFailed = false;
 
-    for (const phase of phases) {
-      console.log(chalk.gray(`    ⏳ ${phase}...`));
+    // Calculate total phases for progress indicator
+    // If spec already ran in auto-detect mode, it's counted separately
+    const totalPhases = specAlreadyRan ? phases.length + 1 : phases.length;
+    const phaseIndexOffset = specAlreadyRan ? 1 : 0;
+
+    for (let phaseIdx = 0; phaseIdx < phases.length; phaseIdx++) {
+      const phase = phases[phaseIdx];
+      const phaseNumber = phaseIdx + 1 + phaseIndexOffset;
+
+      // Create spinner for this phase
+      const phaseSpinner = new PhaseSpinner({
+        phase,
+        phaseIndex: phaseNumber,
+        totalPhases,
+        shutdownManager,
+        iteration: useQualityLoop ? iteration : undefined,
+      });
+      phaseSpinner.start();
 
       // Track phase start in state
       if (stateManager) {
@@ -2363,6 +2390,7 @@ async function runIssueWithLogging(
         sessionId,
         worktreePath,
         shutdownManager,
+        phaseSpinner,
       );
       const phaseEndTime = new Date();
 
@@ -2422,17 +2450,22 @@ async function runIssueWithLogging(
       }
 
       if (result.success) {
-        const duration = result.durationSeconds
-          ? ` (${formatDuration(result.durationSeconds)})`
-          : "";
-        console.log(chalk.green(`    ✓ ${phase}${duration}`));
+        phaseSpinner.succeed();
       } else {
-        console.log(chalk.red(`    ✗ ${phase}: ${result.error}`));
+        phaseSpinner.fail(result.error);
         phasesFailed = true;
 
         // If quality loop enabled, run loop phase to fix issues
         if (useQualityLoop && iteration < maxIterations) {
-          console.log(chalk.yellow(`    Running /loop to fix issues...`));
+          // Create spinner for loop phase
+          const loopSpinner = new PhaseSpinner({
+            phase: "loop",
+            phaseIndex: phaseNumber,
+            totalPhases,
+            shutdownManager,
+            iteration,
+          });
+          loopSpinner.start();
 
           const loopResult = await executePhase(
             issueNumber,
@@ -2441,6 +2474,7 @@ async function runIssueWithLogging(
             sessionId,
             worktreePath,
             shutdownManager,
+            loopSpinner,
           );
           phaseResults.push(loopResult);
 
@@ -2449,11 +2483,11 @@ async function runIssueWithLogging(
           }
 
           if (loopResult.success) {
-            console.log(chalk.green(`    ✓ loop - retrying phases`));
+            loopSpinner.succeed();
             // Continue to next iteration
             break;
           } else {
-            console.log(chalk.red(`    ✗ loop: ${loopResult.error}`));
+            loopSpinner.fail(loopResult.error);
           }
         }
 

--- a/src/lib/phase-spinner.test.ts
+++ b/src/lib/phase-spinner.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  PhaseSpinner,
+  phaseSpinner,
+  formatElapsedTime,
+  type PhaseSpinnerOptions,
+} from "./phase-spinner.js";
+import type { ShutdownManager } from "./shutdown.js";
+
+// Mock the cli-ui module
+vi.mock("./cli-ui.js", () => {
+  const createMockSpinner = () => ({
+    text: "",
+    isSpinning: false,
+    start: vi.fn(function (
+      this: { text: string; isSpinning: boolean },
+      text?: string,
+    ) {
+      if (text) this.text = text;
+      this.isSpinning = true;
+      return this;
+    }),
+    succeed: vi.fn(function (
+      this: { text: string; isSpinning: boolean },
+      text?: string,
+    ) {
+      if (text) this.text = text;
+      this.isSpinning = false;
+      return this;
+    }),
+    fail: vi.fn(function (
+      this: { text: string; isSpinning: boolean },
+      text?: string,
+    ) {
+      if (text) this.text = text;
+      this.isSpinning = false;
+      return this;
+    }),
+    warn: vi.fn(function (
+      this: { text: string; isSpinning: boolean },
+      text?: string,
+    ) {
+      if (text) this.text = text;
+      this.isSpinning = false;
+      return this;
+    }),
+    stop: vi.fn(function (this: { isSpinning: boolean }) {
+      this.isSpinning = false;
+      return this;
+    }),
+  });
+
+  return {
+    spinner: vi.fn(() => createMockSpinner()),
+  };
+});
+
+// Get the mocked spinner function for assertions
+import { spinner as mockSpinnerFactory } from "./cli-ui.js";
+
+describe("formatElapsedTime", () => {
+  it("should format seconds under 60 as Ns", () => {
+    expect(formatElapsedTime(0)).toBe("0s");
+    expect(formatElapsedTime(1)).toBe("1s");
+    expect(formatElapsedTime(45)).toBe("45s");
+    expect(formatElapsedTime(59)).toBe("59s");
+  });
+
+  it("should format seconds 60-3599 as Nm Ns", () => {
+    expect(formatElapsedTime(60)).toBe("1m");
+    expect(formatElapsedTime(61)).toBe("1m 1s");
+    expect(formatElapsedTime(135)).toBe("2m 15s");
+    expect(formatElapsedTime(3599)).toBe("59m 59s");
+  });
+
+  it("should format seconds 3600+ as Nh Nm", () => {
+    expect(formatElapsedTime(3600)).toBe("1h");
+    expect(formatElapsedTime(3660)).toBe("1h 1m");
+    expect(formatElapsedTime(3900)).toBe("1h 5m");
+    expect(formatElapsedTime(7200)).toBe("2h");
+  });
+
+  it("should handle fractional seconds", () => {
+    expect(formatElapsedTime(45.7)).toBe("45s");
+    expect(formatElapsedTime(135.9)).toBe("2m 15s");
+  });
+});
+
+describe("PhaseSpinner", () => {
+  let mockShutdownManager: {
+    registerCleanup: ReturnType<typeof vi.fn>;
+    unregisterCleanup: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    mockShutdownManager = {
+      registerCleanup: vi.fn(),
+      unregisterCleanup: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const defaultOptions: PhaseSpinnerOptions = {
+    phase: "exec",
+    phaseIndex: 2,
+    totalPhases: 3,
+  };
+
+  describe("constructor", () => {
+    it("should create spinner with correct initial text", () => {
+      new PhaseSpinner(defaultOptions);
+
+      expect(mockSpinnerFactory).toHaveBeenCalledWith("    exec (2/3)...");
+    });
+
+    it("should use custom prefix", () => {
+      new PhaseSpinner({ ...defaultOptions, prefix: "  " });
+
+      expect(mockSpinnerFactory).toHaveBeenCalledWith("  exec (2/3)...");
+    });
+
+    it("should include iteration suffix when iteration > 1", () => {
+      new PhaseSpinner({ ...defaultOptions, iteration: 2 });
+
+      expect(mockSpinnerFactory).toHaveBeenCalledWith(
+        "    exec (2/3)... [iteration 2]",
+      );
+    });
+
+    it("should not include iteration suffix when iteration is 1", () => {
+      new PhaseSpinner({ ...defaultOptions, iteration: 1 });
+
+      expect(mockSpinnerFactory).toHaveBeenCalledWith("    exec (2/3)...");
+    });
+  });
+
+  describe("start", () => {
+    it("should start the underlying spinner", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      // Get the mock spinner instance
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.start).toHaveBeenCalled();
+    });
+
+    it("should register cleanup with ShutdownManager", () => {
+      const spinner = new PhaseSpinner({
+        ...defaultOptions,
+        shutdownManager: mockShutdownManager as unknown as ShutdownManager,
+      });
+
+      spinner.start();
+
+      expect(mockShutdownManager.registerCleanup).toHaveBeenCalledWith(
+        "phase-spinner-exec",
+        expect.any(Function),
+      );
+    });
+
+    it("should start elapsed time interval", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      // Get the mock spinner instance
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+
+      // Fast forward 5 seconds
+      vi.advanceTimersByTime(5000);
+
+      // The spinner text should be updated with elapsed time
+      expect(mockSpinner.text).toContain("5s");
+    });
+
+    it("should return this for chaining", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      const result = spinner.start();
+
+      expect(result).toBe(spinner);
+    });
+  });
+
+  describe("succeed", () => {
+    it("should call spinner.succeed with duration", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      // Fast forward 45 seconds
+      vi.advanceTimersByTime(45000);
+
+      spinner.succeed();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.succeed).toHaveBeenCalledWith("    exec (2/3) (45s)");
+    });
+
+    it("should accept custom text", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.succeed("Custom success message");
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        "Custom success message",
+      );
+    });
+
+    it("should clear the interval", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.succeed();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+
+      // Fast forward more time - should not update anymore
+      vi.advanceTimersByTime(10000);
+
+      // Only 2 calls: start and succeed
+      expect(mockSpinner.start).toHaveBeenCalledTimes(1);
+      expect(mockSpinner.succeed).toHaveBeenCalledTimes(1);
+    });
+
+    it("should unregister from ShutdownManager", () => {
+      const spinner = new PhaseSpinner({
+        ...defaultOptions,
+        shutdownManager: mockShutdownManager as unknown as ShutdownManager,
+      });
+
+      spinner.start();
+      spinner.succeed();
+
+      expect(mockShutdownManager.unregisterCleanup).toHaveBeenCalledWith(
+        "phase-spinner-exec",
+      );
+    });
+  });
+
+  describe("fail", () => {
+    it("should call spinner.fail with duration", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      vi.advanceTimersByTime(30000);
+
+      spinner.fail();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.fail).toHaveBeenCalledWith("    exec (2/3) (30s)");
+    });
+
+    it("should include error message if provided", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.fail("Timeout exceeded");
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.fail).toHaveBeenCalledWith(
+        expect.stringContaining("Timeout exceeded"),
+      );
+    });
+
+    it("should clear interval and unregister cleanup", () => {
+      const spinner = new PhaseSpinner({
+        ...defaultOptions,
+        shutdownManager: mockShutdownManager as unknown as ShutdownManager,
+      });
+
+      spinner.start();
+      spinner.fail();
+
+      expect(mockShutdownManager.unregisterCleanup).toHaveBeenCalled();
+    });
+  });
+
+  describe("stop", () => {
+    it("should stop the spinner", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.stop();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.stop).toHaveBeenCalled();
+    });
+
+    it("should clear interval and unregister cleanup", () => {
+      const spinner = new PhaseSpinner({
+        ...defaultOptions,
+        shutdownManager: mockShutdownManager as unknown as ShutdownManager,
+      });
+
+      spinner.start();
+      spinner.stop();
+
+      expect(mockShutdownManager.unregisterCleanup).toHaveBeenCalled();
+    });
+  });
+
+  describe("pause and resume", () => {
+    it("should stop spinner on pause", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.pause();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.stop).toHaveBeenCalled();
+    });
+
+    it("should restart spinner on resume with updated elapsed time", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      vi.advanceTimersByTime(10000);
+
+      spinner.pause();
+      spinner.resume();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      // Should have called start again with elapsed time
+      expect(mockSpinner.start).toHaveBeenCalledTimes(2);
+      expect(mockSpinner.start).toHaveBeenLastCalledWith(
+        expect.stringContaining("10s"),
+      );
+    });
+
+    it("should not update elapsed time while paused", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      vi.advanceTimersByTime(5000);
+      spinner.pause();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      const textBeforePause = mockSpinner.text;
+
+      // Advance time while paused
+      vi.advanceTimersByTime(10000);
+
+      // Text should not have been updated
+      expect(mockSpinner.text).toBe(textBeforePause);
+    });
+
+    it("should handle multiple pause/resume cycles", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.pause();
+      spinner.resume();
+      spinner.pause();
+      spinner.resume();
+      spinner.succeed();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.start).toHaveBeenCalledTimes(3); // initial + 2 resumes
+      expect(mockSpinner.stop).toHaveBeenCalledTimes(2); // 2 pauses
+      expect(mockSpinner.succeed).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("isSpinning", () => {
+    it("should return true when started", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      expect(spinner.isSpinning).toBe(true);
+    });
+
+    it("should return false after succeed", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.succeed();
+
+      expect(spinner.isSpinning).toBe(false);
+    });
+
+    it("should return false when paused", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.pause();
+
+      expect(spinner.isSpinning).toBe(false);
+    });
+  });
+
+  describe("elapsedSeconds", () => {
+    it("should return 0 before start", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+
+      expect(spinner.elapsedSeconds).toBe(0);
+    });
+
+    it("should return elapsed time after start", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+
+      vi.advanceTimersByTime(30000);
+
+      expect(spinner.elapsedSeconds).toBe(30);
+    });
+  });
+
+  describe("dispose", () => {
+    it("should clean up resources", () => {
+      const spinner = new PhaseSpinner({
+        ...defaultOptions,
+        shutdownManager: mockShutdownManager as unknown as ShutdownManager,
+      });
+
+      spinner.start();
+      spinner.dispose();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.stop).toHaveBeenCalled();
+      expect(mockShutdownManager.unregisterCleanup).toHaveBeenCalled();
+    });
+
+    it("should be safe to call multiple times", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.dispose();
+      spinner.dispose();
+      spinner.dispose();
+
+      // Should not throw
+      expect(true).toBe(true);
+    });
+
+    it("should prevent further operations", () => {
+      const spinner = new PhaseSpinner(defaultOptions);
+      spinner.start();
+      spinner.dispose();
+
+      // These should be no-ops after dispose
+      spinner.start();
+      spinner.succeed();
+      spinner.fail();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      // Only the initial start and dispose stop should have been called
+      expect(mockSpinner.start).toHaveBeenCalledTimes(1);
+      expect(mockSpinner.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("ShutdownManager cleanup task", () => {
+    it("should stop spinner when cleanup is triggered", async () => {
+      let cleanupFn: (() => Promise<void>) | undefined;
+
+      mockShutdownManager.registerCleanup.mockImplementation(
+        (_name: string, fn: () => Promise<void>) => {
+          cleanupFn = fn;
+        },
+      );
+
+      const spinner = new PhaseSpinner({
+        ...defaultOptions,
+        shutdownManager: mockShutdownManager as unknown as ShutdownManager,
+      });
+
+      spinner.start();
+
+      // Simulate shutdown by calling the cleanup function
+      expect(cleanupFn).toBeDefined();
+      await cleanupFn!();
+
+      const mockSpinner = (mockSpinnerFactory as ReturnType<typeof vi.fn>).mock
+        .results[0].value;
+      expect(mockSpinner.stop).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("phaseSpinner factory function", () => {
+  it("should create a PhaseSpinner instance", () => {
+    const spinner = phaseSpinner({
+      phase: "qa",
+      phaseIndex: 3,
+      totalPhases: 3,
+    });
+
+    expect(spinner).toBeInstanceOf(PhaseSpinner);
+  });
+});

--- a/src/lib/phase-spinner.ts
+++ b/src/lib/phase-spinner.ts
@@ -1,0 +1,310 @@
+/**
+ * Phase Spinner - Animated spinner with elapsed time for phase execution
+ *
+ * Wraps the cli-ui spinner with:
+ * - Elapsed time tracking (updates every 5 seconds)
+ * - Phase progress indicator (e.g., "spec (1/3)")
+ * - Integration with ShutdownManager for graceful cleanup
+ *
+ * @example
+ * ```typescript
+ * const spinner = new PhaseSpinner({
+ *   phase: 'exec',
+ *   phaseIndex: 2,
+ *   totalPhases: 3,
+ *   shutdownManager,
+ * });
+ *
+ * spinner.start();
+ * // ... phase execution
+ * spinner.succeed(); // Shows "✓ exec (2/3) (45s)"
+ * ```
+ */
+
+import { spinner as createSpinner, type SpinnerManager } from "./cli-ui.js";
+import type { ShutdownManager } from "./shutdown.js";
+
+/**
+ * Elapsed time update interval in milliseconds
+ */
+const ELAPSED_UPDATE_INTERVAL_MS = 5000;
+
+/**
+ * Options for creating a PhaseSpinner
+ */
+export interface PhaseSpinnerOptions {
+  /** Phase name (e.g., "spec", "exec", "qa") */
+  phase: string;
+  /** Current phase index (1-based) */
+  phaseIndex: number;
+  /** Total number of phases */
+  totalPhases: number;
+  /** Optional ShutdownManager for graceful cleanup */
+  shutdownManager?: ShutdownManager;
+  /** Optional prefix for indentation (default: "    ") */
+  prefix?: string;
+  /** Optional quality loop iteration (shows "iteration N" if > 1) */
+  iteration?: number;
+}
+
+/**
+ * Format elapsed time in human-readable format
+ *
+ * @param seconds - Elapsed time in seconds
+ * @returns Formatted string (e.g., "45s", "2m 15s", "1h 5m")
+ */
+export function formatElapsedTime(seconds: number): string {
+  if (seconds < 60) {
+    return `${Math.floor(seconds)}s`;
+  }
+  if (seconds < 3600) {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = Math.floor(seconds % 60);
+    return remainingSeconds > 0
+      ? `${minutes}m ${remainingSeconds}s`
+      : `${minutes}m`;
+  }
+  const hours = Math.floor(seconds / 3600);
+  const remainingMinutes = Math.floor((seconds % 3600) / 60);
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+/**
+ * PhaseSpinner - Animated spinner with elapsed time and phase progress
+ *
+ * Features:
+ * - Animated spinner (or text fallback) via cli-ui
+ * - Elapsed time tracking with automatic updates
+ * - Phase progress indicator (e.g., "exec (2/3)")
+ * - ShutdownManager integration for graceful Ctrl+C cleanup
+ * - Pause/resume for verbose streaming output
+ */
+export class PhaseSpinner {
+  private spinner: SpinnerManager;
+  private startTime: number = 0;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private disposed = false;
+  private paused = false;
+
+  private readonly phase: string;
+  private readonly phaseIndex: number;
+  private readonly totalPhases: number;
+  private readonly shutdownManager?: ShutdownManager;
+  private readonly prefix: string;
+  private readonly iteration?: number;
+  private readonly cleanupName: string;
+
+  constructor(options: PhaseSpinnerOptions) {
+    this.phase = options.phase;
+    this.phaseIndex = options.phaseIndex;
+    this.totalPhases = options.totalPhases;
+    this.shutdownManager = options.shutdownManager;
+    this.prefix = options.prefix ?? "    ";
+    this.iteration = options.iteration;
+    this.cleanupName = `phase-spinner-${options.phase}`;
+
+    // Create the underlying spinner with initial text
+    this.spinner = createSpinner(this.formatText(0));
+  }
+
+  /**
+   * Format the spinner text with phase, progress, and elapsed time
+   */
+  private formatText(elapsedSeconds: number): string {
+    const progress = `(${this.phaseIndex}/${this.totalPhases})`;
+    const elapsed =
+      elapsedSeconds > 0 ? ` ${formatElapsedTime(elapsedSeconds)}` : "";
+    const iterationSuffix =
+      this.iteration && this.iteration > 1
+        ? ` [iteration ${this.iteration}]`
+        : "";
+
+    return `${this.prefix}${this.phase} ${progress}...${elapsed}${iterationSuffix}`;
+  }
+
+  /**
+   * Update the spinner text with current elapsed time
+   */
+  private updateElapsedTime(): void {
+    if (this.disposed || this.paused) return;
+
+    const elapsedSeconds = (Date.now() - this.startTime) / 1000;
+    this.spinner.text = this.formatText(elapsedSeconds);
+  }
+
+  /**
+   * Start the spinner
+   *
+   * Begins the animation and elapsed time tracking.
+   */
+  start(): PhaseSpinner {
+    if (this.disposed) return this;
+
+    this.startTime = Date.now();
+    this.spinner.start(this.formatText(0));
+
+    // Start elapsed time update interval
+    this.intervalId = setInterval(() => {
+      this.updateElapsedTime();
+    }, ELAPSED_UPDATE_INTERVAL_MS);
+
+    // Register with ShutdownManager for graceful cleanup
+    if (this.shutdownManager) {
+      this.shutdownManager.registerCleanup(this.cleanupName, async () => {
+        this.stop();
+      });
+    }
+
+    return this;
+  }
+
+  /**
+   * Mark the phase as succeeded
+   *
+   * Stops the spinner and shows a checkmark with total duration.
+   */
+  succeed(customText?: string): PhaseSpinner {
+    if (this.disposed) return this;
+
+    this.clearInterval();
+    this.unregisterCleanup();
+
+    const elapsedSeconds = (Date.now() - this.startTime) / 1000;
+    const duration = formatElapsedTime(elapsedSeconds);
+    const progress = `(${this.phaseIndex}/${this.totalPhases})`;
+    const text =
+      customText ?? `${this.prefix}${this.phase} ${progress} (${duration})`;
+
+    this.spinner.succeed(text);
+    this.disposed = true;
+
+    return this;
+  }
+
+  /**
+   * Mark the phase as failed
+   *
+   * Stops the spinner and shows an error indicator with message.
+   */
+  fail(error?: string): PhaseSpinner {
+    if (this.disposed) return this;
+
+    this.clearInterval();
+    this.unregisterCleanup();
+
+    const elapsedSeconds = (Date.now() - this.startTime) / 1000;
+    const duration = formatElapsedTime(elapsedSeconds);
+    const progress = `(${this.phaseIndex}/${this.totalPhases})`;
+    const errorSuffix = error ? `: ${error}` : "";
+    const text = `${this.prefix}${this.phase} ${progress} (${duration})${errorSuffix}`;
+
+    this.spinner.fail(text);
+    this.disposed = true;
+
+    return this;
+  }
+
+  /**
+   * Stop the spinner without success/fail indication
+   *
+   * Use this for cleanup or when the phase is interrupted.
+   */
+  stop(): PhaseSpinner {
+    if (this.disposed) return this;
+
+    this.clearInterval();
+    this.unregisterCleanup();
+    this.spinner.stop();
+    this.disposed = true;
+
+    return this;
+  }
+
+  /**
+   * Pause the spinner (for verbose streaming output)
+   *
+   * Temporarily stops the animation without disposing.
+   * Call resume() to continue.
+   */
+  pause(): PhaseSpinner {
+    if (this.disposed || this.paused) return this;
+
+    this.paused = true;
+    this.spinner.stop();
+
+    return this;
+  }
+
+  /**
+   * Resume the spinner after pause
+   *
+   * Restarts the animation with updated elapsed time.
+   */
+  resume(): PhaseSpinner {
+    if (this.disposed || !this.paused) return this;
+
+    this.paused = false;
+    const elapsedSeconds = (Date.now() - this.startTime) / 1000;
+    this.spinner.start(this.formatText(elapsedSeconds));
+
+    return this;
+  }
+
+  /**
+   * Check if the spinner is currently active
+   */
+  get isSpinning(): boolean {
+    return this.spinner.isSpinning && !this.disposed && !this.paused;
+  }
+
+  /**
+   * Get the total elapsed time in seconds
+   */
+  get elapsedSeconds(): number {
+    if (this.startTime === 0) return 0;
+    return (Date.now() - this.startTime) / 1000;
+  }
+
+  /**
+   * Dispose of the spinner and clean up resources
+   *
+   * Called automatically by succeed(), fail(), or stop().
+   * Safe to call multiple times.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+
+    this.clearInterval();
+    this.unregisterCleanup();
+    this.spinner.stop();
+    this.disposed = true;
+  }
+
+  /**
+   * Clear the elapsed time update interval
+   */
+  private clearInterval(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /**
+   * Unregister from ShutdownManager
+   */
+  private unregisterCleanup(): void {
+    if (this.shutdownManager) {
+      this.shutdownManager.unregisterCleanup(this.cleanupName);
+    }
+  }
+}
+
+/**
+ * Create a PhaseSpinner with the given options
+ *
+ * Convenience function matching the pattern of cli-ui.spinner().
+ */
+export function phaseSpinner(options: PhaseSpinnerOptions): PhaseSpinner {
+  return new PhaseSpinner(options);
+}


### PR DESCRIPTION
## Summary

- Add `PhaseSpinner` utility class that provides animated spinners with elapsed time tracking for `sequant run` phase execution
- Replace static "⏳ phase..." text with animated ora spinners showing progress and duration
- Integrate with ShutdownManager for graceful Ctrl+C cleanup
- Support pause/resume for verbose streaming output to prevent terminal corruption

## Changes

### New Files
- `src/lib/phase-spinner.ts` - PhaseSpinner class with elapsed time tracking
- `src/lib/phase-spinner.test.ts` - 35 unit tests for PhaseSpinner

### Modified Files
- `src/commands/run.ts` - Integrate PhaseSpinner into phase execution

## AC Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | Phase execution shows animated ora spinner | ✅ MET |
| AC-2 | Spinner text includes elapsed time (5s updates) | ✅ MET |
| AC-3 | Active phase text is prominent (cyan) | ✅ MET |
| AC-4 | Phase progress shown (e.g., "spec (1/3)") | ✅ MET |
| AC-5 | Completion shows checkmark with duration | ✅ MET |
| AC-6 | Graceful fallback in CI/non-TTY | ✅ MET (via cli-ui) |
| AC-7 | Verbose mode uses text-only output | ✅ MET (via cli-ui) |
| AC-8 | Verbose mode pauses spinner during streaming | ✅ MET |
| AC-9 | Parallel mode uses sequential spinners | ✅ MET |
| AC-10 | Elapsed time interval cleaned up | ✅ MET |
| AC-11 | Spinner registered with ShutdownManager | ✅ MET |
| AC-12 | Auto-detect flow handles nested contexts | ✅ MET |
| AC-13 | Quality loop iterations show transitions | ✅ MET |
| AC-14 | Unit tests mock ora spinner | ✅ MET |

## Test plan

- [x] Unit tests pass (35 tests for PhaseSpinner)
- [x] Build passes (`npm run build`)
- [x] All existing tests pass (1101/1104 - 3 pre-existing semgrep timeouts)
- [ ] Manual test: Run `sequant run <issue>` and verify animated spinner appears
- [ ] Manual test: Verify spinner shows elapsed time updating
- [ ] Manual test: Verify Ctrl+C cleanly stops spinner

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)