### PR TITLE
feat(#299): add call-site review check to QA skill for new functions

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -815,6 +815,120 @@ changed_files=$(git diff main...HEAD --name-only | grep -E '\.(ts|tsx|js|jsx)$')
 
 See [anti-pattern-detection.md](references/anti-pattern-detection.md) for detection commands and full criteria.
 
+### 2f. Call-Site Review (When New Functions Added)
+
+**When to apply:** New exported functions are detected in the diff.
+
+**Purpose:** Review not just the function implementation but **where** and **how** it's called. A function can be perfectly implemented but called incorrectly at the call site. (Origin: Issue #295 — `rebaseBeforePR()` had thorough unit tests but was called for every issue in a chain loop when the AC specified "only the final branch.")
+
+**Detection:**
+```bash
+# Find new exported functions (added lines only)
+new_exports=$(git diff main...HEAD | grep -E '^\+export (async )?function \w+' | sed 's/^+//' | grep -oE 'function \w+' | awk '{print $2}')
+export_count=$(echo "$new_exports" | grep -c . || echo 0)
+
+if [[ $export_count -gt 0 ]]; then
+  echo "New exported functions detected: $export_count"
+  echo "$new_exports"
+fi
+```
+
+**If new exported functions found:**
+
+#### Step 1: Call-Site Inventory (AC-2)
+
+For each new exported function, identify ALL call sites:
+
+```bash
+# For each new function, find call sites
+for func in $new_exports; do
+  echo "=== Call sites for $func ==="
+  grep -rn "${func}(" --include="*.ts" --include="*.tsx" . | grep -v "\.test\." | grep -v "__tests__" | grep -v "export.*function ${func}"
+done
+```
+
+**Call site types:**
+- Direct call: `functionName(args)`
+- Method call: `this.functionName(args)` or `obj.functionName(args)`
+- Callback: `.then(functionName)` or `array.map(functionName)`
+- Conditional: `condition && functionName(args)`
+
+#### Step 2: Condition Audit (AC-3)
+
+For each call site, document the conditions that gate the call:
+
+| Condition Type | Example | Check |
+|----------------|---------|-------|
+| Guard clause | `if (x) { fn() }` | Does condition match AC? |
+| Logical AND | `x && fn()` | Is guard sufficient? |
+| Ternary | `x ? fn() : null` | Correct branch? |
+| Early return | `if (!x) return; fn()` | Correct logic? |
+
+**Compare conditions against AC constraints:**
+- AC says "only when X" → Call site should have `if (X)` guard
+- AC says "not in Y mode" → Call site should have `if (!Y)` guard
+- AC says "for Z items" → Call site should filter for Z condition
+
+#### Step 3: Loop Awareness (AC-4)
+
+**Detect if function is called inside a loop:**
+
+```bash
+# Check context around each call site (5 lines before)
+for func in $new_exports; do
+  grep -rn "${func}(" --include="*.ts" --include="*.tsx" . -B 5 | \
+    grep -E "(for|while|forEach|\.map\(|\.filter\(|\.reduce\()" && \
+    echo "⚠️ $func called inside loop - verify iteration scope"
+done
+```
+
+**Loop iteration review questions:**
+1. Should function run for ALL iterations? → OK if yes
+2. Should function run for FIRST/LAST only? → Check for index guard
+3. Should function run for SOME iterations? → Check for condition filter
+
+**Red flags:**
+- Function called unconditionally in loop when AC says "only once"
+- No break/return after call when AC implies single execution
+- Missing mode/flag guard when AC specifies conditions
+
+#### Step 4: Mode Sensitivity
+
+If the function accepts configuration or mode options:
+- Is the correct mode passed at the call site?
+- Are all mode-specific paths exercised appropriately?
+
+**Output Format:**
+
+```markdown
+### Call-Site Review
+
+**New exported functions detected:** N
+
+| Function | Call Sites | Loop? | Conditions | AC Match |
+|----------|-----------|-------|------------|----------|
+| `newFunction()` | `file.ts:123` | No | `if (success)` | ✅ Matches AC-2 |
+| `anotherFunc()` | `run.ts:456` | Yes | None | ⚠️ Missing guard (AC-3 says "final only") |
+| `thirdFunc()` | Not called | - | - | ⚠️ Unused export |
+
+**Findings:**
+- [List any mismatches between call-site conditions and AC constraints]
+
+**Recommendations:**
+- [Specific fixes needed at call sites]
+```
+
+**Verdict Impact:**
+
+| Finding | Verdict Impact |
+|---------|----------------|
+| All call sites match AC | No impact |
+| Call site missing AC-required guard | `AC_NOT_MET` |
+| Function not called anywhere | `AC_MET_BUT_NOT_A_PLUS` (dead export) |
+| Call site in loop, AC unclear about iteration | `NEEDS_VERIFICATION` |
+
+See [call-site-review.md](references/call-site-review.md) for detailed methodology and examples.
+
 ### 3. QA vs AC
 
 For each AC item, mark as:
@@ -1360,6 +1474,7 @@ npx tsx scripts/state/update.ts fail <issue-number> qa "AC not met"
 - [ ] **Code Review Findings** - Strengths, issues, suggestions
 - [ ] **Test Quality Review** - Included if test files modified (or marked N/A)
 - [ ] **Anti-Pattern Detection** - Dependency audit (if package.json changed) + code patterns
+- [ ] **Call-Site Review** - Included if new exported functions detected (or marked N/A)
 - [ ] **Execution Evidence** - Included if scripts/CLI modified (or marked N/A)
 - [ ] **Script Verification Override** - Included if scripts/CLI modified AND /verify was skipped (with justification and risk assessment)
 - [ ] **Skill Command Verification** - Included if `.claude/skills/**/*.md` modified (or marked N/A)
@@ -1537,6 +1652,24 @@ You MUST include these sections:
 
 **Critical Issues:** X
 **Warnings:** Y
+
+---
+
+### Call-Site Review
+
+[Include if new exported functions detected, otherwise: "N/A - No new exported functions"]
+
+**New exported functions detected:** N
+
+| Function | Call Sites | Loop? | Conditions | AC Match |
+|----------|-----------|-------|------------|----------|
+| `[function]` | `[file:line]` | Yes/No | `[condition]` | ✅ Matches AC-N / ⚠️ [issue] |
+
+**Findings:**
+- [List any mismatches between call-site conditions and AC constraints]
+
+**Recommendations:**
+- [Specific fixes needed at call sites]
 
 ---
 

--- a/.claude/skills/qa/references/call-site-review.md
+++ b/.claude/skills/qa/references/call-site-review.md
@@ -1,0 +1,192 @@
+# Call-Site Review Checklist
+
+## Purpose
+
+When new exported functions are added, QA must review not just the function itself but **where** and **how** it's called. A function can be perfectly implemented but called incorrectly at the call site.
+
+**Origin:** Issue #295 — `rebaseBeforePR()` had thorough unit tests but was called for every issue in a chain loop when the AC specified "only the final branch."
+
+## When to Apply
+
+This review is **triggered** when new exported functions are detected in the diff:
+
+```bash
+# Detect new exported functions (added lines only)
+git diff main...HEAD | grep -E '^\+export (async )?function \w+' | sed 's/^+//'
+```
+
+## Review Steps
+
+### Step 1: Inventory All Call Sites
+
+For each new exported function, find where it's called:
+
+```bash
+# Find call sites for a function
+grep -rn "functionName(" --include="*.ts" --include="*.tsx" . | grep -v "\.test\." | grep -v "__tests__"
+```
+
+### Step 2: Analyze Call-Site Conditions
+
+For each call site, identify:
+
+1. **What conditions gate the call?**
+   - `if` statements, `&&` guards, ternaries
+   - Mode flags, feature flags, environment checks
+
+2. **Is it in a loop?**
+   - `for`, `while`, `forEach`, `.map()`, `.filter()`, etc.
+   - If yes: Should it run for every iteration or only specific ones?
+
+3. **Is it in an async context?**
+   - Is `await` used appropriately?
+   - Could it cause race conditions?
+
+4. **Error handling at call site?**
+   - Is the call wrapped in try/catch?
+   - What happens if the function throws?
+
+### Step 3: AC Constraint Matching
+
+Compare call-site conditions against AC constraints:
+
+| AC Constraint | Call Site Check |
+|---------------|-----------------|
+| "Only for X" | Is there a guard: `if (X)` before the call? |
+| "When Y happens" | Is the call triggered by the Y event/condition? |
+| "Not in Z mode" | Is there a guard: `if (!Z)` or similar? |
+| "Final item only" | If in loop, is there an index check or break? |
+
+### Step 4: Loop Iteration Review
+
+When a function is called inside a loop, answer:
+
+1. **Iteration scope:**
+   - Should it run for ALL iterations? → OK
+   - Should it run for FIRST/LAST only? → Check for index guard
+   - Should it run for SOME iterations? → Check for condition filter
+
+2. **Common patterns to verify:**
+   ```typescript
+   // LAST only - should have index check
+   for (let i = 0; i < items.length; i++) {
+     if (i === items.length - 1) {
+       newFunction(); // ✅ Guarded for last
+     }
+   }
+
+   // FIRST only - should have index check
+   items.forEach((item, index) => {
+     if (index === 0) {
+       newFunction(); // ✅ Guarded for first
+     }
+   });
+
+   // CONDITIONAL - should have filter
+   for (const item of items) {
+     if (item.shouldProcess) {
+       newFunction(item); // ✅ Conditionally called
+     }
+   }
+   ```
+
+3. **Red flags:**
+   - Function called unconditionally in loop when AC says "only once"
+   - No break/return after the call when AC implies single execution
+   - Missing mode/flag guard when AC specifies conditions
+
+### Step 5: Mode/Flag Sensitivity
+
+If the function behaves differently based on mode flags:
+
+1. **Identify mode parameters:**
+   - Does the function accept `options` or `config`?
+   - Are there mode-specific code paths inside?
+
+2. **Verify at call site:**
+   - Is the mode passed correctly?
+   - Does the caller's context match the mode expected?
+
+## Output Format
+
+```markdown
+### Call-Site Review
+
+**New exported functions detected:** N
+
+| Function | Call Sites | Loop? | Conditions | AC Match |
+|----------|-----------|-------|------------|----------|
+| `newFunction()` | `file.ts:123` | No | `if (condition)` | ✅ Matches AC-2 |
+| `anotherFunc()` | `run.ts:456` | Yes (forEach) | None | ⚠️ Missing guard (AC-3 says "final only") |
+| `thirdFunc()` | Not called | - | - | ⚠️ Unused export |
+
+**Findings:**
+- `anotherFunc()` is called in a loop without iteration guard. AC-3 specifies "only for the final item."
+
+**Recommendations:**
+1. Add index check: `if (index === items.length - 1)` before calling `anotherFunc()`
+```
+
+## Verdict Impact
+
+| Finding | Verdict Impact |
+|---------|----------------|
+| All call sites match AC | No impact |
+| Call site missing AC-required guard | `AC_NOT_MET` |
+| Function not called anywhere | `AC_MET_BUT_NOT_A_PLUS` (dead export) |
+| Call site in loop, AC unclear about iteration | `NEEDS_VERIFICATION` |
+
+## Examples
+
+### Example 1: Missing Chain Mode Guard (Issue #295)
+
+**AC:** "Rebase only the final branch in a chain"
+
+**Detection:**
+```bash
+grep -rn "rebaseBeforePR(" --include="*.ts" .
+# Output: src/run.ts:2977:  await rebaseBeforePR(worktreePath)
+```
+
+**Analysis:**
+```typescript
+// Found in loop over all chain issues
+for (const result of chainResults) {
+  if (result.success && result.worktreePath) {
+    await rebaseBeforePR(result.worktreePath);  // ⚠️ Called for ALL
+  }
+}
+```
+
+**Finding:** No guard for "final only" — function called for every issue in chain.
+
+**Fix:** Add final-issue check:
+```typescript
+for (let i = 0; i < chainResults.length; i++) {
+  const result = chainResults[i];
+  const isFinal = i === chainResults.length - 1;
+  if (result.success && result.worktreePath && isFinal) {
+    await rebaseBeforePR(result.worktreePath);  // ✅ Only final
+  }
+}
+```
+
+### Example 2: Correct Guard Present
+
+**AC:** "Send notification only when status is 'complete'"
+
+**Detection:**
+```bash
+grep -rn "sendNotification(" --include="*.ts" .
+# Output: src/handlers.ts:89:  sendNotification(user.email, message)
+```
+
+**Analysis:**
+```typescript
+// Found with proper guard
+if (task.status === 'complete') {
+  sendNotification(user.email, message);  // ✅ Guarded
+}
+```
+
+**Finding:** Call site condition matches AC constraint. No issues.


### PR DESCRIPTION
## Summary

- Adds Section 2f "Call-Site Review" to the QA skill that triggers when new exported functions are detected
- Creates reference document with detailed methodology and examples based on the Issue #295 case study
- Integrates into existing QA workflow: output template, verification checklist, verdict impact

## What's Added

### New QA Check: Call-Site Review

When `/qa` detects new exported functions in a diff, it now performs:

1. **Call-site inventory** - Finds all locations where the new function is called
2. **Condition audit** - Documents guards/conditions at each call site
3. **Loop awareness** - Flags functions called in loops for iteration scope review
4. **AC matching** - Compares call-site conditions against AC constraints

### Output Format

```markdown
### Call-Site Review

| Function | Call Sites | Loop? | Conditions | AC Match |
|----------|-----------|-------|------------|----------|
| `rebaseBeforePR()` | `run.ts:2977` | Yes | `success && worktreePath` | ⚠️ Missing chain mode guard |
```

### Verdict Impact

| Finding | Verdict Impact |
|---------|----------------|
| All call sites match AC | No impact |
| Call site missing AC-required guard | `AC_NOT_MET` |
| Function not called anywhere | `AC_MET_BUT_NOT_A_PLUS` |

## AC Coverage

- [x] AC-1: QA skill detects new exported functions in the diff
- [x] AC-2: For each new function, QA identifies all call sites
- [x] AC-3: Call-site conditions listed and compared against AC constraints
- [x] AC-4: Functions called inside loops flagged for iteration-scope review
- [x] AC-5: Findings included in QA output under "Call-Site Review" section

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (1 unrelated flaky timeout test)
- [ ] Run `/qa` on a PR with new exported functions to verify detection

## Files Changed

- `.claude/skills/qa/SKILL.md` - Added Section 2f, output template, verification checklist
- `.claude/skills/qa/references/call-site-review.md` - New reference doc with methodology

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)