### PR TITLE
docs(qa): document script verification override criteria

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1239,7 +1239,7 @@ fi
 
 **If no verification evidence exists:**
 1. Prompt: "Script changes detected but no execution verification found. Run `/verify <issue> --command \"<test command>\"` before READY_FOR_MERGE verdict."
-2. Do NOT give `READY_FOR_MERGE` verdict until verification is complete
+2. Do NOT give `READY_FOR_MERGE` verdict until verification is complete (unless an approved override applies — see Section 11a)
 3. Verdict should be `AC_MET_BUT_NOT_A_PLUS` with note about missing verification
 
 **Why this matters:**

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -369,7 +369,7 @@ fi
 
 **If no verification evidence exists:**
 1. Prompt: "Script changes detected but no execution verification found. Run `/verify <issue> --command \"<test command>\"` before READY_FOR_MERGE verdict."
-2. Do NOT give `READY_FOR_MERGE` verdict until verification is complete
+2. Do NOT give `READY_FOR_MERGE` verdict until verification is complete (unless an approved override applies — see Section 9a)
 3. Verdict should be `AC_MET_BUT_NOT_A_PLUS` with note about missing verification
 
 **Why this matters:**


### PR DESCRIPTION
## Summary

Closes #176

Documents when it's acceptable to override the `/verify` requirement for script changes in the QA skill, replacing informal judgment calls with structured criteria.

### Changes
- Added Section 11a "Script Verification Override" to `.claude/skills/qa/SKILL.md` with approved/not-approved categories, risk assessment definitions, and decision flow
- Added Section 9a (same content) to `templates/skills/qa/SKILL.md`
- Added "Script Verification Override" output template section to both files
- Updated output verification checklists in both files

### AC Coverage
- [x] AC-1: Document acceptable override criteria in QA skill
- [x] AC-2: Add "Script Verification Override" section to QA output template
- [x] AC-3: Require explicit risk assessment when overriding
- [x] AC-4: Update `templates/skills/qa/SKILL.md` with override guidance

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 1218 tests pass (`npm test`)
- [x] Documentation-only change — no runtime impact
- [x] Both `.claude/skills/qa/SKILL.md` and `templates/skills/qa/SKILL.md` updated in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)