### PR TITLE
test(#460): add batch-executor unit tests for label-based phase shortcuts

### DIFF
--- a/src/lib/workflow/batch-executor.test.ts
+++ b/src/lib/workflow/batch-executor.test.ts
@@ -412,8 +412,8 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
     });
   });
 
-  describe("substring matching (documents current includes() behavior for #461)", () => {
-    it("'dispatch' label triggers bug shortcut via substring match on 'patch'", async () => {
+  describe("exact matching (#461): substring labels do NOT trigger shortcuts", () => {
+    it("'dispatch' label does not trigger bug shortcut despite containing 'patch'", async () => {
       await runIssueWithLogging(
         110,
         makeConfig(),
@@ -424,14 +424,13 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         makeOptions(),
       );
 
-      // "dispatch".includes("patch") === true — current (broken) behavior
-      // #461 will switch to exact match, at which point this test should
-      // be updated to expect spec to run (no shortcut)
+      // #461 switched to exact match — "dispatch" no longer matches "patch"
+      // Spec runs because no shortcut fires, then fallback detection runs
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toContain("spec");
     });
 
-    it("'redocs-system' label triggers docs shortcut via substring match on 'doc'", async () => {
+    it("'redocs-system' label does not trigger docs shortcut despite containing 'doc'", async () => {
       await runIssueWithLogging(
         111,
         makeConfig(),
@@ -442,11 +441,9 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         makeOptions(),
       );
 
-      // "redocs-system".includes("doc") === true — current (broken) behavior
-      // #461 will switch to exact match, at which point this test should
-      // be updated to expect spec to run (no shortcut)
+      // #461 switched to exact match — "redocs-system" no longer matches "doc"
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toContain("spec");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `batch-executor.test.ts` with 18 unit tests covering label-based phase shortcuts and issueConfig construction
- Tests verify the wiring between batch-executor's label detection and `executePhaseWithRetry` — the gap that phase-mapper tests alone cannot cover
- Covers all 4 original ACs plus 2 derived ACs (case-insensitivity, autoDetectPhases=false)

### Pre-PR AC Verification

| AC | Source | Description | Status | Evidence |
|----|--------|-------------|--------|----------|
| AC-1 | Original | `batch-executor.test.ts` exists with tests for `isSimpleBugFix`, `isDocs` | ✅ | 5 tests across both shortcut types |
| AC-2 | Original | `issueConfig.issueType` set to `"docs"` for docs labels | ✅ | 3 tests (docs, documentation, readme) |
| AC-3 | Original | No `issueType` for non-docs labels | ✅ | 3 tests (enhancement, bug, empty) |
| AC-4 | Original | Bug labels take precedence over docs in phase selection | ✅ | 2 tests (phases + issueType independence) |
| AC-5 | Derived | Case-insensitive label matching | ✅ | 3 tests (BUG, DOCS, Documentation) |
| AC-6 | Derived | `autoDetectPhases=false` skips shortcuts | ✅ | 2 tests |

## Test plan

- [x] `npx vitest run src/lib/workflow/batch-executor.test.ts` — 18/18 pass
- [x] `npm run build` — clean
- [x] `npm run lint` — clean

Closes #460