### PR TITLE
fix(deps): upgrade diff to 8.0.3 for DoS fix (#315)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "chokidar": "^5.0.0",
         "cli-table3": "^0.6.5",
         "commander": "^12.1.0",
-        "diff": "^7.0.0",
+        "diff": "^8.0.3",
         "gradient-string": "^3.0.0",
         "hono": "^4.12.1",
         "inquirer": "^12.3.2",
@@ -30,7 +30,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@types/diff": "^7.0.0",
         "@types/gradient-string": "^1.1.6",
         "@types/inquirer": "^9.0.7",
         "@types/node": "^22.10.5",
@@ -1781,13 +1780,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2700,9 +2692,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "chokidar": "^5.0.0",
     "cli-table3": "^0.6.5",
     "commander": "^12.1.0",
-    "diff": "^7.0.0",
+    "diff": "^8.0.3",
     "gradient-string": "^3.0.0",
     "hono": "^4.12.1",
     "inquirer": "^12.3.2",
@@ -73,7 +73,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@types/diff": "^7.0.0",
     "@types/gradient-string": "^1.1.6",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^22.10.5",


### PR DESCRIPTION
## Summary
- Upgrades `diff` from 7.0.0 to 8.0.3 to address GHSA-73rr-hh4g-fpgx (DoS in parsePatch/applyPatch)
- Removes `@types/diff` (diff v8 ships its own TypeScript types)

## AC Verification

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | `diff` upgraded to >= 8.0.3 | ✅ 8.0.3 installed |
| AC-2 | All call sites still work | ✅ Build passes (1 call site: `src/commands/update.ts`) |
| AC-3 | `npm audit` no longer flags diff | ✅ Verified |
| AC-4 | All existing tests pass | ✅ 1447 passed |

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] `npm test` — 1447 tests pass
- [x] `npm audit` confirms diff vulnerability resolved

Closes #315