### PR TITLE
feat(#260): GitHub-based workflow phase detection for smart resumption

### DIFF
--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -57,6 +57,55 @@ When invoked as `/exec`, your job is to:
 5. Iterate until the AC appear satisfied or clear blockers are reached.
 6. Draft a progress update for the GitHub issue.
 
+## Phase Detection (Smart Resumption)
+
+**Before executing**, check if this phase has already been completed or if prerequisites are met:
+
+```bash
+# Check for existing phase markers
+phase_data=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]' | \
+  grep -oP '<!-- SEQUANT_PHASE: \K\{[^}]+\}' | tail -1)
+
+if [[ -n "$phase_data" ]]; then
+  phase=$(echo "$phase_data" | jq -r '.phase')
+  status=$(echo "$phase_data" | jq -r '.status')
+
+  # Skip if exec is already completed
+  if [[ "$phase" == "exec" && "$status" == "completed" ]]; then
+    echo "⏭️ Exec phase already completed. Skipping."
+    # Exit early — no work needed
+  fi
+
+  # Resume if exec previously failed
+  if [[ "$phase" == "exec" && "$status" == "failed" ]]; then
+    echo "🔄 Exec phase previously failed. Resuming from failure point."
+    # Continue execution — will retry the implementation
+  fi
+fi
+```
+
+**Behavior:**
+- If `exec:completed` → Skip with message
+- If `exec:failed` → Resume (retry implementation)
+- If `spec:completed` (no exec marker) → Normal execution
+- If no markers found → Normal execution (fresh start)
+- If detection fails (API error) → Fall through to normal execution
+
+**Phase Marker Emission:**
+
+When posting the progress update comment to GitHub, append a phase marker at the end:
+
+```markdown
+<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"<ISO-8601>","pr":<PR_NUMBER>} -->
+```
+
+If exec fails, emit a failure marker:
+```markdown
+<!-- SEQUANT_PHASE: {"phase":"exec","status":"failed","timestamp":"<ISO-8601>","error":"<error message>"} -->
+```
+
+Include this marker in every `gh issue comment` that represents phase completion or failure.
+
 ## Behavior
 
 Invocation:

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -64,6 +64,52 @@ When running as part of an orchestrated workflow (e.g., `sequant run` or `/fulls
 - Fetch fresh issue context from GitHub
 - Post QA comment directly to GitHub
 
+## Phase Detection (Smart Resumption)
+
+**Before executing**, check if the exec phase has been completed (prerequisite for QA):
+
+```bash
+# Check for existing phase markers
+comments_json=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]')
+exec_completed=$(echo "$comments_json" | \
+  grep -oP '<!-- SEQUANT_PHASE: \K\{[^}]+\}' | \
+  jq -r 'select(.phase == "exec" and .status == "completed")' 2>/dev/null)
+
+if [[ -z "$exec_completed" ]]; then
+  # Check if any exec marker exists at all
+  exec_any=$(echo "$comments_json" | \
+    grep -oP '<!-- SEQUANT_PHASE: \K\{[^}]+\}' | \
+    jq -r 'select(.phase == "exec")' 2>/dev/null)
+
+  if [[ -n "$exec_any" ]]; then
+    echo "⚠️ Exec phase not completed (status: $(echo "$exec_any" | jq -r '.status')). Run /exec first."
+  else
+    echo "ℹ️ No phase markers found — proceeding with QA (may be a fresh issue or legacy workflow)."
+  fi
+fi
+```
+
+**Behavior:**
+- If `exec:completed` marker found → Normal QA execution
+- If `exec:failed` or `exec:in_progress` → Warn "Exec not complete, run /exec first" (but don't block — QA may still be useful for partial review)
+- If no markers found → Normal execution (backward compatible)
+- If detection fails (API error) → Fall through to normal execution
+
+**Phase Marker Emission:**
+
+When posting the QA review comment to GitHub, append a phase marker at the end:
+
+```markdown
+<!-- SEQUANT_PHASE: {"phase":"qa","status":"completed","timestamp":"<ISO-8601>"} -->
+```
+
+If QA determines AC_NOT_MET, emit:
+```markdown
+<!-- SEQUANT_PHASE: {"phase":"qa","status":"failed","timestamp":"<ISO-8601>","error":"AC_NOT_MET"} -->
+```
+
+Include this marker in every `gh issue comment` that represents QA completion.
+
 ## Behavior
 
 Invocation:

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -186,6 +186,10 @@ program
     "Base branch for worktree creation (default: main or settings.run.defaultBase)",
   )
   .option("--no-mcp", "Disable MCP server injection in headless mode")
+  .option(
+    "--resume",
+    "Resume from last completed phase (reads phase markers from GitHub)",
+  )
   .action(runCommand);
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,21 @@ export type {
   IssueStatus,
   PRInfo,
   LoopState,
+  PhaseMarker,
 } from "./lib/workflow/state-schema.js";
+// Phase detection exports
+export {
+  formatPhaseMarker,
+  parsePhaseMarkers,
+  detectPhaseFromComments,
+  getPhaseMap,
+  getCompletedPhasesFromComments,
+  getResumablePhases,
+  isPhaseCompletedOrPast,
+  getIssuePhase,
+  getCompletedPhases,
+  getResumablePhasesForIssue,
+} from "./lib/workflow/phase-detection.js";
 export {
   createStateHook,
   isOrchestrated,

--- a/src/lib/workflow/phase-detection.test.ts
+++ b/src/lib/workflow/phase-detection.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatPhaseMarker,
+  parsePhaseMarkers,
+  detectPhaseFromComments,
+  getPhaseMap,
+  getCompletedPhasesFromComments,
+  getResumablePhases,
+  isPhaseCompletedOrPast,
+} from "./phase-detection.js";
+import type { PhaseMarker } from "./state-schema.js";
+
+describe("formatPhaseMarker", () => {
+  it("produces valid HTML comment with JSON", () => {
+    const marker: PhaseMarker = {
+      phase: "spec",
+      status: "completed",
+      timestamp: "2025-01-15T10:30:00.000Z",
+    };
+    const result = formatPhaseMarker(marker);
+    expect(result).toBe(
+      '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:30:00.000Z"} -->',
+    );
+  });
+
+  it("includes optional pr field", () => {
+    const marker: PhaseMarker = {
+      phase: "exec",
+      status: "completed",
+      timestamp: "2025-01-15T10:30:00.000Z",
+      pr: 42,
+    };
+    const result = formatPhaseMarker(marker);
+    expect(result).toContain('"pr":42');
+  });
+
+  it("includes optional error field", () => {
+    const marker: PhaseMarker = {
+      phase: "exec",
+      status: "failed",
+      timestamp: "2025-01-15T10:30:00.000Z",
+      error: "Build failed",
+    };
+    const result = formatPhaseMarker(marker);
+    expect(result).toContain('"error":"Build failed"');
+  });
+
+  it("roundtrips through parse", () => {
+    const marker: PhaseMarker = {
+      phase: "qa",
+      status: "completed",
+      timestamp: "2025-01-15T12:00:00.000Z",
+    };
+    const formatted = formatPhaseMarker(marker);
+    const parsed = parsePhaseMarkers(formatted);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual(marker);
+  });
+});
+
+describe("parsePhaseMarkers", () => {
+  it("extracts marker from comment body", () => {
+    const body = `## Spec Complete
+
+Some human-readable content.
+
+<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:30:00.000Z"} -->`;
+    const markers = parsePhaseMarkers(body);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].phase).toBe("spec");
+    expect(markers[0].status).toBe("completed");
+  });
+
+  it("extracts multiple markers from one comment", () => {
+    const body = `<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->
+Some content
+<!-- SEQUANT_PHASE: {"phase":"exec","status":"in_progress","timestamp":"2025-01-15T11:00:00.000Z"} -->`;
+    const markers = parsePhaseMarkers(body);
+    expect(markers).toHaveLength(2);
+    expect(markers[0].phase).toBe("spec");
+    expect(markers[1].phase).toBe("exec");
+  });
+
+  it("returns empty array for no markers", () => {
+    const body = "Just a regular comment with no markers.";
+    expect(parsePhaseMarkers(body)).toEqual([]);
+  });
+
+  it("skips malformed JSON", () => {
+    const body =
+      '<!-- SEQUANT_PHASE: {invalid json} -->\n<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->';
+    const markers = parsePhaseMarkers(body);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].phase).toBe("spec");
+  });
+
+  it("skips markers with invalid schema", () => {
+    // Missing required fields
+    const body =
+      '<!-- SEQUANT_PHASE: {"phase":"spec"} -->\n<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->';
+    const markers = parsePhaseMarkers(body);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].phase).toBe("exec");
+  });
+
+  it("skips markers with unknown phase", () => {
+    const body =
+      '<!-- SEQUANT_PHASE: {"phase":"unknown","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->';
+    const markers = parsePhaseMarkers(body);
+    expect(markers).toEqual([]);
+  });
+
+  it("handles empty string", () => {
+    expect(parsePhaseMarkers("")).toEqual([]);
+  });
+});
+
+describe("detectPhaseFromComments", () => {
+  it("returns latest marker by timestamp", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"qa","status":"in_progress","timestamp":"2025-01-15T12:00:00.000Z"} -->',
+      },
+    ];
+    const result = detectPhaseFromComments(comments);
+    expect(result).not.toBeNull();
+    expect(result!.phase).toBe("qa");
+    expect(result!.status).toBe("in_progress");
+  });
+
+  it("returns null for no comments", () => {
+    expect(detectPhaseFromComments([])).toBeNull();
+  });
+
+  it("returns null when no markers present", () => {
+    const comments = [
+      { body: "Just a regular comment." },
+      { body: "Another comment without markers." },
+    ];
+    expect(detectPhaseFromComments(comments)).toBeNull();
+  });
+
+  it("handles mixed comments with and without markers", () => {
+    const comments = [
+      { body: "Regular comment" },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      { body: "Another regular comment" },
+    ];
+    const result = detectPhaseFromComments(comments);
+    expect(result).not.toBeNull();
+    expect(result!.phase).toBe("spec");
+  });
+});
+
+describe("getPhaseMap", () => {
+  it("returns latest marker per phase", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"in_progress","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+    ];
+    const map = getPhaseMap(comments);
+    expect(map.size).toBe(1);
+    expect(map.get("exec")!.status).toBe("completed");
+  });
+
+  it("tracks multiple phases", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"qa","status":"failed","timestamp":"2025-01-15T12:00:00.000Z"} -->',
+      },
+    ];
+    const map = getPhaseMap(comments);
+    expect(map.size).toBe(3);
+    expect(map.get("spec")!.status).toBe("completed");
+    expect(map.get("exec")!.status).toBe("completed");
+    expect(map.get("qa")!.status).toBe("failed");
+  });
+
+  it("returns empty map for no markers", () => {
+    expect(getPhaseMap([{ body: "no markers" }]).size).toBe(0);
+  });
+});
+
+describe("getCompletedPhasesFromComments", () => {
+  it("returns only completed phases in workflow order", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"qa","status":"failed","timestamp":"2025-01-15T12:00:00.000Z"} -->',
+      },
+    ];
+    const completed = getCompletedPhasesFromComments(comments);
+    expect(completed).toEqual(["spec", "exec"]);
+  });
+
+  it("returns empty array when no phases completed", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"in_progress","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+    ];
+    expect(getCompletedPhasesFromComments(comments)).toEqual([]);
+  });
+
+  it("respects workflow phase ordering", () => {
+    // Even if exec is completed before spec in timestamp, output follows WORKFLOW_PHASES order
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"qa","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+    ];
+    const completed = getCompletedPhasesFromComments(comments);
+    expect(completed).toEqual(["spec", "qa"]);
+  });
+});
+
+describe("getResumablePhases", () => {
+  it("filters out completed phases", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+    ];
+    const result = getResumablePhases(["spec", "exec", "qa"], comments);
+    expect(result).toEqual(["qa"]);
+  });
+
+  it("keeps failed phases (for retry)", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"failed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+    ];
+    const result = getResumablePhases(["spec", "exec", "qa"], comments);
+    expect(result).toEqual(["exec", "qa"]);
+  });
+
+  it("returns all phases when no markers exist", () => {
+    const result = getResumablePhases(
+      ["spec", "exec", "qa"],
+      [{ body: "no markers" }],
+    );
+    expect(result).toEqual(["spec", "exec", "qa"]);
+  });
+
+  it("returns all phases for empty comments", () => {
+    const result = getResumablePhases(["spec", "exec", "qa"], []);
+    expect(result).toEqual(["spec", "exec", "qa"]);
+  });
+
+  it("handles all phases completed", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T11:00:00.000Z"} -->',
+      },
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"qa","status":"completed","timestamp":"2025-01-15T12:00:00.000Z"} -->',
+      },
+    ];
+    const result = getResumablePhases(["spec", "exec", "qa"], comments);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("isPhaseCompletedOrPast", () => {
+  it("returns true when target phase is completed", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+    ];
+    expect(isPhaseCompletedOrPast("spec", comments)).toBe(true);
+  });
+
+  it("returns true when a later phase is completed", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+    ];
+    // spec is before exec in WORKFLOW_PHASES, so if exec is completed, spec must have been too
+    expect(isPhaseCompletedOrPast("spec", comments)).toBe(true);
+  });
+
+  it("returns false when target phase not reached", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+    ];
+    expect(isPhaseCompletedOrPast("exec", comments)).toBe(false);
+  });
+
+  it("returns false when target phase is in_progress", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"in_progress","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+    ];
+    expect(isPhaseCompletedOrPast("exec", comments)).toBe(false);
+  });
+
+  it("returns false when target phase failed and no later phase completed", () => {
+    const comments = [
+      {
+        body: '<!-- SEQUANT_PHASE: {"phase":"exec","status":"failed","timestamp":"2025-01-15T10:00:00.000Z"} -->',
+      },
+    ];
+    expect(isPhaseCompletedOrPast("exec", comments)).toBe(false);
+  });
+
+  it("returns false for empty comments", () => {
+    expect(isPhaseCompletedOrPast("spec", [])).toBe(false);
+  });
+});

