### PR TITLE
test(#189): add Linux CI testing for plugin installation

### DIFF
--- a/.github/workflows/plugin-install-test.yml
+++ b/.github/workflows/plugin-install-test.yml
@@ -153,8 +153,8 @@ jobs:
 
       - name: Test plugin install
         run: |
-          echo "Testing claude plugin install..."
-          if claude plugin install sequant 2>&1; then
+          echo "Testing claude plugin install sequant@sequant..."
+          if claude plugin install sequant@sequant 2>&1; then
             echo "Plugin install succeeded!"
           else
             exit_code=$?


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`plugin-install-test.yml`) that validates plugin installation on Ubuntu Linux, completing the cross-platform testing deferred from #185.

### What it tests

**Job 1: Plugin Structure Validation**
- plugin.json and marketplace.json validation
- Skills discoverability (all SKILL.md files present and non-empty)
- Claude CLI plugin commands (marketplace add, install, validate) with graceful fallback

**Job 2: Hooks Validation**
- Bash syntax checking (`bash -n`) for pre-tool.sh and post-tool.sh
- hooks.json structure and script references
- Smoke tests with mock JSON input
- Security guardrail verification (blocked commands)

**Job 3: Setup Directory Creation**
- Directory creation logic validation
- Git prerequisites check
- Constitution template existence check

### Key design decisions

- **Separate workflow file** (not added to ci.yml) — different path triggers
- **Graceful degradation** — Claude CLI plugin commands skip if unavailable
- **Path filtering** — only triggers on changes to `.claude-plugin/`, `hooks/`, `skills/`, `memory/`

### AC Coverage

| AC | Status |
|---|---|
| AC-1: Workflow tests on Ubuntu | MET |
| AC-2: Runs on PR to main | MET |
| AC-3: marketplace add works | MET |
| AC-4: plugin install works | MET |
| AC-5: Skills discoverable | MET |
| AC-6: Hooks execute (bash) | MET |
| AC-7: Setup creates directories | MET |
| AC-8: Auth graceful skip | MET |

Fixes #189