### PR TITLE
feat(#453): streamline /assess PROCEED output for scan-friendly results

### DIFF
--- a/.claude/skills/assess/SKILL.md
+++ b/.claude/skills/assess/SKILL.md
@@ -396,9 +396,9 @@ gh issue edit <N> --add-label <label>
 
 After providing the assessment, briefly note:
 
-- **Confidence Level:** How certain are you about the recommendation? (High/Medium/Low)
-- **Information Gaps:** What information would improve this assessment?
-- **Alternative Interpretations:** Are there other ways to interpret the current state?
+- **Confidence Level:** How certain are you about the recommendation? (High/Medium/Low) — **For PROCEED:** omit when High with no information gaps (per template conditional)
+- **Information Gaps:** What information would improve this assessment? — omit when none
+- **Alternative Interpretations:** Are there other ways to interpret the current state? — omit when none
 
 ## Persist Analysis to Issue Comments
 

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -396,9 +396,9 @@ gh issue edit <N> --add-label <label>
 
 After providing the assessment, briefly note:
 
-- **Confidence Level:** How certain are you about the recommendation? (High/Medium/Low)
-- **Information Gaps:** What information would improve this assessment?
-- **Alternative Interpretations:** Are there other ways to interpret the current state?
+- **Confidence Level:** How certain are you about the recommendation? (High/Medium/Low) — **For PROCEED:** omit when High with no information gaps (per template conditional)
+- **Information Gaps:** What information would improve this assessment? — omit when none
+- **Alternative Interpretations:** Are there other ways to interpret the current state? — omit when none
 
 ## Persist Analysis to Issue Comments
 

--- a/templates/skills/assess/SKILL.md
+++ b/templates/skills/assess/SKILL.md
@@ -396,9 +396,9 @@ gh issue edit <N> --add-label <label>
 
 After providing the assessment, briefly note:
 
-- **Confidence Level:** How certain are you about the recommendation? (High/Medium/Low)
-- **Information Gaps:** What information would improve this assessment?
-- **Alternative Interpretations:** Are there other ways to interpret the current state?
+- **Confidence Level:** How certain are you about the recommendation? (High/Medium/Low) — **For PROCEED:** omit when High with no information gaps (per template conditional)
+- **Information Gaps:** What information would improve this assessment? — omit when none
+- **Alternative Interpretations:** Are there other ways to interpret the current state? — omit when none
 
 ## Persist Analysis to Issue Comments
 


### PR DESCRIPTION
## Summary

- Reduce `/assess` PROCEED verbosity by making sections conditional: health collapses to `✓ All clear` when clean, flags table shows only enabled flags, label review and confidence omitted when not actionable
- Add multi-issue summary table (Issue/Action/Workflow) at top when 2+ issues assessed
- CLI command uses positional args with only non-default flags shown

## AC Coverage

| AC | Status |
|----|--------|
| AC-1: Flags table shows only enabled flags | MET |
| AC-2: Health collapses when clean | MET |
| AC-3: Remove "Why this workflow" section | MET |
| AC-4: Label Review is conditional | MET |
| AC-5: Confidence is conditional | MET |
| AC-6: Multi-issue summary table | MET |
| AC-7: CLI command uses minimal flags | MET |
| AC-8: Sync all three skill copies | MET |

## Test plan

- [ ] Run `/assess <issue>` on a clean PROCEED issue — verify collapsed health, no label review, no confidence
- [ ] Run `/assess <issue>` on issue with warnings — verify expanded health signals
- [ ] Run `/assess <N1> <N2>` — verify summary table at top before per-issue details
- [ ] Run `diff` on all three SKILL.md copies — verify identical
- [ ] Verify CLI command box shows positional args, no `--issues`/`--phases`

Fixes #453