### PR TITLE
refactor(#227): Decouple derived AC extraction from hardcoded dimensions

### DIFF
--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -216,8 +216,9 @@ Per Quality Plan:
 ```bash
 # Extract derived ACs from spec comment's Derived ACs table
 # Format: | Source | AC-N: Description | Priority |
+# Uses flexible pattern to match any source dimension (not hardcoded)
 derived_acs=$(gh issue view <issue-number> --comments --json comments -q '.comments[].body' | \
-  grep -E '\|\s*(Error Handling|Test Coverage|Best Practices|Code Quality|Completeness|Polish)\s*\|.*AC-[0-9]+:' | \
+  grep -E '\|[^|]+\|\s*AC-[0-9]+:' | \
   grep -oE 'AC-[0-9]+:[^|]+' | \
   sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | \
   sort -u)

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -354,8 +354,9 @@ quality_plan_exists=$(gh issue view <issue> --comments --json comments -q '.comm
    ```bash
    # Extract derived ACs from spec comment's Derived ACs table
    # Format: | Source | AC-N: Description | Priority |
+   # Uses flexible pattern to match any source dimension (not hardcoded)
    derived_acs=$(gh issue view <issue-number> --comments --json comments -q '.comments[].body' | \
-     grep -E '\|\s*(Error Handling|Test Coverage|Best Practices|Code Quality|Completeness|Polish)\s*\|.*AC-[0-9]+:' | \
+     grep -E '\|[^|]+\|\s*AC-[0-9]+:' | \
      grep -oE 'AC-[0-9]+:[^|]+' | \
      sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | \
      sort -u)


### PR DESCRIPTION
## Summary

- Replaces hardcoded quality dimension names with a flexible regex pattern
- Updates both `/exec` and `/qa` skills to use identical patterns
- Automatically supports new quality dimensions without skill updates

## Changes

| File | Change |
|------|--------|
| `.claude/skills/exec/SKILL.md` | Updated grep pattern to `\|[^|]+\|\s*AC-[0-9]+:` |
| `.claude/skills/qa/SKILL.md` | Updated grep pattern to match (identical) |

## Pattern Comparison

**Before (hardcoded):**
```bash
grep -E '\|\s*(Error Handling|Test Coverage|Best Practices|Code Quality|Completeness|Polish)\s*\|.*AC-[0-9]+:'
```

**After (flexible):**
```bash
grep -E '\|[^|]+\|\s*AC-[0-9]+:'
```

## Test Plan

- [x] `npm test` - 1158 tests passed
- [x] `npm run build` - TypeScript compilation successful
- [x] `npm run lint` - No warnings
- [x] Verified both files use identical patterns
- [x] Verified no other tables use `AC-N:` format (no false positive risk)

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Derived AC extraction works for any quality dimension without hardcoding | ✅ Implemented | Pattern `\|[^|]+\|` matches any source |
| AC-2 | No false positives from non-derived-AC tables | ✅ Implemented | Pattern requires `AC-[0-9]+:` which is unique to derived ACs |
| AC-3 | Pattern is consistent across `/exec` and `/qa` skills | ✅ Implemented | Both use identical pattern |

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)