### PR TITLE
feat(#320): Consolidate documentation source-of-truth in workflow skills

### DIFF
--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -508,6 +508,71 @@ echo "Current branch: $CURRENT_BRANCH"
 - Documents intentional deferrals
 - Enables better QA in `/qa` phase
 
+### 3f. CHANGELOG Update (REQUIRED for user-facing changes)
+
+**Purpose:** Ensure all user-facing changes are documented in the CHANGELOG before PR creation. This prevents documentation gaps and reduces release overhead.
+
+**When to update CHANGELOG:**
+
+| Change Type | CHANGELOG Required? | Section |
+|-------------|---------------------|---------|
+| New feature | ✅ Yes | `### Added` |
+| Bug fix | ✅ Yes | `### Fixed` |
+| Breaking change | ✅ Yes | `### Changed` or `### Removed` |
+| Performance improvement | ✅ Yes | `### Changed` |
+| Dependency update (security) | ✅ Yes | `### Fixed` or `### Security` |
+| Documentation only | ❌ No | - |
+| Internal refactor (no behavior change) | ❌ No | - |
+| Test-only changes | ❌ No | - |
+| CI/workflow changes | ❌ No | - |
+
+**How to update:**
+
+1. **Check if CHANGELOG.md exists:**
+   ```bash
+   if [ -f "CHANGELOG.md" ]; then
+     echo "CHANGELOG.md found - update required for user-facing changes"
+   else
+     echo "No CHANGELOG.md - skip CHANGELOG update"
+   fi
+   ```
+
+2. **If CHANGELOG.md exists and change is user-facing**, use the Edit tool to add an entry under `## [Unreleased]`:
+
+   ```markdown
+   ## [Unreleased]
+
+   ### Added
+
+   - Brief description of new feature (#<issue-number>)
+   ```
+
+3. **Entry format:**
+   - Start with a verb: "Add", "Fix", "Update", "Remove", "Improve"
+   - Keep it concise (1-2 lines)
+   - Include issue number as `(#123)`
+   - Group related changes in a single bullet with sub-bullets if needed
+
+**Example entries:**
+
+```markdown
+### Added
+
+- CHANGELOG update step in /exec skill (#320)
+  - Instructs /exec to add [Unreleased] entries during feature commits
+  - Includes change type classification table
+
+### Fixed
+
+- Race condition in parallel agent spawning (#315)
+```
+
+**If CHANGELOG doesn't exist:** Skip this step. Not all projects use CHANGELOG.md.
+
+**If change is not user-facing:** Skip this step but note in progress summary: "CHANGELOG: N/A (internal change)"
+
+---
+
 ### PR Creation and Verification
 
 After implementation is complete and all checks pass, create and verify the PR:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Consolidated documentation source-of-truth in workflow skills (#320)
+  - `/exec`: New CHANGELOG update step requiring `[Unreleased]` entries for user-facing changes
+  - `/qa`: New CHANGELOG quality gate blocks `READY_FOR_MERGE` without CHANGELOG entry
+  - `/release`: Enhanced Step 4.6 auto-generates what-weve-built.md bullets from CHANGELOG
 - Call-site review check for QA skill (#299)
   - Detects new exported functions (including arrow exports) in the diff
   - Inventories all call sites, audits conditions, flags loop iteration scope


### PR DESCRIPTION
## Summary

- Add CHANGELOG update step to `/exec` skill (Section 3f) - instructs implementation phase to add `[Unreleased]` entries for user-facing changes
- Add CHANGELOG quality gate to `/qa` skill (Section 10a) - blocks `READY_FOR_MERGE` verdict when user-facing changes lack CHANGELOG entry
- Enhance `/release` Step 4.6 to auto-generate `what-weve-built.md` feature bullets from CHANGELOG's `[Unreleased]` section

## Pre-PR AC Verification

| AC | Source | Description | Status | Evidence |
|----|--------|-------------|--------|----------|
| AC-1 | Original | /exec adds CHANGELOG entry to [Unreleased] | ✅ Implemented | `.claude/skills/exec/SKILL.md:511-576` (Section 3f) |
| AC-2 | Original | /qa verifies CHANGELOG entry before READY_FOR_MERGE | ✅ Implemented | `.claude/skills/qa/SKILL.md:1335-1396` (Section 10a) |
| AC-3 | Original | /release generates what-weve-built from CHANGELOG | ✅ Implemented | `.claude/skills/release/SKILL.md:255-306` (enhanced Step 4.6) |
| AC-4 | Original | /docs does NOT trigger what-weve-built updates | ✅ Verified | `/docs` skill already handles only admin/feature docs, not what-weve-built |
| AC-5 | Original | Metric: ≤10% release commits need manual what-weve-built edits | ⏳ Post-adoption | Cannot measure until workflow is in use |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` - 1447/1448 tests pass (1 pre-existing flaky timeout unrelated to changes)
- [ ] Manual verification: Run `/exec` on test issue, verify CHANGELOG prompt appears
- [ ] Manual verification: Run `/qa` on PR without CHANGELOG entry, verify block message

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)