### PR TITLE
feat(#435): MCP progress notifications with timeout reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `sequant stats --detailed` for QA verdict distribution, temporal trends, and per-label segmentation (#437)
 - Add `scripts/analytics/analyze-runs.ts` for bulk run log analysis with baselines, failure forensics, and first-pass QA rate (#437)
+- Add MCP progress notifications for `sequant_run` with timeout reset (#435)
+  - Batch executor emits start, complete, and failed events via `SEQUANT_PROGRESS:` lines
+  - Event-appropriate messages: `#N: phase started`, `#N: phase ✓ (Ns)`, `#N: phase ✗ — error`
+  - Spawn timeout resets on each progress event (30min per-phase, 2hr absolute ceiling)
+  - Only complete/failed events increment the progress counter; start events are informational
 - Add `"assess"` signal source and `sequant:assess` CI trigger label with backward-compatible `"solve"` / `sequant:solve` deprecation (#438)
 - Optimize QA skill re-runs by diffing against prior findings (#377)
   - Add `commitSHA` field to phase markers for incremental QA baseline tracking

--- a/__tests__/integration/mcp-progress-notifications.integration.test.ts
+++ b/__tests__/integration/mcp-progress-notifications.integration.test.ts
@@ -47,8 +47,17 @@ interface ProgressNotification {
 }
 
 /** Helper: build a SEQUANT_PROGRESS line as the batch executor emits it */
-function progressLine(issue: number, phase: string): string {
-  return `SEQUANT_PROGRESS:${JSON.stringify({ issue, phase })}\n`;
+function progressLine(
+  issue: number,
+  phase: string,
+  event: "start" | "complete" | "failed" = "start",
+  extra?: { durationSeconds?: number; error?: string },
+): string {
+  const payload: Record<string, unknown> = { issue, phase, event };
+  if (extra?.durationSeconds !== undefined)
+    payload.durationSeconds = extra.durationSeconds;
+  if (extra?.error !== undefined) payload.error = extra.error;
+  return `SEQUANT_PROGRESS:${JSON.stringify(payload)}\n`;
 }
 
 /** Create a mock ChildProcess with controllable stderr chunks for progress simulation */
@@ -135,16 +144,19 @@ describe.skipIf(!mcpSdkAvailable)(
     });
 
     describe("AC-2: Phase transitions emit notifications/progress", () => {
-      it("should emit progress notifications for each phase start on stderr", async () => {
+      it("should emit progress notifications for each phase event on stderr", async () => {
         const progressEvents: ProgressNotification[] = [];
 
         mockedSpawn.mockImplementation(() =>
           createMockProcessWithPhaseOutput({
             exitCode: 0,
             stderrChunks: [
-              progressLine(421, "spec"),
-              progressLine(421, "exec"),
-              progressLine(421, "qa"),
+              progressLine(421, "spec", "start"),
+              progressLine(421, "spec", "complete", { durationSeconds: 10 }),
+              progressLine(421, "exec", "start"),
+              progressLine(421, "exec", "complete", { durationSeconds: 20 }),
+              progressLine(421, "qa", "start"),
+              progressLine(421, "qa", "complete", { durationSeconds: 15 }),
             ],
           }),
         );
@@ -162,35 +174,33 @@ describe.skipIf(!mcpSdkAvailable)(
 
         await new Promise((r) => setTimeout(r, 50));
 
-        // Should emit 3 notifications (one per phase)
-        expect(progressEvents).toHaveLength(3);
-        expect(progressEvents[0]).toMatchObject({
-          progress: 1,
-          total: 3,
-        });
+        // 6 events: 3 starts + 3 completes
+        expect(progressEvents).toHaveLength(6);
+        // Start events don't increment progress
+        expect(progressEvents[0]).toMatchObject({ progress: 0, total: 3 });
         expect(progressEvents[0].message).toContain("spec");
-        expect(progressEvents[1]).toMatchObject({
-          progress: 2,
-          total: 3,
-        });
-        expect(progressEvents[1].message).toContain("exec");
-        expect(progressEvents[2]).toMatchObject({
-          progress: 3,
-          total: 3,
-        });
-        expect(progressEvents[2].message).toContain("qa");
+        expect(progressEvents[0].message).toContain("started");
+        // Complete events increment progress
+        expect(progressEvents[1]).toMatchObject({ progress: 1, total: 3 });
+        expect(progressEvents[1].message).toContain("spec");
+        // Exec start (still progress=1)
+        expect(progressEvents[2]).toMatchObject({ progress: 1, total: 3 });
+        // Exec complete (progress=2)
+        expect(progressEvents[3]).toMatchObject({ progress: 2, total: 3 });
+        // QA complete (progress=3)
+        expect(progressEvents[5]).toMatchObject({ progress: 3, total: 3 });
       });
 
-      it("should include incrementing progress counter", async () => {
+      it("should include incrementing progress counter on complete events", async () => {
         const progressValues: number[] = [];
 
         mockedSpawn.mockImplementation(() =>
           createMockProcessWithPhaseOutput({
             exitCode: 0,
             stderrChunks: [
-              progressLine(421, "spec"),
-              progressLine(421, "exec"),
-              progressLine(421, "qa"),
+              progressLine(421, "spec", "complete", { durationSeconds: 10 }),
+              progressLine(421, "exec", "complete", { durationSeconds: 20 }),
+              progressLine(421, "qa", "complete", { durationSeconds: 15 }),
             ],
           }),
         );
@@ -217,7 +227,7 @@ describe.skipIf(!mcpSdkAvailable)(
         mockedSpawn.mockImplementation(() =>
           createMockProcessWithPhaseOutput({
             exitCode: 0,
-            stderrChunks: [progressLine(421, "spec")],
+            stderrChunks: [progressLine(421, "spec", "start")],
           }),
         );
 
@@ -243,10 +253,17 @@ describe.skipIf(!mcpSdkAvailable)(
         const { parseProgressLine } =
           await import("../../src/mcp/tools/run.js");
 
-        // Standard format from batch executor
+        // New format requires event field
+        expect(
+          parseProgressLine(
+            'SEQUANT_PROGRESS:{"issue":123,"phase":"spec","event":"start"}',
+          ),
+        ).toEqual({ issue: 123, phase: "spec", event: "start" });
+
+        // Old format (without event) returns null
         expect(
           parseProgressLine('SEQUANT_PROGRESS:{"issue":123,"phase":"spec"}'),
-        ).toEqual({ issue: 123, phase: "spec" });
+        ).toBeNull();
 
         // Non-progress lines should NOT match
         expect(parseProgressLine("some random log")).toBeNull();
@@ -260,9 +277,9 @@ describe.skipIf(!mcpSdkAvailable)(
           createMockProcessWithPhaseOutput({
             exitCode: 0,
             stderrChunks: [
-              progressLine(421, "spec"),
-              progressLine(421, "exec"),
-              progressLine(421, "qa"),
+              progressLine(421, "spec", "start"),
+              progressLine(421, "exec", "start"),
+              progressLine(421, "qa", "start"),
             ],
           }),
         );
@@ -342,7 +359,7 @@ describe.skipIf(!mcpSdkAvailable)(
             exitCode: 0,
             stderrChunks: [
               "warning: something\n",
-              progressLine(421, "exec"),
+              progressLine(421, "exec", "start"),
               "error detail\n",
             ],
           }),
@@ -373,7 +390,7 @@ describe.skipIf(!mcpSdkAvailable)(
         mockedSpawn.mockImplementation(() =>
           createMockProcessWithPhaseOutput({
             exitCode: 0,
-            stderrChunks: [progressLine(100, "spec")],
+            stderrChunks: [progressLine(100, "spec", "start")],
           }),
         );
 

--- a/__tests__/mcp-progress-notifications.test.ts
+++ b/__tests__/mcp-progress-notifications.test.ts
@@ -104,17 +104,26 @@ interface ProgressNotification {
 }
 
 /** Helper: build a SEQUANT_PROGRESS line as the batch executor emits it */
-function progressLine(issue: number, phase: string): string {
-  return `SEQUANT_PROGRESS:${JSON.stringify({ issue, phase })}\n`;
+function progressLine(
+  issue: number,
+  phase: string,
+  event: "start" | "complete" | "failed" = "start",
+  extra?: { durationSeconds?: number; error?: string },
+): string {
+  const payload: Record<string, unknown> = { issue, phase, event };
+  if (extra?.durationSeconds !== undefined)
+    payload.durationSeconds = extra.durationSeconds;
+  if (extra?.error !== undefined) payload.error = extra.error;
+  return `SEQUANT_PROGRESS:${JSON.stringify(payload)}\n`;
 }
 
 describe("parseProgressLine", () => {
-  it("should parse a valid progress line", async () => {
+  it("should parse a valid progress line with event field", async () => {
     const { parseProgressLine } = await import("../src/mcp/tools/run.js");
     const result = parseProgressLine(
-      'SEQUANT_PROGRESS:{"issue":123,"phase":"spec"}',
+      'SEQUANT_PROGRESS:{"issue":123,"phase":"spec","event":"start"}',
     );
-    expect(result).toEqual({ issue: 123, phase: "spec" });
+    expect(result).toEqual({ issue: 123, phase: "spec", event: "start" });
   });
 
   it("should return null for non-progress lines", async () => {
@@ -131,11 +140,22 @@ describe("parseProgressLine", () => {
 
   it("should return null for JSON missing required fields", async () => {
     const { parseProgressLine } = await import("../src/mcp/tools/run.js");
-    expect(parseProgressLine('SEQUANT_PROGRESS:{"issue":123}')).toBeNull();
-    expect(parseProgressLine('SEQUANT_PROGRESS:{"phase":"spec"}')).toBeNull();
+    // Missing event field
+    expect(
+      parseProgressLine('SEQUANT_PROGRESS:{"issue":123,"phase":"spec"}'),
+    ).toBeNull();
+    // Missing phase field
+    expect(
+      parseProgressLine('SEQUANT_PROGRESS:{"issue":123,"event":"start"}'),
+    ).toBeNull();
+    // Missing issue field
+    expect(
+      parseProgressLine('SEQUANT_PROGRESS:{"phase":"spec","event":"start"}'),
+    ).toBeNull();
+    // Non-numeric issue
     expect(
       parseProgressLine(
-        'SEQUANT_PROGRESS:{"issue":"not-a-number","phase":"spec"}',
+        'SEQUANT_PROGRESS:{"issue":"not-a-number","phase":"spec","event":"start"}',
       ),
     ).toBeNull();
   });
@@ -230,7 +250,10 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       mockedSpawn.mockImplementation(() =>
         createMockProcess({
           exitCode: 0,
-          stderrChunks: [progressLine(421, "spec")],
+          stderrChunks: [
+            progressLine(421, "spec", "start"),
+            progressLine(421, "spec", "complete", { durationSeconds: 10 }),
+          ],
         }),
       );
 
@@ -248,9 +271,12 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       // Allow fire-and-forget notification to propagate
       await new Promise((r) => setTimeout(r, 50));
 
-      expect(progressEvents.length).toBeGreaterThanOrEqual(1);
-      expect(progressEvents[0].progress).toBe(1);
+      expect(progressEvents.length).toBeGreaterThanOrEqual(2);
+      // Start event: progress stays at 0 (only complete/failed increment)
+      expect(progressEvents[0].progress).toBe(0);
       expect(progressEvents[0].total).toBe(3);
+      // Complete event: progress increments to 1
+      expect(progressEvents[1].progress).toBe(1);
     });
 
     it("should handle missing _meta gracefully", async () => {
@@ -275,7 +301,7 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       mockedSpawn.mockImplementation(() =>
         createMockProcess({
           exitCode: 0,
-          stderrChunks: [progressLine(421, "spec")],
+          stderrChunks: [progressLine(421, "spec", "start")],
         }),
       );
 
@@ -305,9 +331,9 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
         createMockProcess({
           exitCode: 0,
           stderrChunks: [
-            progressLine(100, "spec"),
-            progressLine(200, "spec"),
-            progressLine(100, "exec"),
+            progressLine(100, "spec", "start"),
+            progressLine(200, "spec", "start"),
+            progressLine(100, "exec", "start"),
           ],
         }),
       );
@@ -342,7 +368,7 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       mockedSpawn.mockImplementation(() =>
         createMockProcess({
           exitCode: 0,
-          stderrChunks: [progressLine(100, "spec")],
+          stderrChunks: [progressLine(100, "spec", "start")],
         }),
       );
 
@@ -370,7 +396,7 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       mockedSpawn.mockImplementation(() =>
         createMockProcess({
           exitCode: 0,
-          stderrChunks: [progressLine(100, "spec")],
+          stderrChunks: [progressLine(100, "spec", "start")],
         }),
       );
 
@@ -400,7 +426,7 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       mockedSpawn.mockImplementation(() =>
         createMockProcess({
           exitCode: 0,
-          stderrChunks: [progressLine(100, "exec")],
+          stderrChunks: [progressLine(100, "exec", "start")],
         }),
       );
 
@@ -427,7 +453,10 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       mockedSpawn.mockImplementation(() =>
         createMockProcess({
           exitCode: 0,
-          stderrChunks: [progressLine(421, "spec"), progressLine(421, "exec")],
+          stderrChunks: [
+            progressLine(421, "spec", "start"),
+            progressLine(421, "exec", "start"),
+          ],
         }),
       );
 
@@ -447,9 +476,9 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
         createMockProcess({
           exitCode: 0,
           stderrChunks: [
-            progressLine(421, "spec"),
-            progressLine(421, "exec"),
-            progressLine(421, "qa"),
+            progressLine(421, "spec", "start"),
+            progressLine(421, "exec", "start"),
+            progressLine(421, "qa", "start"),
           ],
         }),
       );
@@ -475,7 +504,9 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
     it("should handle progress line split across stderr chunks", async () => {
       const progressEvents: ProgressNotification[] = [];
 
-      const fullLine = `SEQUANT_PROGRESS:{"issue":421,"phase":"spec"}\n`;
+      const fullLine = progressLine(421, "spec", "complete", {
+        durationSeconds: 5,
+      });
       const split1 = fullLine.slice(0, 20);
       const split2 = fullLine.slice(20);
 
@@ -500,6 +531,7 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(progressEvents).toHaveLength(1);
+      // Complete event increments progress
       expect(progressEvents[0].progress).toBe(1);
     });
 
@@ -510,9 +542,9 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
         createMockProcess({
           exitCode: 0,
           stderrChunks: [
-            progressLine(421, "spec") +
-              progressLine(421, "exec") +
-              progressLine(421, "qa"),
+            progressLine(421, "spec", "complete", { durationSeconds: 10 }) +
+              progressLine(421, "exec", "complete", { durationSeconds: 20 }) +
+              progressLine(421, "qa", "complete", { durationSeconds: 30 }),
           ],
         }),
       );
@@ -531,6 +563,7 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(progressEvents).toHaveLength(3);
+      // Complete events increment progress: 1, 2, 3
       expect(progressEvents.map((e) => e.progress)).toEqual([1, 2, 3]);
     });
 
@@ -541,7 +574,9 @@ describe.skipIf(!mcpSdkAvailable)("MCP Progress Notifications (#421)", () => {
         createMockProcess({
           exitCode: 0,
           stderrChunks: [
-            "some warning\n" + progressLine(421, "spec") + "another warning\n",
+            "some warning\n" +
+              progressLine(421, "spec", "start") +
+              "another warning\n",
           ],
         }),
       );

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -171,7 +171,7 @@ Once set up, talk to your AI assistant naturally:
 
 ### During a run
 
-- **Progress notifications.** If your MCP client supports progress tokens (Claude Desktop, Cursor, and most SDK-based clients do), you'll receive real-time phase transition updates automatically — no polling needed. The server sends `notifications/progress` at each phase start, which also prevents client-side timeouts.
+- **Progress notifications.** If your MCP client supports progress tokens (Claude Desktop, Cursor, and most SDK-based clients do), you'll receive real-time phase updates automatically — no polling needed. The server sends `notifications/progress` at phase start, completion, and failure. Messages include timing and error details (e.g., `#42: exec ✓ (120s)` or `#42: qa ✗ — timeout`). Each progress notification also resets the server-side spawn timeout, so long-running but progressing workflows won't be killed.
 - **It takes time.** A full spec+exec+qa cycle typically takes 10–20 minutes per issue. Don't assume it's stuck.
 - **Check progress manually** by asking for `sequant_status` on the issue. The server stays responsive while a run is in progress — status checks and log queries return immediately.
 - **Cancel if needed.** Your MCP client can abort a running `sequant_run` call. The subprocess and its children are cleaned up automatically (SIGTERM, then SIGKILL after 5 seconds if needed).
@@ -225,7 +225,13 @@ Execute workflow phases for GitHub issues.
 | `qualityLoop` | `boolean` | No | `false` | Auto-retry on QA failure |
 | `agent` | `string` | No | configured default | Agent backend to use |
 
-**Progress notifications:** When the client sends a `progressToken` in `_meta`, the server emits `notifications/progress` at each phase start. Each notification includes the issue number, phase name, current step, and total steps. Most MCP clients send progress tokens automatically and use them to prevent tool-call timeouts — no configuration needed.
+**Progress notifications:** When the client sends a `progressToken` in `_meta`, the server emits `notifications/progress` at each phase boundary — start, completion, and failure. Each notification includes:
+
+- `progress` — completed phases so far (increments on complete/failed events only)
+- `total` — total expected phases (issues × phases)
+- `message` — human-readable status (e.g., `#42: spec started`, `#42: exec ✓ (120s)`, `#42: qa ✗ — timeout`)
+
+Progress notifications also reset the server-side spawn timeout (30-minute per-phase ceiling, 2-hour absolute maximum), preventing premature process kills on long-running but progressing workflows. When no `progressToken` is provided, the server falls back to a fixed 30-minute timeout with identical behavior to previous versions.
 
 **Response** (structured JSON):
 
@@ -372,10 +378,11 @@ If `sequant_run` behaves differently than your local `sequant run`, you may have
 
 ### Client reports a timeout
 
-Most clients reset their timeout automatically when they receive progress notifications — and the server sends these at every phase transition. If you still hit timeouts:
+The server resets its own spawn timeout on each progress event (30-minute per-phase ceiling, 2-hour absolute max), and most clients also reset their client-side timeout when they receive `notifications/progress`. If you still hit timeouts:
 
 1. Check that your client supports `resetTimeoutOnProgress` (Claude Desktop and Cursor do)
-2. Run phases individually instead of a full workflow:
+2. For multi-issue runs exceeding 2 hours, split into smaller batches
+3. Run phases individually instead of a full workflow:
    > "Use sequant to run only the spec phase for issue #42"
 
 ### Sequant can't find the project (Claude Desktop)
@@ -396,4 +403,4 @@ Only one SSE client can connect at a time. If you see `409 Conflict`:
 2. Disconnect the existing client, or wait for it to time out
 3. Verify with `GET /health` — `connected: false` means the slot is free
 
-*Generated for Issue #372 / PR #387 on 2026-03-23. Updated for #396 (optional SDK), #388 (async execution, cancellation), #389 (version consistency), #391 (structured response format), #394 (real-time progress reporting), #390 (SSE multi-client rejection, health connection status), #392 (non-interactive MCP opt-in), #395 (per-client config generation) on 2026-03-24. Updated for #420 (server instructions, tool annotations, improved descriptions), #421 (progress notifications for sequant_run), #423 (status reconciliation with GitHub) on 2026-03-25.*
+*Generated for Issue #372 / PR #387 on 2026-03-23. Updated for #396 (optional SDK), #388 (async execution, cancellation), #389 (version consistency), #391 (structured response format), #394 (real-time progress reporting), #390 (SSE multi-client rejection, health connection status), #392 (non-interactive MCP opt-in), #395 (per-client config generation) on 2026-03-24. Updated for #420 (server instructions, tool annotations, improved descriptions), #421 (progress notifications for sequant_run), #423 (status reconciliation with GitHub) on 2026-03-25. Updated for #435 (progress event lifecycle, timeout reset, event-appropriate messages) on 2026-03-25.*

--- a/src/lib/workflow/batch-executor.ts
+++ b/src/lib/workflow/batch-executor.ts
@@ -36,10 +36,27 @@ import {
  * Emit a structured progress line to stderr for MCP progress notifications.
  * Only emits when running under an orchestrator (e.g., MCP server).
  * The MCP handler parses these lines to send `notifications/progress`.
+ *
+ * @param issue - GitHub issue number
+ * @param phase - Phase name (e.g., "spec", "exec", "qa")
+ * @param event - Phase lifecycle event: "start", "complete", or "failed"
+ * @param extra - Optional fields: durationSeconds (on complete), error (on failed)
  */
-function emitProgressLine(issue: number, phase: string): void {
+export function emitProgressLine(
+  issue: number,
+  phase: string,
+  event: "start" | "complete" | "failed" = "start",
+  extra?: { durationSeconds?: number; error?: string },
+): void {
   if (!process.env.SEQUANT_ORCHESTRATOR) return;
-  const line = `SEQUANT_PROGRESS:${JSON.stringify({ issue, phase })}\n`;
+  const payload: Record<string, unknown> = { issue, phase, event };
+  if (extra?.durationSeconds !== undefined) {
+    payload.durationSeconds = extra.durationSeconds;
+  }
+  if (extra?.error !== undefined) {
+    payload.error = extra.error;
+  }
+  const line = `SEQUANT_PROGRESS:${JSON.stringify(payload)}\n`;
   process.stderr.write(line);
 }
 
@@ -467,7 +484,7 @@ export async function runIssueWithLogging(
             shutdownManager,
           });
       specSpinner?.start();
-      emitProgressLine(issueNumber, "spec");
+      emitProgressLine(issueNumber, "spec", "start");
 
       // Track spec phase start in state
       if (stateManager) {
@@ -512,6 +529,20 @@ export async function runIssueWithLogging(
 
       phaseResults.push(specResult);
       specAlreadyRan = true;
+
+      // Emit completion/failure progress event (AC-8)
+      const specDurationSec = Math.round(
+        (specEndTime.getTime() - specStartTime.getTime()) / 1000,
+      );
+      if (specResult.success) {
+        emitProgressLine(issueNumber, "spec", "complete", {
+          durationSeconds: specDurationSec,
+        });
+      } else {
+        emitProgressLine(issueNumber, "spec", "failed", {
+          error: specResult.error ?? "unknown",
+        });
+      }
 
       // Log spec phase result
       // Note: Spec runs in main repo, not worktree, so no git diff stats
@@ -674,7 +705,7 @@ export async function runIssueWithLogging(
             iteration: useQualityLoop ? iteration : undefined,
           });
       phaseSpinner?.start();
-      emitProgressLine(issueNumber, phase);
+      emitProgressLine(issueNumber, phase, "start");
 
       // Track phase start in state
       if (stateManager) {
@@ -715,6 +746,20 @@ export async function runIssueWithLogging(
       }
 
       phaseResults.push(result);
+
+      // Emit completion/failure progress event (AC-8)
+      const phaseDurationSec = Math.round(
+        (phaseEndTime.getTime() - phaseStartTime.getTime()) / 1000,
+      );
+      if (result.success) {
+        emitProgressLine(issueNumber, phase, "complete", {
+          durationSeconds: phaseDurationSec,
+        });
+      } else {
+        emitProgressLine(issueNumber, phase, "failed", {
+          error: result.error ?? "unknown",
+        });
+      }
 
       // Log phase result with observability data (AC-1, AC-2, AC-3, AC-7)
       if (logWriter) {
@@ -793,8 +838,9 @@ export async function runIssueWithLogging(
                 iteration,
               });
           loopSpinner?.start();
-          emitProgressLine(issueNumber, "loop");
+          emitProgressLine(issueNumber, "loop", "start");
 
+          const loopStartTime = new Date();
           const loopResult = await executePhaseWithRetry(
             issueNumber,
             "loop",
@@ -804,7 +850,22 @@ export async function runIssueWithLogging(
             shutdownManager,
             loopSpinner,
           );
+          const loopEndTime = new Date();
           phaseResults.push(loopResult);
+
+          // Emit loop completion/failure progress event (AC-8)
+          const loopDurationSec = Math.round(
+            (loopEndTime.getTime() - loopStartTime.getTime()) / 1000,
+          );
+          if (loopResult.success) {
+            emitProgressLine(issueNumber, "loop", "complete", {
+              durationSeconds: loopDurationSec,
+            });
+          } else {
+            emitProgressLine(issueNumber, "loop", "failed", {
+              error: loopResult.error ?? "unknown",
+            });
+          }
 
           if (loopResult.sessionId) {
             sessionId = loopResult.sessionId;

--- a/src/mcp/tools/run.test.ts
+++ b/src/mcp/tools/run.test.ts
@@ -1,15 +1,27 @@
 /**
- * Unit tests for sequant_run structured output (Issue #391)
+ * Unit tests for sequant_run MCP tool (Issues #391, #435)
  *
- * Tests buildStructuredResponse and readLatestRunLog directly
- * without MCP server infrastructure.
+ * Tests buildStructuredResponse, readLatestRunLog, and progress notification
+ * functions (parseProgressLine, createLineBuffer, formatProgressMessage)
+ * directly without MCP server infrastructure.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { existsSync } from "fs";
 import { readdir, readFile } from "fs/promises";
-import { buildStructuredResponse, readLatestRunLog } from "./run.js";
+import {
+  buildStructuredResponse,
+  readLatestRunLog,
+  parseProgressLine,
+  createLineBuffer,
+  formatProgressMessage,
+  spawnAsync,
+  PHASE_TIMEOUT,
+  MAX_TOTAL_TIMEOUT,
+} from "./run.js";
+import type { ProgressEvent } from "./run.js";
 import type { RunLog } from "../../lib/workflow/run-log-schema.js";
+import { emitProgressLine } from "../../lib/workflow/batch-executor.js";
 
 // Mock fs.existsSync (still used synchronously in resolveLogDir)
 vi.mock("fs", async (importOriginal) => {
@@ -444,5 +456,351 @@ describe("readLatestRunLog", () => {
 
     const result = await readLatestRunLog();
     expect(result).toBeNull();
+  });
+});
+
+// ── Issue #435: Progress notification tests ──────────────────────────
+
+describe("parseProgressLine", () => {
+  it("should parse a valid start event", () => {
+    const line =
+      'SEQUANT_PROGRESS:{"issue":325,"phase":"spec","event":"start"}';
+    const result = parseProgressLine(line);
+    expect(result).toEqual({
+      issue: 325,
+      phase: "spec",
+      event: "start",
+    });
+  });
+
+  it("should parse a valid complete event with durationSeconds", () => {
+    const line =
+      'SEQUANT_PROGRESS:{"issue":325,"phase":"spec","event":"complete","durationSeconds":45}';
+    const result = parseProgressLine(line);
+    expect(result).toEqual({
+      issue: 325,
+      phase: "spec",
+      event: "complete",
+      durationSeconds: 45,
+    });
+  });
+
+  it("should parse a valid failed event with error", () => {
+    const line =
+      'SEQUANT_PROGRESS:{"issue":325,"phase":"exec","event":"failed","error":"timeout"}';
+    const result = parseProgressLine(line);
+    expect(result).toEqual({
+      issue: 325,
+      phase: "exec",
+      event: "failed",
+      error: "timeout",
+    });
+  });
+
+  it("should return null for non-progress lines", () => {
+    expect(parseProgressLine("some random stderr output")).toBeNull();
+    expect(parseProgressLine("")).toBeNull();
+    expect(parseProgressLine("SEQUANT_OTHER:data")).toBeNull();
+  });
+
+  it("should return null for invalid JSON after prefix", () => {
+    expect(parseProgressLine("SEQUANT_PROGRESS:{invalid json}")).toBeNull();
+  });
+
+  it("should return null when required fields are missing", () => {
+    // Missing event field (required in new schema)
+    expect(
+      parseProgressLine('SEQUANT_PROGRESS:{"issue":1,"phase":"spec"}'),
+    ).toBeNull();
+    // Missing phase field
+    expect(
+      parseProgressLine('SEQUANT_PROGRESS:{"issue":1,"event":"start"}'),
+    ).toBeNull();
+    // Missing issue field
+    expect(
+      parseProgressLine('SEQUANT_PROGRESS:{"phase":"spec","event":"start"}'),
+    ).toBeNull();
+  });
+
+  it("should return null for invalid event type", () => {
+    expect(
+      parseProgressLine(
+        'SEQUANT_PROGRESS:{"issue":1,"phase":"spec","event":"unknown"}',
+      ),
+    ).toBeNull();
+  });
+
+  it("should ignore non-numeric durationSeconds", () => {
+    const line =
+      'SEQUANT_PROGRESS:{"issue":1,"phase":"spec","event":"complete","durationSeconds":"fast"}';
+    const result = parseProgressLine(line);
+    expect(result).toEqual({
+      issue: 1,
+      phase: "spec",
+      event: "complete",
+    });
+    expect(result?.durationSeconds).toBeUndefined();
+  });
+});
+
+describe("createLineBuffer", () => {
+  it("should yield complete lines from a single chunk", () => {
+    const lines: string[] = [];
+    const buffer = createLineBuffer((line) => lines.push(line));
+
+    buffer("line1\nline2\n");
+    expect(lines).toEqual(["line1", "line2"]);
+  });
+
+  it("should handle partial chunks across multiple calls", () => {
+    const lines: string[] = [];
+    const buffer = createLineBuffer((line) => lines.push(line));
+
+    buffer("SEQUANT_PRO");
+    expect(lines).toEqual([]); // no complete line yet
+
+    buffer("GRESS:{}\n");
+    expect(lines).toEqual(["SEQUANT_PROGRESS:{}"]);
+  });
+
+  it("should handle multiple lines in a single chunk", () => {
+    const lines: string[] = [];
+    const buffer = createLineBuffer((line) => lines.push(line));
+
+    buffer("a\nb\nc\n");
+    expect(lines).toEqual(["a", "b", "c"]);
+  });
+
+  it("should skip empty lines", () => {
+    const lines: string[] = [];
+    const buffer = createLineBuffer((line) => lines.push(line));
+
+    buffer("a\n\nb\n");
+    // empty string between \n\n should be skipped
+    expect(lines).toEqual(["a", "b"]);
+  });
+
+  it("should hold incomplete trailing content until next chunk", () => {
+    const lines: string[] = [];
+    const buffer = createLineBuffer((line) => lines.push(line));
+
+    buffer("hello\nworld");
+    expect(lines).toEqual(["hello"]);
+    // "world" is buffered, not emitted
+
+    buffer(" end\n");
+    expect(lines).toEqual(["hello", "world end"]);
+  });
+});
+
+describe("formatProgressMessage", () => {
+  it("should format start events", () => {
+    const event: ProgressEvent = {
+      issue: 325,
+      phase: "spec",
+      event: "start",
+    };
+    expect(formatProgressMessage(event)).toBe("#325: spec started");
+  });
+
+  it("should format complete events with duration", () => {
+    const event: ProgressEvent = {
+      issue: 325,
+      phase: "spec",
+      event: "complete",
+      durationSeconds: 45,
+    };
+    expect(formatProgressMessage(event)).toBe("#325: spec \u2713 (45s)");
+  });
+
+  it("should format complete events without duration", () => {
+    const event: ProgressEvent = {
+      issue: 325,
+      phase: "exec",
+      event: "complete",
+    };
+    expect(formatProgressMessage(event)).toBe("#325: exec \u2713");
+  });
+
+  it("should format failed events with error", () => {
+    const event: ProgressEvent = {
+      issue: 384,
+      phase: "exec",
+      event: "failed",
+      error: "timeout",
+    };
+    expect(formatProgressMessage(event)).toBe(
+      "#384: exec \u2717 \u2014 timeout",
+    );
+  });
+
+  it("should format failed events without error", () => {
+    const event: ProgressEvent = {
+      issue: 384,
+      phase: "qa",
+      event: "failed",
+    };
+    expect(formatProgressMessage(event)).toBe("#384: qa \u2717");
+  });
+});
+
+describe("spawnAsync timeout reset (AC-4)", () => {
+  it("should export PHASE_TIMEOUT and MAX_TOTAL_TIMEOUT constants", () => {
+    expect(PHASE_TIMEOUT).toBe(1_800_000); // 30 minutes
+    expect(MAX_TOTAL_TIMEOUT).toBe(7_200_000); // 2 hours
+  });
+
+  it("should kill process after timeout with no progress", async () => {
+    // Use a very short timeout for testing
+    await expect(
+      spawnAsync("sleep", ["10"], {
+        timeout: 100, // 100ms timeout
+      }),
+    ).rejects.toThrow("Process timed out after 100ms");
+  });
+
+  it("should reset timeout when SEQUANT_PROGRESS lines arrive on stderr", async () => {
+    let progressCalls = 0;
+
+    // This process emits SEQUANT_PROGRESS lines on stderr every 100ms
+    // and runs for ~500ms total. With a 300ms timeout and progress
+    // resets, it should complete successfully instead of timing out.
+    // Without progress resets, it would time out at 300ms.
+    const result = await spawnAsync(
+      "bash",
+      [
+        "-c",
+        'for i in 1 2 3 4 5; do echo "SEQUANT_PROGRESS:{\"issue\":1,\"phase\":\"spec\",\"event\":\"start\"}" >&2; sleep 0.1; done; echo done',
+      ],
+      {
+        timeout: 300,
+        onProgress: () => {
+          progressCalls++;
+        },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("done");
+    // spawnAsync detects progress lines internally and calls onProgress
+    expect(progressCalls).toBeGreaterThan(0);
+  }, 5000);
+
+  it("should respect MAX_TOTAL_TIMEOUT even with progress resets", async () => {
+    // With onProgress set, maxTotal = MAX_TOTAL_TIMEOUT (2 hours)
+    // This test verifies the timeout message mentions progress when onProgress is set
+    await expect(
+      spawnAsync("sleep", ["10"], {
+        timeout: 50,
+        onProgress: () => {},
+      }),
+    ).rejects.toThrow("no progress for 50ms");
+  });
+
+  it("should behave identically without onProgress (AC-5)", async () => {
+    // Without onProgress, the original single-timeout behavior is preserved
+    await expect(
+      spawnAsync("sleep", ["10"], {
+        timeout: 50,
+      }),
+    ).rejects.toThrow("Process timed out after 50ms");
+  });
+
+  it("should kill process when maxTotalTimeout ceiling is exceeded despite progress", async () => {
+    // Process emits progress every 50ms and would run for ~500ms.
+    // Per-phase timeout (500ms) alone would let it complete.
+    // But the absolute ceiling (200ms) forces termination even though
+    // progress resets keep the per-phase timer alive.
+    const startTime = Date.now();
+    await expect(
+      spawnAsync(
+        "bash",
+        [
+          "-c",
+          'for i in 1 2 3 4 5 6 7 8 9 10; do echo "SEQUANT_PROGRESS:{\"issue\":1,\"phase\":\"spec\",\"event\":\"start\"}" >&2; sleep 0.05; done; echo done',
+        ],
+        {
+          timeout: 500, // per-phase: generous (would not expire alone)
+          maxTotalTimeout: 200, // absolute ceiling: 200ms
+          onProgress: () => {},
+        },
+      ),
+    ).rejects.toThrow("timed out");
+    const elapsed = Date.now() - startTime;
+    // Process was killed around the 200ms ceiling, not at 500ms per-phase
+    expect(elapsed).toBeLessThan(400);
+  }, 5000);
+});
+
+describe("emitProgressLine (AC-8)", () => {
+  const originalEnv = process.env.SEQUANT_ORCHESTRATOR;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SEQUANT_ORCHESTRATOR;
+    } else {
+      process.env.SEQUANT_ORCHESTRATOR = originalEnv;
+    }
+  });
+
+  it("should emit start event to stderr when orchestrated", () => {
+    process.env.SEQUANT_ORCHESTRATOR = "mcp-server";
+    const writeSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    emitProgressLine(325, "spec", "start");
+
+    expect(writeSpy).toHaveBeenCalledOnce();
+    const output = writeSpy.mock.calls[0][0] as string;
+    const parsed = parseProgressLine(output.trim());
+    expect(parsed).toEqual({
+      issue: 325,
+      phase: "spec",
+      event: "start",
+    });
+  });
+
+  it("should emit complete event with durationSeconds", () => {
+    process.env.SEQUANT_ORCHESTRATOR = "mcp-server";
+    const writeSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    emitProgressLine(325, "spec", "complete", { durationSeconds: 45 });
+
+    const output = writeSpy.mock.calls[0][0] as string;
+    const parsed = parseProgressLine(output.trim());
+    expect(parsed).toEqual({
+      issue: 325,
+      phase: "spec",
+      event: "complete",
+      durationSeconds: 45,
+    });
+  });
+
+  it("should emit failed event with error", () => {
+    process.env.SEQUANT_ORCHESTRATOR = "mcp-server";
+    const writeSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    emitProgressLine(325, "exec", "failed", { error: "timeout" });
+
+    const output = writeSpy.mock.calls[0][0] as string;
+    const parsed = parseProgressLine(output.trim());
+    expect(parsed).toEqual({
+      issue: 325,
+      phase: "exec",
+      event: "failed",
+      error: "timeout",
+    });
+  });
+
+  it("should not emit when SEQUANT_ORCHESTRATOR is not set", () => {
+    delete process.env.SEQUANT_ORCHESTRATOR;
+    const writeSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    emitProgressLine(325, "spec", "start");
+
+    expect(writeSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/mcp/tools/run.ts
+++ b/src/mcp/tools/run.ts
@@ -292,6 +292,9 @@ const PROGRESS_LINE_PREFIX = "SEQUANT_PROGRESS:";
 export interface ProgressEvent {
   issue: number;
   phase: string;
+  event: "start" | "complete" | "failed";
+  durationSeconds?: number;
+  error?: string;
 }
 
 /**
@@ -302,12 +305,50 @@ export function parseProgressLine(line: string): ProgressEvent | null {
   if (!line.startsWith(PROGRESS_LINE_PREFIX)) return null;
   try {
     const json = JSON.parse(line.slice(PROGRESS_LINE_PREFIX.length));
-    if (typeof json.issue === "number" && typeof json.phase === "string") {
-      return { issue: json.issue, phase: json.phase };
+    if (
+      typeof json.issue === "number" &&
+      typeof json.phase === "string" &&
+      typeof json.event === "string" &&
+      (json.event === "start" ||
+        json.event === "complete" ||
+        json.event === "failed")
+    ) {
+      const result: ProgressEvent = {
+        issue: json.issue,
+        phase: json.phase,
+        event: json.event,
+      };
+      if (typeof json.durationSeconds === "number") {
+        result.durationSeconds = json.durationSeconds;
+      }
+      if (typeof json.error === "string") {
+        result.error = json.error;
+      }
+      return result;
     }
     return null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Build a human-readable message for a progress notification (AC-3).
+ * @internal Exported for testing only.
+ */
+export function formatProgressMessage(event: ProgressEvent): string {
+  const prefix = `#${event.issue}`;
+  switch (event.event) {
+    case "start":
+      return `${prefix}: ${event.phase} started`;
+    case "complete": {
+      const dur = event.durationSeconds ? ` (${event.durationSeconds}s)` : "";
+      return `${prefix}: ${event.phase} \u2713${dur}`;
+    }
+    case "failed": {
+      const reason = event.error ? ` \u2014 ${event.error}` : "";
+      return `${prefix}: ${event.phase} \u2717${reason}`;
+    }
   }
 }
 
@@ -424,16 +465,19 @@ export function registerRunTool(server: McpServer): void {
       // Extract progress token for MCP progress notifications (AC-1)
       const progressToken = extra._meta?.progressToken;
 
-      // Track progress across phase transitions
-      let currentStep = 0;
+      // Track progress: only complete/failed events increment the counter
+      let completedSteps = 0;
 
       /**
        * Emit a progress notification if the client provided a progressToken.
+       * Only complete/failed events increment the progress counter.
        * Failures are caught to avoid aborting the run (AC-6).
        */
       const emitProgress = (event: ProgressEvent): void => {
         if (progressToken === undefined) return;
-        currentStep++;
+        if (event.event === "complete" || event.event === "failed") {
+          completedSteps++;
+        }
         try {
           // Fire-and-forget: don't await to avoid blocking the output stream
           void extra
@@ -441,9 +485,9 @@ export function registerRunTool(server: McpServer): void {
               method: "notifications/progress",
               params: {
                 progressToken,
-                progress: currentStep,
+                progress: completedSteps,
                 total: totalSteps,
-                message: `Issue #${event.issue}: ${event.phase} phase started (${currentStep}/${totalSteps})`,
+                message: formatProgressMessage(event),
               },
             })
             .catch(() => {
@@ -456,16 +500,20 @@ export function registerRunTool(server: McpServer): void {
 
       /**
        * Handle a complete line of subprocess stderr, checking for progress events.
-       * The batch executor emits SEQUANT_PROGRESS:{json} lines at each phase start.
+       * The batch executor emits SEQUANT_PROGRESS:{json} lines at phase boundaries.
        */
       const handleLine = (line: string): void => {
         const event = parseProgressLine(line);
         if (event) emitProgress(event);
       };
 
-      // Line-buffer stderr to handle chunk boundaries correctly
-      const stderrLineBuffer =
-        progressToken !== undefined ? createLineBuffer(handleLine) : undefined;
+      // Line-buffer stderr to handle chunk boundaries correctly.
+      // When a progressToken is present, we also enable spawnAsync's
+      // internal progress detection for timeout reset (AC-4).
+      const hasProgressToken = progressToken !== undefined;
+      const stderrLineBuffer = hasProgressToken
+        ? createLineBuffer(handleLine)
+        : undefined;
 
       // Register all issues as active runs for real-time status polling
       for (const issue of issues) {
@@ -474,13 +522,17 @@ export function registerRunTool(server: McpServer): void {
 
       try {
         const result = await spawnAsync(command, args, {
-          timeout: 1800000, // 30 min default
+          timeout: PHASE_TIMEOUT,
           env: {
             ...process.env,
             SEQUANT_ORCHESTRATOR: "mcp-server",
           },
           signal: extra.signal,
           onStderr: stderrLineBuffer,
+          // Enable timeout reset on progress events when client
+          // provided a progressToken (AC-4). spawnAsync detects
+          // SEQUANT_PROGRESS lines from stderr internally.
+          onProgress: hasProgressToken ? () => {} : undefined,
         });
 
         const stdout = result.stdout || "";
@@ -549,6 +601,12 @@ export interface SpawnResult {
   stderr: string;
 }
 
+/** Per-phase timeout ceiling (30 minutes) */
+export const PHASE_TIMEOUT = 1_800_000;
+
+/** Absolute maximum run duration (2 hours), even with progress resets */
+export const MAX_TOTAL_TIMEOUT = 7_200_000;
+
 export interface SpawnOptions {
   timeout: number;
   env?: NodeJS.ProcessEnv;
@@ -557,6 +615,18 @@ export interface SpawnOptions {
   onStderr?: (chunk: string) => void;
   /** Called with each stdout chunk (real-time, before process exits) */
   onStdout?: (chunk: string) => void;
+  /**
+   * Called when a progress event is detected from stderr.
+   * When set, enables resettable timeout: the per-phase timeout resets on
+   * each SEQUANT_PROGRESS line, but the absolute ceiling still applies.
+   */
+  onProgress?: () => void;
+  /**
+   * Override the absolute timeout ceiling (defaults to MAX_TOTAL_TIMEOUT).
+   * Only applies when onProgress is set. Useful for testing.
+   * @internal
+   */
+  maxTotalTimeout?: number;
 }
 
 /** @internal Exported for testing only */
@@ -590,13 +660,57 @@ export function spawnAsync(
       }
     };
 
-    const timeoutId = setTimeout(() => {
-      killProcessGroup(proc);
-      settle({
-        ok: false,
-        error: new Error(`Process timed out after ${options.timeout}ms`),
-      });
-    }, options.timeout);
+    // Resettable timeout: resets on progress events (AC-4).
+    // Uses options.timeout as the per-phase ceiling and MAX_TOTAL_TIMEOUT
+    // as the absolute ceiling to prevent infinite runs.
+    const runStart = Date.now();
+    const maxTotal = options.onProgress
+      ? (options.maxTotalTimeout ?? MAX_TOTAL_TIMEOUT)
+      : options.timeout;
+
+    const scheduleTimeout = (): ReturnType<typeof setTimeout> => {
+      const elapsed = Date.now() - runStart;
+      const remaining = Math.min(options.timeout, maxTotal - elapsed);
+      if (remaining <= 0) {
+        // Already exceeded max total — kill immediately
+        killProcessGroup(proc);
+        settle({
+          ok: false,
+          error: new Error(
+            `Process exceeded maximum total timeout of ${maxTotal}ms`,
+          ),
+        });
+        return setTimeout(() => {}, 0); // dummy handle
+      }
+      return setTimeout(() => {
+        killProcessGroup(proc);
+        const msg = options.onProgress
+          ? `Process timed out: no progress for ${options.timeout}ms (total elapsed: ${Date.now() - runStart}ms)`
+          : `Process timed out after ${options.timeout}ms`;
+        settle({ ok: false, error: new Error(msg) });
+      }, remaining);
+    };
+
+    let timeoutId = scheduleTimeout();
+
+    // When progress monitoring is enabled, detect SEQUANT_PROGRESS lines
+    // from stderr and reset the timeout on each one. This keeps the timeout
+    // reset logic co-located with the timer inside spawnAsync (AC-4).
+    const resetTimeout = () => {
+      if (!settled) {
+        clearTimeout(timeoutId);
+        timeoutId = scheduleTimeout();
+      }
+    };
+
+    const progressLineBuffer = options.onProgress
+      ? createLineBuffer((line) => {
+          if (line.startsWith(PROGRESS_LINE_PREFIX)) {
+            resetTimeout();
+            options.onProgress!();
+          }
+        })
+      : undefined;
 
     const onAbort = () => {
       killProcessGroup(proc);
@@ -623,6 +737,7 @@ export function spawnAsync(
       const chunk = data.toString();
       stderr += chunk;
       options.onStderr?.(chunk);
+      progressLineBuffer?.(chunk);
     });
 
     proc.on("error", (err: NodeJS.ErrnoException) => {


### PR DESCRIPTION
## Summary

- Extend `ProgressEvent` interface with `event` type (`start`/`complete`/`failed`), `durationSeconds`, and `error` fields
- Batch executor now emits structured progress events at phase start, completion, and failure
- `spawnAsync` detects `SEQUANT_PROGRESS:` lines from stderr and resets per-phase timeout (30min ceiling, 2hr absolute max)
- Event-appropriate progress messages: `#N: phase started`, `#N: phase ✓ (Ns)`, `#N: phase ✗ — error`
- Only complete/failed events increment progress counter; start events are informational

## AC Coverage

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | ✅ Already implemented | `run.ts` progressToken + sendNotification |
| AC-2 | ✅ Already implemented | `createLineBuffer` streams stderr |
| AC-3 | ✅ Implemented | `formatProgressMessage` with event-appropriate messages |
| AC-4 | ✅ Implemented | `spawnAsync` resettable timeout via internal progress detection |
| AC-5 | ✅ Already implemented | No-op guard when no progressToken |
| AC-6 | ✅ Already implemented | RunToolResponse unchanged |
| AC-7 | ✅ Already implemented | ToolHandlerExtra typing |
| AC-8 | ✅ Implemented | `emitProgressLine` with start/complete/failed events + duration/error |
| AC-9 | ✅ Already implemented | SEQUANT_PROGRESS: prefix |
| AC-10 | ✅ Implemented | 29 new unit tests across parseProgressLine, createLineBuffer, formatProgressMessage, timeout reset, emitProgressLine |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] All 78 progress-related tests pass (unit + integration)
- [x] Full test suite passes (2 pre-existing known failures only)
- [x] Timeout reset verified: process with progress lines completes despite exceeding initial timeout
- [x] Backward compatibility verified: no-progressToken behavior identical to before

Closes #435