--- a/src/lib/workflow/phase-detection.ts
+++ b/src/lib/workflow/phase-detection.ts
@@ -1,0 +1,275 @@
+/**
+ * GitHub-based workflow phase detection for smart resumption.
+ *
+ * Reads phase markers from GitHub issue comments to detect workflow state
+ * across machines, sessions, and users. Enables skills and `sequant run`
+ * to resume from where they left off.
+ *
+ * Phase markers are embedded as HTML comments in issue comment bodies:
+ * ```
+ * <!-- SEQUANT_PHASE: {"phase":"exec","status":"completed","timestamp":"..."} -->
+ * ```
+ */
+
+import { execSync } from "child_process";
+import {
+  type Phase,
+  type PhaseMarker,
+  PhaseMarkerSchema,
+  WORKFLOW_PHASES,
+} from "./state-schema.js";
+
+/** Regex to extract phase marker JSON from HTML comments */
+const PHASE_MARKER_REGEX = /<!-- SEQUANT_PHASE: (\{[^}]+\}) -->/g;
+
+/**
+ * Format a phase marker as an HTML comment string for embedding in GitHub comments.
+ *
+ * @param marker - The phase marker data
+ * @returns HTML comment string like `<!-- SEQUANT_PHASE: {...} -->`
+ */
+export function formatPhaseMarker(marker: PhaseMarker): string {
+  return `<!-- SEQUANT_PHASE: ${JSON.stringify(marker)} -->`;
+}
+
+/**
+ * Parse all phase markers from a single comment body.
+ *
+ * @param commentBody - The full body text of a GitHub comment
+ * @returns Array of parsed phase markers (empty if none found)
+ */
+export function parsePhaseMarkers(commentBody: string): PhaseMarker[] {
+  const markers: PhaseMarker[] = [];
+  // Reset regex state for reuse
+  PHASE_MARKER_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = PHASE_MARKER_REGEX.exec(commentBody)) !== null) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      const result = PhaseMarkerSchema.safeParse(parsed);
+      if (result.success) {
+        markers.push(result.data);
+      }
+    } catch {
+      // Malformed JSON — skip silently
+    }
+  }
+
+  return markers;
+}
+
+/**
+ * Detect the latest phase from an array of comment bodies.
+ *
+ * Scans all comments for phase markers and returns the most recent one
+ * based on the timestamp field.
+ *
+ * @param comments - Array of objects with a `body` string field
+ * @returns The latest phase marker, or null if no markers found
+ */
+export function detectPhaseFromComments(
+  comments: { body: string }[],
+): PhaseMarker | null {
+  const allMarkers: PhaseMarker[] = [];
+
+  for (const comment of comments) {
+    const markers = parsePhaseMarkers(comment.body);
+    allMarkers.push(...markers);
+  }
+
+  if (allMarkers.length === 0) {
+    return null;
+  }
+
+  // Sort by timestamp descending, return latest
+  allMarkers.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  );
+
+  return allMarkers[0];
+}
+
+/**
+ * Get all phase markers from issue comments, grouped by phase.
+ *
+ * Returns the latest marker for each phase that has been recorded.
+ *
+ * @param comments - Array of comment bodies
+ * @returns Map of phase → latest marker for that phase
+ */
+export function getPhaseMap(
+  comments: { body: string }[],
+): Map<Phase, PhaseMarker> {
+  const phaseMap = new Map<Phase, PhaseMarker>();
+
+  for (const comment of comments) {
+    const markers = parsePhaseMarkers(comment.body);
+    for (const marker of markers) {
+      const existing = phaseMap.get(marker.phase);
+      if (
+        !existing ||
+        new Date(marker.timestamp).getTime() >
+          new Date(existing.timestamp).getTime()
+      ) {
+        phaseMap.set(marker.phase, marker);
+      }
+    }
+  }
+
+  return phaseMap;
+}
+
+/**
+ * Get list of phases that have been completed for an issue.
+ *
+ * @param comments - Array of comment bodies
+ * @returns Array of phase names that have status "completed"
+ */
+export function getCompletedPhasesFromComments(
+  comments: { body: string }[],
+): Phase[] {
+  const phaseMap = getPhaseMap(comments);
+  const completed: Phase[] = [];
+
+  for (const phase of WORKFLOW_PHASES) {
+    const marker = phaseMap.get(phase);
+    if (marker && marker.status === "completed") {
+      completed.push(phase);
+    }
+  }
+
+  return completed;
+}
+
+/**
+ * Determine which phases to run based on completed phases and requested phases.
+ *
+ * Filters out phases that are already completed. If a phase failed,
+ * it is kept in the list (for retry).
+ *
+ * @param requestedPhases - The phases the user wants to run
+ * @param comments - Array of comment bodies from the issue
+ * @returns Filtered array of phases that still need to run
+ */
+export function getResumablePhases(
+  requestedPhases: readonly string[],
+  comments: { body: string }[],
+): string[] {
+  const completedPhases = new Set(getCompletedPhasesFromComments(comments));
+
+  return requestedPhases.filter(
+    (phase) => !completedPhases.has(phase as Phase),
+  );
+}
+
+/**
+ * Check if a specific phase has been reached or passed.
+ *
+ * Uses WORKFLOW_PHASES ordering to determine if the target phase
+ * is at or before the latest completed phase.
+ *
+ * @param targetPhase - The phase to check
+ * @param comments - Array of comment bodies
+ * @returns true if targetPhase has been completed or a later phase has been completed
+ */
+export function isPhaseCompletedOrPast(
+  targetPhase: Phase,
+  comments: { body: string }[],
+): boolean {
+  const phaseMap = getPhaseMap(comments);
+  const targetIndex = WORKFLOW_PHASES.indexOf(targetPhase);
+
+  // Check if target phase itself is completed
+  const targetMarker = phaseMap.get(targetPhase);
+  if (targetMarker && targetMarker.status === "completed") {
+    return true;
+  }
+
+  // Check if any later phase is completed (implies target was completed)
+  for (let i = targetIndex + 1; i < WORKFLOW_PHASES.length; i++) {
+    const laterPhase = WORKFLOW_PHASES[i];
+    const laterMarker = phaseMap.get(laterPhase);
+    if (laterMarker && laterMarker.status === "completed") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get the current phase status for an issue from GitHub comments.
+ *
+ * Calls `gh` CLI to fetch comments and parse phase markers.
+ *
+ * @param issueNumber - GitHub issue number
+ * @returns Latest phase marker, or null if no markers found or on error
+ */
+export function getIssuePhase(issueNumber: number): PhaseMarker | null {
+  try {
+    const output = execSync(
+      `gh issue view ${issueNumber} --json comments --jq '[.comments[].body]'`,
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    const bodies: string[] = JSON.parse(output);
+    const comments = bodies.map((body) => ({ body }));
+    return detectPhaseFromComments(comments);
+  } catch {
+    // GitHub CLI failure — fall through to normal execution
+    return null;
+  }
+}
+
+/**
+ * Get completed phases for an issue from GitHub comments.
+ *
+ * Calls `gh` CLI to fetch comments and extract completed phases.
+ *
+ * @param issueNumber - GitHub issue number
+ * @returns Array of completed phase names, or empty array on error
+ */
+export function getCompletedPhases(issueNumber: number): Phase[] {
+  try {
+    const output = execSync(
+      `gh issue view ${issueNumber} --json comments --jq '[.comments[].body]'`,
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    const bodies: string[] = JSON.parse(output);
+    const comments = bodies.map((body) => ({ body }));
+    return getCompletedPhasesFromComments(comments);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get resumable phases for an issue from GitHub comments.
+ *
+ * Convenience wrapper that fetches comments via `gh` CLI and
+ * filters requested phases by completed status.
+ *
+ * @param issueNumber - GitHub issue number
+ * @param requestedPhases - The phases the user wants to run
+ * @returns Filtered phases that still need to run
+ */
+export function getResumablePhasesForIssue(
+  issueNumber: number,
+  requestedPhases: readonly string[],
+): string[] {
+  try {
+    const output = execSync(
+      `gh issue view ${issueNumber} --json comments --jq '[.comments[].body]'`,
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    const bodies: string[] = JSON.parse(output);
+    const comments = bodies.map((body) => ({ body }));
+    return getResumablePhases(requestedPhases, comments);
+  } catch {
+    // On error, return all phases (no filtering)
+    return [...requestedPhases];
+  }
+}

--- a/src/lib/workflow/state-schema.ts
+++ b/src/lib/workflow/state-schema.ts
@@ -81,6 +81,26 @@ export const PhaseSchema = z.enum([
 export type Phase = z.infer<typeof PhaseSchema>;
 
 /**
+ * Phase marker stored in GitHub issue comments for cross-session detection.
+ *
+ * Embedded as HTML comments: `<!-- SEQUANT_PHASE: {...} -->`
+ */
+export const PhaseMarkerSchema = z.object({
+  /** The workflow phase */
+  phase: PhaseSchema,
+  /** Phase completion status */
+  status: PhaseStatusSchema,
+  /** ISO 8601 timestamp */
+  timestamp: z.string().datetime(),
+  /** PR number if created during this phase */
+  pr: z.number().int().positive().optional(),
+  /** Error message if phase failed */
+  error: z.string().optional(),
+});
+
+export type PhaseMarker = z.infer<typeof PhaseMarkerSchema>;
+
+/**
  * Individual phase state within an issue
  */
 export const PhaseStateSchema = z.object({

--- a/templates/skills/fullsolve/SKILL.md
+++ b/templates/skills/fullsolve/SKILL.md
@@ -90,6 +90,52 @@ When invoked as `/fullsolve <issue-number>`, execute the complete issue resoluti
 /fullsolve 218 --max-iterations 5 # Override max fix iterations
 ```
 
+## Phase Detection (Smart Resumption)
+
+**Before starting any phase**, detect the current workflow state from GitHub issue comments to enable smart resumption:
+
+```bash
+# Get all phase markers from issue comments
+comments_json=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]')
+markers=$(echo "$comments_json" | grep -oP '<!-- SEQUANT_PHASE: \K\{[^}]+\}')
+
+if [[ -n "$markers" ]]; then
+  echo "Phase markers detected:"
+  echo "$markers" | jq -r '"  \(.phase): \(.status)"'
+
+  # Determine resume point
+  latest_completed=$(echo "$markers" | jq -r 'select(.status == "completed") | .phase' | tail -1)
+  latest_failed=$(echo "$markers" | jq -r 'select(.status == "failed") | .phase' | tail -1)
+
+  echo "Latest completed: ${latest_completed:-none}"
+  echo "Latest failed: ${latest_failed:-none}"
+fi
+```
+
+**Resume Logic:**
+
+| Detected State | Action |
+|---------------|--------|
+| No markers | Start from Phase 1 (spec) — fresh start |
+| `spec:completed` | Skip to Phase 2 (exec) |
+| `exec:completed` | Skip to Phase 3 (test) or Phase 4 (qa) |
+| `exec:failed` | Resume at Phase 2 (exec) — retry |
+| `test:completed` | Skip to Phase 4 (qa) |
+| `qa:completed` | Skip to Phase 5 (PR) |
+| `qa:failed` | Resume at Phase 4 (qa) — retry with /loop |
+| All completed | Skip to PR creation (if no PR exists) |
+
+**Backward Compatibility:**
+- Issues without markers → treat as fresh start (no phase detection)
+- If detection fails (API error) → fall through to standard Phase 0 checks
+
+**Phase Marker Emission:**
+
+When posting progress comments after each phase, append the appropriate marker:
+```markdown
+<!-- SEQUANT_PHASE: {"phase":"<phase>","status":"<completed|failed>","timestamp":"<ISO-8601>"} -->
+```
+
 ## Phase 0: Pre-flight Checks
 
 **CRITICAL after context restoration:** Before starting any work, verify the current git state to avoid duplicate work.


### PR DESCRIPTION
## Summary

- Add `PhaseMarker` schema and `phase-detection.ts` library with functions to format, parse, and detect workflow phase markers from GitHub issue comments
- Add `--resume` flag to `sequant run` CLI that reads phase markers and skips completed phases
- Update `/spec`, `/exec`, `/qa`, `/fullsolve` skill templates to emit phase markers in progress comments and check them before executing

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Skills append `<!-- SEQUANT_PHASE: {...} -->` marker to progress comments | ✅ Implemented | All 4 skill SKILL.md files + templates updated with marker emission instructions |
| AC-2 | Phase detection helper reads latest phase from issue comments | ✅ Implemented | `src/lib/workflow/phase-detection.ts` with 32 passing tests |
| AC-3 | `/spec` skips if `spec:completed` or later | ✅ Implemented | `.claude/skills/spec/SKILL.md` Phase Detection section |
| AC-4 | `/exec` skips if `exec:completed`, resumes if `exec:failed` | ✅ Implemented | `.claude/skills/exec/SKILL.md` Phase Detection section |
| AC-5 | `/qa` checks `exec:completed` before running | ✅ Implemented | `.claude/skills/qa/SKILL.md` Phase Detection section |
| AC-6 | `/fullsolve` resumes from current phase | ✅ Implemented | `.claude/skills/fullsolve/SKILL.md` Phase Detection section with resume table |
| AC-7 | `sequant run --resume` uses phase detection | ✅ Implemented | `src/commands/run.ts` + `bin/cli.ts` with `--resume` flag |

## Test Coverage

- **32 new tests** for phase detection library covering:
  - Format/parse roundtrip
  - Multiple markers per comment
  - Malformed JSON handling
  - Schema validation
  - Phase ordering and completion detection
  - Resume filtering logic
- **1210 total tests passing** (0 failures)

## Key Files Changed

| File | Change |
|------|--------|
| `src/lib/workflow/phase-detection.ts` | NEW: Core detection library |
| `src/lib/workflow/phase-detection.test.ts` | NEW: 32 unit tests |
| `src/lib/workflow/state-schema.ts` | ADD: PhaseMarkerSchema |
| `src/commands/run.ts` | ADD: `--resume` flag + filtering logic |
| `bin/cli.ts` | ADD: `--resume` CLI option |
| `src/index.ts` | ADD: Phase detection exports |
| `.claude/skills/{spec,exec,qa,fullsolve}/SKILL.md` | ADD: Phase Detection sections |
| `templates/skills/{spec,exec,qa,fullsolve}/SKILL.md` | ADD: Phase Detection sections (templates) |

## Test Plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npm test` passes (1210/1210)
- [ ] Manual: Run `/spec` on an issue, verify marker appears in comment
- [ ] Manual: Run `sequant run <issue> --resume` after partial completion

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)