### PR TITLE
fix(#395): generate per-client MCP configs with cwd and env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix MCP config generation producing identical configs for all clients (#395)
+  - Claude Desktop and VS Code + Continue configs now include `cwd` (absolute project path)
+  - Cursor config omits `cwd` (runs from workspace root)
+  - `env.ANTHROPIC_API_KEY` is only included when the env var is actually set
+  - `sequant init` generates per-client configs with correct fields
+
 ### Changed
 
 - Replace `spawnSync` with async `spawn` in MCP `sequant_run` tool (#388)

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -114,7 +114,7 @@ Detected 2 MCP-compatible client(s):
 Add Sequant MCP server to detected clients? (Y/n)
 ```
 
-Note: this currently doesn't set `cwd` for Claude Desktop — you may need to add it manually.
+Sequant detects each client type and generates the appropriate config — including `cwd` for Claude Desktop and VS Code + Continue.
 
 ## What You Can Ask
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -562,7 +562,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
     if (addMcp) {
       for (const client of detectedClients) {
-        const added = addSequantToMcpConfig(client.configPath);
+        const added = addSequantToMcpConfig(
+          client.configPath,
+          client.clientType,
+        );
         if (added) {
           ui.printStatus("success", `Added Sequant MCP to ${client.name}`);
         } else {

--- a/src/lib/mcp-config.test.ts
+++ b/src/lib/mcp-config.test.ts
@@ -19,6 +19,68 @@ describe("mcp-config", () => {
       expect(config.command).toBe("npx");
       expect(config.args).toEqual(["sequant@latest", "serve"]);
     });
+
+    it("should include cwd for claude-desktop", () => {
+      const config = getSequantMcpConfig({
+        projectDir: "/my/project",
+        clientType: "claude-desktop",
+      });
+      expect(config.cwd).toBe("/my/project");
+    });
+
+    it("should include cwd for vscode-continue", () => {
+      const config = getSequantMcpConfig({
+        projectDir: "/my/project",
+        clientType: "vscode-continue",
+      });
+      expect(config.cwd).toBe("/my/project");
+    });
+
+    it("should omit cwd for cursor", () => {
+      const config = getSequantMcpConfig({
+        projectDir: "/my/project",
+        clientType: "cursor",
+      });
+      expect(config.cwd).toBeUndefined();
+    });
+
+    it("should fall back to process.cwd() when projectDir is omitted for claude-desktop", () => {
+      const config = getSequantMcpConfig({
+        clientType: "claude-desktop",
+      });
+      expect(config.cwd).toBe(process.cwd());
+    });
+
+    it("should omit cwd when no clientType is given", () => {
+      const config = getSequantMcpConfig({ projectDir: "/my/project" });
+      expect(config.cwd).toBeUndefined();
+    });
+
+    describe("env.ANTHROPIC_API_KEY", () => {
+      const originalEnv = process.env.ANTHROPIC_API_KEY;
+
+      afterEach(() => {
+        if (originalEnv !== undefined) {
+          process.env.ANTHROPIC_API_KEY = originalEnv;
+        } else {
+          delete process.env.ANTHROPIC_API_KEY;
+        }
+      });
+
+      it("should include env when ANTHROPIC_API_KEY is set", () => {
+        process.env.ANTHROPIC_API_KEY = "sk-ant-test-key";
+        const config = getSequantMcpConfig();
+        expect(config.env).toEqual({
+          ANTHROPIC_API_KEY: "sk-ant-test-key",
+        });
+      });
+
+      it("should omit env when ANTHROPIC_API_KEY is not set", () => {
+        delete process.env.ANTHROPIC_API_KEY;
+        const config = getSequantMcpConfig();
+        expect(config.env).toBeUndefined();
+      });
+    });
   });
 
   describe("detectMcpClients", () => {
@@ -31,12 +93,22 @@ describe("mcp-config", () => {
       expect(names).toContain("VS Code + Continue");
     });
 
-    it("should have configPath for each client", () => {
+    it("should have configPath and clientType for each client", () => {
       const clients = detectMcpClients();
       for (const client of clients) {
         expect(client.configPath).toBeTruthy();
         expect(typeof client.exists).toBe("boolean");
+        expect(client.clientType).toBeTruthy();
       }
+    });
+
+    it("should assign correct clientType to each client", () => {
+      const clients = detectMcpClients();
+      const byName = Object.fromEntries(clients.map((c) => [c.name, c]));
+
+      expect(byName["Claude Desktop"].clientType).toBe("claude-desktop");
+      expect(byName["Cursor"].clientType).toBe("cursor");
+      expect(byName["VS Code + Continue"].clientType).toBe("vscode-continue");
     });
   });
 
@@ -93,6 +165,22 @@ describe("mcp-config", () => {
 
       const content = JSON.parse(fs.readFileSync(testConfig, "utf-8"));
       expect(content.mcpServers.sequant).toBeDefined();
+    });
+
+    it("should include cwd when clientType is claude-desktop", () => {
+      const result = addSequantToMcpConfig(testConfig, "claude-desktop");
+      expect(result).toBe(true);
+
+      const content = JSON.parse(fs.readFileSync(testConfig, "utf-8"));
+      expect(content.mcpServers.sequant.cwd).toBe(process.cwd());
+    });
+
+    it("should omit cwd when clientType is cursor", () => {
+      const result = addSequantToMcpConfig(testConfig, "cursor");
+      expect(result).toBe(true);
+
+      const content = JSON.parse(fs.readFileSync(testConfig, "utf-8"));
+      expect(content.mcpServers.sequant.cwd).toBeUndefined();
     });
   });
 });

--- a/src/lib/mcp-config.ts
+++ b/src/lib/mcp-config.ts
@@ -9,20 +9,49 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 
+export type McpClientType = "claude-desktop" | "cursor" | "vscode-continue";
+
 export interface McpClientInfo {
   name: string;
+  clientType: McpClientType;
   configPath: string;
   exists: boolean;
 }
 
 /**
- * Sequant MCP server configuration entry
+ * Clients that need an explicit cwd because they don't run from the project directory.
  */
-export function getSequantMcpConfig(): Record<string, unknown> {
-  return {
+const CLIENTS_NEEDING_CWD: ReadonlySet<McpClientType> = new Set([
+  "claude-desktop",
+  "vscode-continue",
+]);
+
+/**
+ * Sequant MCP server configuration entry.
+ *
+ * @param options.projectDir - Absolute project path (used as cwd for clients that need it)
+ * @param options.clientType - Target client; determines whether cwd/env are included
+ */
+export function getSequantMcpConfig(options?: {
+  projectDir?: string;
+  clientType?: McpClientType;
+}): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     command: "npx",
     args: ["sequant@latest", "serve"],
   };
+
+  // Add cwd for clients that don't run from the project directory
+  if (options?.clientType && CLIENTS_NEEDING_CWD.has(options.clientType)) {
+    config.cwd = options.projectDir ?? process.cwd();
+  }
+
+  // Only include ANTHROPIC_API_KEY when it is actually set
+  if (process.env.ANTHROPIC_API_KEY) {
+    config.env = { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY };
+  }
+
+  return config;
 }
 
 /**
@@ -54,6 +83,7 @@ export function detectMcpClients(): McpClientInfo[] {
 
   clients.push({
     name: "Claude Desktop",
+    clientType: "claude-desktop",
     configPath: claudeDesktopConfig,
     exists: fs.existsSync(claudeDesktopConfig),
   });
@@ -62,6 +92,7 @@ export function detectMcpClients(): McpClientInfo[] {
   const cursorConfig = path.join(process.cwd(), ".cursor", "mcp.json");
   clients.push({
     name: "Cursor",
+    clientType: "cursor",
     configPath: cursorConfig,
     exists: fs.existsSync(path.join(process.cwd(), ".cursor")),
   });
@@ -70,6 +101,7 @@ export function detectMcpClients(): McpClientInfo[] {
   const vscodeConfig = path.join(home, ".continue", "config.json");
   clients.push({
     name: "VS Code + Continue",
+    clientType: "vscode-continue",
     configPath: vscodeConfig,
     exists: fs.existsSync(vscodeConfig),
   });
@@ -81,8 +113,14 @@ export function detectMcpClients(): McpClientInfo[] {
  * Add Sequant MCP server to a client's config file.
  * Returns true if written, false if already configured.
  */
-export function addSequantToMcpConfig(configPath: string): boolean {
-  const sequantConfig = getSequantMcpConfig();
+export function addSequantToMcpConfig(
+  configPath: string,
+  clientType?: McpClientType,
+): boolean {
+  const sequantConfig = getSequantMcpConfig({
+    projectDir: process.cwd(),
+    clientType,
+  });
 
   let config: Record<string, unknown> = {};
   if (fs.existsSync(configPath)) {


### PR DESCRIPTION
## Summary

- `getSequantMcpConfig()` now accepts `projectDir` and `clientType` parameters to generate client-appropriate configs
- Claude Desktop and VS Code + Continue configs include `cwd` (absolute project path); Cursor omits it
- `env.ANTHROPIC_API_KEY` is only included when the env var is actually set (no placeholder that confuses Max plan users)
- `sequant init` passes client type through to config generation

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | `getSequantMcpConfig()` accepts `projectDir` and `clientType` | ✅ | `src/lib/mcp-config.ts:35-38` |
| AC-2 | Claude Desktop config includes `cwd` | ✅ | `CLIENTS_NEEDING_CWD` set, tests verify |
| AC-3 | Cursor config omits `cwd` | ✅ | Not in `CLIENTS_NEEDING_CWD`, tests verify |
| AC-4 | `env.ANTHROPIC_API_KEY` only when set | ✅ | `mcp-config.ts:50-52`, env tests |
| AC-5 | `sequant init` generates per-client configs | ✅ | `init.ts:565-568` passes `client.clientType` |
| AC-6 | Docs match generated configs | ✅ | Updated `mcp-server.md` note |
| AC-7 | Tests cover per-client config | ✅ | 17 tests including per-client cases |

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 1843/1843 pass
- [x] Per-client config tests verify cwd inclusion/omission
- [x] env.ANTHROPIC_API_KEY tests verify conditional inclusion

Closes #395