### PR TITLE
feat(#179): Add --reflect flag for post-run analysis

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -207,6 +207,7 @@ program
     "-f, --force",
     "Force re-execution of completed issues (bypass pre-flight state guard)",
   )
+  .option("--reflect", "Analyze run results and suggest improvements")
   .action(runCommand);
 
 program

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -48,6 +48,7 @@ import {
 import { getTokenUsageForRun } from "../lib/workflow/token-utils.js";
 import type { CacheMetrics } from "../lib/workflow/run-log-schema.js";
 import { reconcileStateAtStartup } from "../lib/workflow/state-utils.js";
+import { analyzeRun, formatReflection } from "../lib/workflow/run-reflect.js";
 
 /**
  * Worktree information for an issue
@@ -1643,6 +1644,12 @@ interface RunOptions {
    * Bypasses the pre-flight state guard that skips ready_for_merge/merged issues.
    */
   force?: boolean;
+  /**
+   * Analyze run results and suggest workflow improvements.
+   * Displays observations about timing patterns, phase mismatches, and
+   * actionable suggestions after the summary output.
+   */
+  reflect?: boolean;
 }
 
 /**
@@ -3118,6 +3125,24 @@ export async function runCommand(
     if (logPath) {
       console.log(colors.muted(`  📝 Log: ${logPath}`));
       console.log("");
+    }
+
+    // Reflection analysis (--reflect flag)
+    if (mergedOptions.reflect && results.length > 0) {
+      const reflection = analyzeRun({
+        results,
+        issueInfoMap,
+        runLog: logWriter?.getRunLog() ?? null,
+        config: {
+          phases: config.phases,
+          qualityLoop: config.qualityLoop,
+        },
+      });
+      const reflectionOutput = formatReflection(reflection);
+      if (reflectionOutput) {
+        console.log(reflectionOutput);
+        console.log("");
+      }
     }
 
     if (config.dryRun) {

--- a/src/lib/workflow/run-reflect.test.ts
+++ b/src/lib/workflow/run-reflect.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeRun,
+  formatReflection,
+  type ReflectionInput,
+  type ReflectionOutput,
+} from "./run-reflect.js";
+import type { IssueResult } from "./types.js";
+import type { RunLog } from "./run-log-schema.js";
+
+function makeResult(
+  issueNumber: number,
+  phases: Array<{
+    phase: string;
+    success?: boolean;
+    durationSeconds?: number;
+  }>,
+  overrides?: Partial<IssueResult>,
+): IssueResult {
+  return {
+    issueNumber,
+    success: overrides?.success ?? true,
+    phaseResults: phases.map((p) => ({
+      phase: p.phase as IssueResult["phaseResults"][0]["phase"],
+      success: p.success ?? true,
+      durationSeconds: p.durationSeconds,
+    })),
+    ...overrides,
+  };
+}
+
+function makeInput(overrides?: Partial<ReflectionInput>): ReflectionInput {
+  return {
+    results: [],
+    issueInfoMap: new Map(),
+    runLog: null,
+    config: { phases: ["spec", "exec", "qa"], qualityLoop: false },
+    ...overrides,
+  };
+}
+
+describe("analyzeRun", () => {
+  describe("timing patterns", () => {
+    it("detects similar spec times across issues", () => {
+      const input = makeInput({
+        results: [
+          makeResult(1, [
+            { phase: "spec", durationSeconds: 170 },
+            { phase: "exec", durationSeconds: 300 },
+          ]),
+          makeResult(2, [
+            { phase: "spec", durationSeconds: 180 },
+            { phase: "exec", durationSeconds: 600 },
+          ]),
+        ],
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.observations.some((o) => o.includes("Spec times similar")),
+      ).toBe(true);
+      expect(
+        result.suggestions.some((s) => s.includes("--phases exec,qa")),
+      ).toBe(true);
+    });
+
+    it("does not flag timing when only one issue", () => {
+      const input = makeInput({
+        results: [makeResult(1, [{ phase: "spec", durationSeconds: 170 }])],
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.observations.filter((o) => o.includes("Spec times")),
+      ).toHaveLength(0);
+    });
+
+    it("flags long QA phases", () => {
+      const input = makeInput({
+        results: [
+          makeResult(1, [
+            { phase: "spec", durationSeconds: 100 },
+            { phase: "qa", durationSeconds: 400 },
+          ]),
+        ],
+      });
+
+      const result = analyzeRun(input);
+
+      expect(result.observations.some((o) => o.includes("QA took"))).toBe(true);
+      expect(result.suggestions.some((s) => s.includes("sub-agent"))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("phase mismatches", () => {
+    it("detects .tsx changes without test phase via runLog", () => {
+      const runLog = {
+        version: 1 as const,
+        runId: "test-uuid",
+        startTime: new Date().toISOString(),
+        config: {
+          phases: ["spec" as const, "exec" as const, "qa" as const],
+          sequential: false,
+          qualityLoop: false,
+          maxIterations: 3,
+        },
+        issues: [
+          {
+            issueNumber: 42,
+            title: "Test issue",
+            labels: [],
+            status: "success" as const,
+            totalDurationSeconds: 300,
+            phases: [
+              {
+                phase: "exec" as const,
+                issueNumber: 42,
+                startTime: new Date().toISOString(),
+                endTime: new Date().toISOString(),
+                durationSeconds: 200,
+                status: "success" as const,
+                fileDiffStats: [
+                  {
+                    path: "src/components/Button.tsx",
+                    additions: 10,
+                    deletions: 2,
+                    status: "modified" as const,
+                  },
+                ],
+              },
+              {
+                phase: "qa" as const,
+                issueNumber: 42,
+                startTime: new Date().toISOString(),
+                endTime: new Date().toISOString(),
+                durationSeconds: 100,
+                status: "success" as const,
+              },
+            ],
+          },
+        ],
+        summary: {
+          totalIssues: 1,
+          passed: 1,
+          failed: 0,
+          totalDurationSeconds: 300,
+        },
+      };
+
+      const input = makeInput({
+        results: [makeResult(42, [{ phase: "exec" }, { phase: "qa" }])],
+        runLog,
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.observations.some(
+          (o) => o.includes("#42") && o.includes(".tsx"),
+        ),
+      ).toBe(true);
+      expect(
+        result.suggestions.some((s) => s.includes("ui") && s.includes("label")),
+      ).toBe(true);
+    });
+
+    it("does not flag when test phase was executed", () => {
+      const runLog = {
+        version: 1 as const,
+        runId: "test-uuid",
+        startTime: new Date().toISOString(),
+        config: {
+          phases: [
+            "spec" as const,
+            "exec" as const,
+            "test" as const,
+            "qa" as const,
+          ],
+          sequential: false,
+          qualityLoop: false,
+          maxIterations: 3,
+        },
+        issues: [
+          {
+            issueNumber: 42,
+            title: "Test issue",
+            labels: [],
+            status: "success" as const,
+            totalDurationSeconds: 400,
+            phases: [
+              {
+                phase: "exec" as const,
+                issueNumber: 42,
+                startTime: new Date().toISOString(),
+                endTime: new Date().toISOString(),
+                durationSeconds: 200,
+                status: "success" as const,
+                fileDiffStats: [
+                  {
+                    path: "src/components/Button.tsx",
+                    additions: 10,
+                    deletions: 2,
+                    status: "modified" as const,
+                  },
+                ],
+              },
+              {
+                phase: "test" as const,
+                issueNumber: 42,
+                startTime: new Date().toISOString(),
+                endTime: new Date().toISOString(),
+                durationSeconds: 100,
+                status: "success" as const,
+              },
+              {
+                phase: "qa" as const,
+                issueNumber: 42,
+                startTime: new Date().toISOString(),
+                endTime: new Date().toISOString(),
+                durationSeconds: 100,
+                status: "success" as const,
+              },
+            ],
+          },
+        ],
+        summary: {
+          totalIssues: 1,
+          passed: 1,
+          failed: 0,
+          totalDurationSeconds: 400,
+        },
+      };
+
+      const input = makeInput({
+        results: [
+          makeResult(42, [
+            { phase: "exec" },
+            { phase: "test" },
+            { phase: "qa" },
+          ]),
+        ],
+        runLog,
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.observations.filter((o) => o.includes(".tsx")),
+      ).toHaveLength(0);
+    });
+
+    it("falls back to label check when no runLog", () => {
+      const issueInfoMap = new Map<
+        number,
+        { title: string; labels: string[] }
+      >();
+      issueInfoMap.set(10, { title: "UI Fix", labels: ["ui", "enhancement"] });
+
+      const input = makeInput({
+        results: [
+          makeResult(10, [
+            { phase: "spec" },
+            { phase: "exec" },
+            { phase: "qa" },
+          ]),
+        ],
+        issueInfoMap,
+        runLog: null,
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.observations.some(
+          (o) => o.includes("#10") && o.includes("UI label"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("workflow improvements", () => {
+    it("detects all issues running same phases", () => {
+      const input = makeInput({
+        results: [
+          makeResult(1, [
+            { phase: "spec" },
+            { phase: "exec" },
+            { phase: "qa" },
+          ]),
+          makeResult(2, [
+            { phase: "spec" },
+            { phase: "exec" },
+            { phase: "qa" },
+          ]),
+          makeResult(3, [
+            { phase: "spec" },
+            { phase: "exec" },
+            { phase: "qa" },
+          ]),
+        ],
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.observations.some((o) => o.includes("identical phases")),
+      ).toBe(true);
+    });
+
+    it("detects quality loop triggers", () => {
+      const input = makeInput({
+        results: [
+          makeResult(
+            1,
+            [{ phase: "spec" }, { phase: "exec" }, { phase: "qa" }],
+            {
+              loopTriggered: true,
+            },
+          ),
+        ],
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.observations.some((o) => o.includes("Quality loop triggered")),
+      ).toBe(true);
+      expect(result.suggestions.some((s) => s.includes("complex"))).toBe(true);
+    });
+
+    it("suggests quality loop when failures occur without it", () => {
+      const input = makeInput({
+        results: [
+          makeResult(
+            1,
+            [{ phase: "spec" }, { phase: "exec", success: false }],
+            {
+              success: false,
+            },
+          ),
+          makeResult(2, [
+            { phase: "spec" },
+            { phase: "exec" },
+            { phase: "qa" },
+          ]),
+        ],
+        config: { phases: ["spec", "exec", "qa"], qualityLoop: false },
+      });
+
+      const result = analyzeRun(input);
+
+      expect(result.suggestions.some((s) => s.includes("--quality-loop"))).toBe(
+        true,
+      );
+    });
+
+    it("does not suggest quality loop when already enabled", () => {
+      const input = makeInput({
+        results: [
+          makeResult(
+            1,
+            [{ phase: "spec" }, { phase: "exec", success: false }],
+            {
+              success: false,
+            },
+          ),
+        ],
+        config: { phases: ["spec", "exec", "qa"], qualityLoop: true },
+      });
+
+      const result = analyzeRun(input);
+
+      expect(
+        result.suggestions.filter((s) => s.includes("--quality-loop")),
+      ).toHaveLength(0);
+    });
+  });
+});
+
+describe("formatReflection", () => {
+  it("returns empty string when no observations or suggestions", () => {
+    const output: ReflectionOutput = { observations: [], suggestions: [] };
+    expect(formatReflection(output)).toBe("");
+  });
+
+  it("formats observations and suggestions in a box", () => {
+    const output: ReflectionOutput = {
+      observations: ["Issue #1 was slow"],
+      suggestions: ["Try --fast mode"],
+    };
+
+    const formatted = formatReflection(output);
+
+    expect(formatted).toContain("Run Analysis");
+    expect(formatted).toContain("Observations:");
+    expect(formatted).toContain("Issue #1 was slow");
+    expect(formatted).toContain("Suggestions:");
+    expect(formatted).toContain("Try --fast mode");
+  });
+
+  it("truncates output to max 10 lines", () => {
+    const output: ReflectionOutput = {
+      observations: Array.from({ length: 6 }, (_, i) => `Observation ${i + 1}`),
+      suggestions: Array.from({ length: 6 }, (_, i) => `Suggestion ${i + 1}`),
+    };
+
+    const formatted = formatReflection(output);
+
+    // Should contain "... and N more" truncation indicator
+    expect(formatted).toContain("... and");
+    expect(formatted).toContain("more");
+
+    // Count bullet points (content lines) — should be <= 10
+    const bulletLines = formatted
+      .split("\n")
+      .filter((l) => l.includes("\u2022"));
+    expect(bulletLines.length).toBeLessThanOrEqual(10);
+  });
+
+  it("handles only observations (no suggestions)", () => {
+    const output: ReflectionOutput = {
+      observations: ["Something noteworthy"],
+      suggestions: [],
+    };
+
+    const formatted = formatReflection(output);
+
+    expect(formatted).toContain("Observations:");
+    expect(formatted).not.toContain("Suggestions:");
+  });
+
+  it("handles only suggestions (no observations)", () => {
+    const output: ReflectionOutput = {
+      observations: [],
+      suggestions: ["Try this improvement"],
+    };
+
+    const formatted = formatReflection(output);
+
+    expect(formatted).not.toContain("Observations:");
+    expect(formatted).toContain("Suggestions:");
+  });
+});

--- a/src/lib/workflow/run-reflect.ts
+++ b/src/lib/workflow/run-reflect.ts
@@ -1,0 +1,291 @@
+/**
+ * Run reflection analysis — analyzes completed run data and suggests improvements.
+ *
+ * Used by the `--reflect` flag on `sequant run` to provide post-run insights.
+ */
+
+import type { IssueResult } from "./types.js";
+import type { RunLog } from "./run-log-schema.js";
+
+export interface ReflectionInput {
+  results: IssueResult[];
+  issueInfoMap: Map<number, { title: string; labels: string[] }>;
+  runLog: Omit<RunLog, "endTime"> | null;
+  config: { phases: string[]; qualityLoop: boolean };
+}
+
+export interface ReflectionOutput {
+  observations: string[];
+  suggestions: string[];
+}
+
+const MAX_OUTPUT_LINES = 10;
+
+/**
+ * Analyze a completed run and return observations + suggestions.
+ */
+export function analyzeRun(input: ReflectionInput): ReflectionOutput {
+  const observations: string[] = [];
+  const suggestions: string[] = [];
+
+  analyzeTimingPatterns(input, observations, suggestions);
+  detectPhaseMismatches(input, observations, suggestions);
+  suggestImprovements(input, observations, suggestions);
+
+  return { observations, suggestions };
+}
+
+/**
+ * Compare phase durations across issues to find timing anomalies.
+ */
+function analyzeTimingPatterns(
+  input: ReflectionInput,
+  observations: string[],
+  suggestions: string[],
+): void {
+  const { results } = input;
+
+  // Compare spec phase durations (needs 2+ issues)
+  const specTimings = results
+    .map((r) => ({
+      issue: r.issueNumber,
+      duration: r.phaseResults.find((p) => p.phase === "spec")?.durationSeconds,
+    }))
+    .filter(
+      (t): t is { issue: number; duration: number } => t.duration != null,
+    );
+
+  if (specTimings.length >= 2) {
+    const min = Math.min(...specTimings.map((t) => t.duration));
+    const max = Math.max(...specTimings.map((t) => t.duration));
+
+    // If spec times are similar (within 30%) despite different issues, flag it
+    if (max > 0 && min / max > 0.7 && max - min < 120) {
+      observations.push(
+        `Spec times similar across issues (${formatSec(min)}–${formatSec(max)}) despite varying complexity`,
+      );
+      suggestions.push(
+        "Consider `--phases exec,qa` for simple fixes to skip spec",
+      );
+    }
+  }
+
+  // Flag individual phases that took unusually long
+  for (const result of results) {
+    for (const phase of result.phaseResults) {
+      if (
+        phase.phase === "qa" &&
+        phase.durationSeconds &&
+        phase.durationSeconds > 300
+      ) {
+        observations.push(
+          `#${result.issueNumber} QA took ${formatSec(phase.durationSeconds)}`,
+        );
+        suggestions.push("Long QA may indicate sub-agent spawning issues");
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Detect mismatches between file changes and executed phases.
+ */
+function detectPhaseMismatches(
+  input: ReflectionInput,
+  observations: string[],
+  suggestions: string[],
+): void {
+  const { runLog, results } = input;
+
+  // Check fileDiffStats from runLog for .tsx/.jsx changes without test phase
+  if (runLog?.issues) {
+    for (const issueLog of runLog.issues) {
+      const phases = issueLog.phases.map((p) => p.phase);
+      const hasTestPhase = phases.includes("test");
+
+      if (hasTestPhase) continue;
+
+      // Collect all modified files across phases
+      const modifiedFiles: string[] = [];
+      for (const phase of issueLog.phases) {
+        if (phase.fileDiffStats) {
+          modifiedFiles.push(...phase.fileDiffStats.map((f) => f.path));
+        }
+        if (phase.filesModified) {
+          modifiedFiles.push(...phase.filesModified);
+        }
+      }
+
+      const hasTsxFiles = modifiedFiles.some(
+        (f) => f.endsWith(".tsx") || f.endsWith(".jsx"),
+      );
+
+      if (hasTsxFiles) {
+        observations.push(
+          `#${issueLog.issueNumber} modified .tsx files but no browser test ran`,
+        );
+        suggestions.push(
+          `Add \`ui\` label to #${issueLog.issueNumber} for browser testing`,
+        );
+      }
+    }
+  }
+
+  // Fallback: check labels if no runLog
+  if (!runLog) {
+    for (const result of results) {
+      const info = input.issueInfoMap.get(result.issueNumber);
+      const labels = info?.labels ?? [];
+      const hasUiLabel = labels.some((l) =>
+        ["ui", "frontend", "admin"].includes(l.toLowerCase()),
+      );
+      const hasTestPhase = result.phaseResults.some((p) => p.phase === "test");
+      if (hasUiLabel && !hasTestPhase) {
+        observations.push(
+          `#${result.issueNumber} has UI label but no test phase ran`,
+        );
+        suggestions.push("Include test phase for UI-labeled issues");
+      }
+    }
+  }
+}
+
+/**
+ * Suggest workflow improvements based on run patterns.
+ */
+function suggestImprovements(
+  input: ReflectionInput,
+  observations: string[],
+  suggestions: string[],
+): void {
+  const { results, config } = input;
+
+  // Check if all issues ran the same phases
+  if (results.length >= 2) {
+    const phaseSets = results.map((r) =>
+      r.phaseResults.map((p) => p.phase).join(","),
+    );
+    const allSame = phaseSets.every((s) => s === phaseSets[0]);
+    if (allSame) {
+      observations.push(
+        "All issues ran identical phases despite different requirements",
+      );
+      suggestions.push(
+        "Use `/solve` first to get per-issue phase recommendations",
+      );
+    }
+  }
+
+  // Check if quality loop was triggered
+  const loopIssues = results.filter((r) => r.loopTriggered);
+  if (loopIssues.length > 0) {
+    const issueNums = loopIssues.map((r) => `#${r.issueNumber}`).join(", ");
+    observations.push(`Quality loop triggered for ${issueNums}`);
+    suggestions.push(
+      "Consider adding `complex` label upfront for similar issues",
+    );
+  }
+
+  // Check for failed issues
+  const failedIssues = results.filter((r) => !r.success);
+  if (failedIssues.length > 0 && results.length > 1) {
+    const failRate = ((failedIssues.length / results.length) * 100).toFixed(0);
+    observations.push(
+      `${failRate}% failure rate (${failedIssues.length}/${results.length})`,
+    );
+  }
+
+  // Suggest quality loop if not enabled and failures occurred
+  if (!config.qualityLoop && failedIssues.length > 0) {
+    suggestions.push("Enable `--quality-loop` to auto-retry failed phases");
+  }
+}
+
+/**
+ * Format reflection output as a box with observations and suggestions.
+ * Enforces max 10 content lines.
+ */
+export function formatReflection(output: ReflectionOutput): string {
+  const { observations, suggestions } = output;
+
+  if (observations.length === 0 && suggestions.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [];
+
+  // Collect all content lines
+  const contentLines: string[] = [];
+  for (const obs of observations) {
+    contentLines.push(`  \u2022 ${obs}`);
+  }
+  for (const sug of suggestions) {
+    contentLines.push(`  \u2022 ${sug}`);
+  }
+
+  // Truncate if needed
+  const truncated = contentLines.length > MAX_OUTPUT_LINES;
+  const displayLines = truncated
+    ? contentLines.slice(0, MAX_OUTPUT_LINES - 1)
+    : contentLines;
+
+  // Calculate box width
+  const maxLineLen = Math.max(
+    ...displayLines.map((l) => l.length),
+    truncated ? 30 : 0,
+    20,
+  );
+  const boxWidth = Math.min(Math.max(maxLineLen + 4, 40), 66);
+
+  // Build box
+  lines.push(
+    `  \u250C\u2500 Run Analysis ${"─".repeat(Math.max(boxWidth - 16, 0))}\u2510`,
+  );
+  lines.push(`  \u2502${" ".repeat(boxWidth - 2)}\u2502`);
+
+  if (observations.length > 0) {
+    lines.push(
+      `  \u2502  Observations:${" ".repeat(Math.max(boxWidth - 17, 0))}\u2502`,
+    );
+    for (const line of displayLines.slice(0, observations.length)) {
+      lines.push(`  \u2502${padRight(line, boxWidth - 2)}\u2502`);
+    }
+    lines.push(`  \u2502${" ".repeat(boxWidth - 2)}\u2502`);
+  }
+
+  const sugLines = displayLines.slice(observations.length);
+  if (sugLines.length > 0) {
+    lines.push(
+      `  \u2502  Suggestions:${" ".repeat(Math.max(boxWidth - 16, 0))}\u2502`,
+    );
+    for (const line of sugLines) {
+      lines.push(`  \u2502${padRight(line, boxWidth - 2)}\u2502`);
+    }
+    lines.push(`  \u2502${" ".repeat(boxWidth - 2)}\u2502`);
+  }
+
+  if (truncated) {
+    const remaining = contentLines.length - (MAX_OUTPUT_LINES - 1);
+    const moreText = `  ... and ${remaining} more`;
+    lines.push(`  \u2502${padRight(moreText, boxWidth - 2)}\u2502`);
+    lines.push(`  \u2502${" ".repeat(boxWidth - 2)}\u2502`);
+  }
+
+  lines.push(`  \u2514${"─".repeat(boxWidth - 2)}\u2518`);
+
+  return lines.join("\n");
+}
+
+function padRight(str: string, len: number): string {
+  return str.length >= len
+    ? str.slice(0, len)
+    : str + " ".repeat(len - str.length);
+}
+
+function formatSec(seconds: number): string {
+  if (seconds < 60) return `${seconds.toFixed(0)}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60);
+  return `${mins}m ${secs}s`;
+}


### PR DESCRIPTION
## Summary

- Add optional `--reflect` flag to `sequant run` that analyzes completed run data and surfaces timing patterns, phase mismatches, and workflow improvement suggestions
- New `run-reflect.ts` module with `analyzeRun()` and `formatReflection()` functions
- 15 unit tests covering all analysis paths

## AC Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | Add `--reflect` flag to `sequant run` | ✅ MET |
| AC-2 | Analyze phase timing patterns across issues | ✅ MET |
| AC-3 | Detect potential phase mismatches (.tsx without /test) | ✅ MET |
| AC-4 | Suggest workflow improvements based on patterns | ✅ MET |
| AC-5 | Output is concise (max 10 lines of suggestions) | ✅ MET |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] 15 dedicated unit tests pass (`run-reflect.test.ts`)
- [x] 94 run command tests pass (`run.test.ts`)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)