### PR TITLE
fix(#403): surface non-fatal warnings in all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add file locking (`O_EXCL`) around read-modify-write cycles in `StateManager`
   - Stale lock detection with configurable timeout prevents deadlocks
   - No API changes; existing CLI and callers work without modification
+- Surface non-fatal warning messages in all modes, not just verbose (#403)
+  - State reconciliation, state lookup, and metrics recording failures now always show a one-line warning
+  - Verbose mode continues to show additional error details
 - Fix MCP config generation producing identical configs for all clients (#395)
   - Claude Desktop and VS Code + Continue configs now include `cwd` (absolute project path)
   - Cursor config omits `cwd` (runs from workspace root)

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "child_process";
 
 // Mock child_process
@@ -34,6 +34,7 @@ import {
   removeStaleWorktree,
   createPR,
   detectDefaultBranch,
+  logNonFatalWarning,
 } from "./run.js";
 
 const mockGetResumablePhasesForIssue = vi.mocked(getResumablePhasesForIssue);
@@ -2250,5 +2251,42 @@ describe("filterResumedPhases", () => {
     const original = ["spec", "exec", "qa"] as any[];
     filterResumedPhases(42, original, false);
     expect(original).toEqual(["spec", "exec", "qa"]);
+  });
+});
+
+describe("logNonFatalWarning", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("should always log the warning message regardless of verbose", () => {
+    logNonFatalWarning("warning message", new Error("details"), false);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0][0]).toContain("warning message");
+  });
+
+  it("should log error details only in verbose mode", () => {
+    const error = new Error("something broke");
+    logNonFatalWarning("warning message", error, true);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2);
+    expect(consoleSpy.mock.calls[0][0]).toContain("warning message");
+    expect(consoleSpy.mock.calls[1][0]).toContain("something broke");
+  });
+
+  it("should not log error details when verbose is false", () => {
+    logNonFatalWarning("warning message", new Error("secret"), false);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    // Only the warning, not the error detail
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join(" ");
+    expect(allOutput).not.toContain("secret");
   });
 });

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -35,6 +35,18 @@ import { getTokenUsageForRun } from "../lib/workflow/token-utils.js";
 import { reconcileStateAtStartup } from "../lib/workflow/state-utils.js";
 import { analyzeRun, formatReflection } from "../lib/workflow/run-reflect.js";
 
+/** @internal Log a non-fatal warning: one-line summary always, detail in verbose. */
+export function logNonFatalWarning(
+  message: string,
+  error: unknown,
+  verbose: boolean,
+): void {
+  console.log(chalk.yellow(message));
+  if (verbose) {
+    console.log(chalk.gray(`    ${error}`));
+  }
+}
+
 // Extracted modules
 import {
   detectDefaultBranch,
@@ -428,13 +440,13 @@ export async function runCommand(
           ),
         );
       }
-    } catch {
+    } catch (error) {
       // AC-8: Graceful degradation - don't block execution on reconciliation failure
-      if (config.verbose) {
-        console.log(
-          chalk.yellow(`  ⚠️  State reconciliation failed, continuing...`),
-        );
-      }
+      logNonFatalWarning(
+        `  ⚠️  State reconciliation failed, continuing...`,
+        error,
+        config.verbose,
+      );
     }
   }
 
@@ -460,8 +472,13 @@ export async function runCommand(
         } else {
           activeIssues.push(issueNumber);
         }
-      } catch {
+      } catch (error) {
         // AC-8: Graceful degradation - if state check fails, include the issue
+        logNonFatalWarning(
+          `  ⚠️  State lookup failed for #${issueNumber}, including anyway...`,
+          error,
+          config.verbose,
+        );
         activeIssues.push(issueNumber);
       }
     }
@@ -851,11 +868,11 @@ export async function runCommand(
         }
       } catch (metricsError) {
         // Metrics recording errors shouldn't stop execution
-        if (config.verbose) {
-          console.log(
-            chalk.yellow(`  ⚠️  Metrics recording error: ${metricsError}`),
-          );
-        }
+        logNonFatalWarning(
+          `  ⚠️  Metrics recording failed, continuing...`,
+          metricsError,
+          config.verbose,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- State reconciliation, state lookup, and metrics recording failures now always log a one-line yellow warning regardless of `--verbose`
- Verbose mode continues to show additional error details (stack trace / full error object)
- Extracted `logNonFatalWarning` helper for DRY consistency across all three catch blocks
- Added 3 unit tests for the warning pattern

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | State reconciliation warnings in all modes | ✅ | `run.ts:443` — removed verbose guard |
| AC-2 | Metrics recording warnings in all modes | ✅ | `run.ts:873` — removed verbose guard |
| AC-3 | State guard logs which issue failed and why | ✅ | `run.ts:478` — includes `#${issueNumber}` in message |
| AC-4 | Verbose shows additional detail | ✅ | `logNonFatalWarning` logs `chalk.gray` detail only when verbose=true |
| AC-5 | No change to control flow | ✅ | All catch blocks still continue execution |
| AC-6 | Tests pass + new coverage | ✅ | 3 new tests for `logNonFatalWarning` |

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` — 123/123 pass in run.test.ts (3 pre-existing timeouts in unrelated state tests)
- [ ] Manual: `sequant run` with corrupt `.sequant/state.json` shows warning without `--verbose`
- [ ] Manual: `sequant run --verbose` shows warning + error details

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)