### PR TITLE
docs(#243): Document PR session linking workflow

### DIFF
--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -481,6 +481,8 @@ After implementation is complete and all checks pass, create and verify the PR:
    )"
    ```
 
+   > **Session Auto-Linking (Claude Code v2.1.27+):** When you create a PR using `gh pr create`, Claude Code automatically links the current session to that PR. This enables resuming work on the PR later using `claude --from-pr <pr-number>`. No manual linking is required.
+
 3. **Immediately verify PR was created:**
    ```bash
    # Verify PR exists - this MUST succeed
@@ -507,6 +509,30 @@ After implementation is complete and all checks pass, create and verify the PR:
    npx tsx scripts/state/update.ts pr <issue-number> "$PR_NUMBER" "$PR_URL"
    ```
    This enables `--cleanup` to detect merged PRs and auto-remove state entries.
+
+### Resuming PR Sessions
+
+**Claude Code v2.1.27+** introduced the `--from-pr` flag to resume sessions linked to a specific GitHub PR:
+
+```bash
+# Resume by PR number
+claude --from-pr 123
+
+# Resume by PR URL
+claude --from-pr https://github.com/owner/repo/pull/123
+```
+
+**How it works:**
+- Sessions are automatically linked to PRs when created via `gh pr create`
+- Use `--from-pr` to return to work on a specific PR with full session context
+- Useful for context switching between multiple PRs or returning to stale work
+
+**When to use:**
+| Scenario | Command |
+|----------|---------|
+| Return to PR after break | `claude --from-pr <pr-number>` |
+| Switch between PRs | `claude --from-pr <other-pr>` |
+| Resume from PR URL | `claude --from-pr <full-url>` |
 
 **PR Verification Failure Handling:**
 


### PR DESCRIPTION
## Summary

- Document the `--from-pr` flag for resuming Claude Code sessions linked to PRs
- Add note that sessions auto-link when using `gh pr create`
- Both features added in Claude Code v2.1.27

## Changes

Added to `.claude/skills/exec/SKILL.md`:
1. **Session Auto-Linking callout** - Note after `gh pr create` example explaining automatic session linking
2. **Resuming PR Sessions section** - New subsection documenting the `--from-pr` flag with usage table

## Test plan

- [x] Manual review: Documentation is clear and accurate
- [x] Build passes: No TypeScript errors
- [x] Lint passes: No ESLint errors
- [x] Tests pass: 1178 tests passing

## AC Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | `--from-pr` flag documented in relevant workflow docs | ✅ Implemented |
| AC-2 | Auto-linking behavior noted for `gh pr create` usage | ✅ Implemented |

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)