### PR TITLE
feat(#434): include QA verdict summary in sequant_logs output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Include QA verdict summary in `sequant_logs` MCP tool response (#434)
-  - Expose existing `verdict` field and new `qaSummary` (acMet, acTotal, gaps, suggestions)
-  - Parse AC coverage data from QA output via `parseQaSummary()`
+  - Expose existing `verdict` field and new `summary` (acMet, acTotal, gaps, suggestions)
+  - Parse AC coverage data from QA output via `parseQaSummary()` — handles 3/4/5-column tables, emoji statuses, `PARTIAL` shorthand
   - Eliminates need to separately fetch issue comments for batch QA review
 - Add small-diff fast path to `/qa` skill to skip sub-agent spawning for trivial changes (#465)
   - Diffs below configurable threshold (default: 100 lines) use inline quality checks instead of 3 sub-agents

--- a/src/lib/workflow/batch-executor.ts
+++ b/src/lib/workflow/batch-executor.ts
@@ -792,7 +792,7 @@ export async function runIssueWithLogging(
           {
             error: result.error,
             verdict: result.verdict,
-            qaSummary: result.qaSummary,
+            summary: result.summary,
             // Observability fields (AC-1, AC-2, AC-3, AC-7)
             filesModified: diffStats?.filesModified,
             fileDiffStats: diffStats?.fileDiffStats,

--- a/src/lib/workflow/log-writer.ts
+++ b/src/lib/workflow/log-writer.ts
@@ -339,7 +339,7 @@ export function createPhaseLogFromTiming(
       | "testsRun"
       | "testsPassed"
       | "verdict"
-      | "qaSummary"
+      | "summary"
       | "commitHash"
       | "fileDiffStats"
       | "cacheMetrics"

--- a/src/lib/workflow/phase-executor.test.ts
+++ b/src/lib/workflow/phase-executor.test.ts
@@ -114,7 +114,7 @@ describe("parseQaSummary", () => {
 | AC | Source | Description | Status | Notes |
 |----|--------|-------------|--------|-------|
 | AC-1 | Original | Expose verdict | MET | Works correctly |
-| AC-2 | Original | Add qaSummary | MET | Schema added |
+| AC-2 | Original | Add summary | MET | Schema added |
 | AC-3 | Original | Parse AC data | NOT_MET | Missing parser |
 
 **Coverage:** 2/3 AC items fully met`;
@@ -129,14 +129,8 @@ describe("parseQaSummary", () => {
   });
 
   it("parses compact AC table (4-column format)", () => {
-    const output = `### AC Coverage
-
-| AC | Description | Status | Notes |
-|----|-------------|--------|-------|
-| AC-1 | Feature works | MET | Done |
-| AC-2 | Tests pass | MET | All green |
-
-**Coverage:** 2/2 AC items fully met`;
+    const output = `| AC-1 | Feature works | MET | Done |
+| AC-2 | Tests pass | MET | All green |`;
 
     const result = parseQaSummary(output);
     expect(result).toEqual({
@@ -145,6 +139,54 @@ describe("parseQaSummary", () => {
       gaps: [],
       suggestions: [],
     });
+  });
+
+  it("parses 3-column table (from /fullsolve summaries)", () => {
+    const output = `| AC-1 | Record resolvedAt timestamp | MET |
+| AC-2 | Auto-prune on read | MET |
+| AC-3 | CLI flag | NOT_MET |`;
+
+    const result = parseQaSummary(output);
+    expect(result).toEqual({
+      acMet: 2,
+      acTotal: 3,
+      gaps: [],
+      suggestions: [],
+    });
+  });
+
+  it("handles emoji-prefixed statuses", () => {
+    const output = `| AC-1 | Feature works | ✅ MET | Good |
+| AC-2 | Error handling | ❌ NOT_MET | Missing |
+| AC-3 | Partial work | ⚠️ PARTIAL | Needs more |`;
+
+    const result = parseQaSummary(output);
+    expect(result).not.toBeNull();
+    expect(result!.acMet).toBe(1);
+    expect(result!.acTotal).toBe(3);
+  });
+
+  it("handles PARTIAL shorthand (counts as non-MET)", () => {
+    const output = `| AC-1 | Desc | MET | OK |
+| AC-2 | Desc | PARTIAL | Needs work |`;
+
+    const result = parseQaSummary(output);
+    expect(result).toEqual({
+      acMet: 1,
+      acTotal: 2,
+      gaps: [],
+      suggestions: [],
+    });
+  });
+
+  it("handles status with trailing text in same cell", () => {
+    const output = `| AC-1 | Plugin bundles MCP | ✅ MET — flat format | Verified |
+| AC-6 | Marketplace submission | ⚠️ PARTIAL — requires manual step | Noted |`;
+
+    const result = parseQaSummary(output);
+    expect(result).not.toBeNull();
+    expect(result!.acMet).toBe(1);
+    expect(result!.acTotal).toBe(2);
   });
 
   it("counts PARTIALLY_MET and PENDING as not met", () => {
@@ -157,6 +199,20 @@ describe("parseQaSummary", () => {
     expect(result).toEqual({
       acMet: 1,
       acTotal: 4,
+      gaps: [],
+      suggestions: [],
+    });
+  });
+
+  it("skips Derived ACs header row", () => {
+    const output = `| AC-1 | Original | Feature | MET | Done |
+| **Derived ACs** | | | | |
+| AC-6 | Derived (Error) | Handle errors | MET | OK |`;
+
+    const result = parseQaSummary(output);
+    expect(result).toEqual({
+      acMet: 2,
+      acTotal: 2,
       gaps: [],
       suggestions: [],
     });
@@ -184,39 +240,36 @@ describe("parseQaSummary", () => {
     });
   });
 
-  it("extracts suggestions from Suggestions section", () => {
-    const output = `| AC-1 | Desc | MET | Done |
-
-**Suggestions:**
-- Add SHA format regex validation
-- Consider caching parsed results`;
-
-    const result = parseQaSummary(output);
-    expect(result).toEqual({
-      acMet: 1,
-      acTotal: 1,
-      gaps: [],
-      suggestions: [
-        "Add SHA format regex validation",
-        "Consider caching parsed results",
-      ],
-    });
-  });
-
-  it("skips 'None' entries in Issues and Suggestions", () => {
+  it("filters all None variants from Issues and Suggestions", () => {
     const output = `| AC-1 | Original | Feature | MET | Done |
 
 **Issues:**
 - None
 
 **Suggestions:**
-- None`;
+- None found`;
 
     const result = parseQaSummary(output);
     expect(result).toEqual({
       acMet: 1,
       acTotal: 1,
       gaps: [],
+      suggestions: [],
+    });
+  });
+
+  it("filters 'None — description' but keeps 'Nonetheless...'", () => {
+    const output = `| AC-1 | Desc | MET | OK |
+
+**Issues:**
+- None — test file is focused
+- Nonetheless, check edge cases`;
+
+    const result = parseQaSummary(output);
+    expect(result).toEqual({
+      acMet: 1,
+      acTotal: 1,
+      gaps: ["Nonetheless, check edge cases"],
       suggestions: [],
     });
   });
@@ -229,7 +282,7 @@ describe("parseQaSummary", () => {
 | AC | Source | Description | Status | Notes |
 |----|--------|-------------|--------|-------|
 | AC-1 | Original | Expose verdict field | MET | Already stored, now exposed |
-| AC-2 | Original | Add qaSummary schema | MET | Schema added to run-log-schema.ts |
+| AC-2 | Original | Add summary schema | MET | Schema added to run-log-schema.ts |
 | AC-3 | Original | Parse AC data from output | MET | parseQaSummary function added |
 | AC-4 | Derived | Backward compatibility | MET | Old logs parse fine |
 
@@ -260,6 +313,30 @@ describe("parseQaSummary", () => {
       "Consider adding debug logging for parse failures",
       "Extract regex patterns to named constants",
     ]);
+  });
+
+  it("handles real QA output from issue #478", () => {
+    const output = `### AC Coverage
+
+| AC | Description | Status |
+|----|------------|--------|
+| AC-1 | Record resolvedAt timestamp | ✅ MET |
+| AC-2 | Auto-prune on read (in-memory TTL) | ✅ MET |
+| AC-3 | TTL configurable via settings | ✅ MET |
+
+**Issues:**
+- None found
+
+**Suggestions:**
+- None — implementation is clean`;
+
+    const result = parseQaSummary(output);
+    expect(result).toEqual({
+      acMet: 3,
+      acTotal: 3,
+      gaps: [],
+      suggestions: [],
+    });
   });
 });
 

--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -139,68 +139,99 @@ export function parseQaVerdict(output: string): QaVerdict | null {
 /**
  * Parse condensed QA summary from QA phase output (#434).
  *
- * Extracts AC coverage counts, gaps (from "Issues" section),
- * and suggestions from the structured QA review markdown.
+ * Handles multiple AC table formats produced by the QA skill:
+ * - 5-column: | AC-N | source | desc | STATUS | notes |
+ * - 4-column: | AC-N | desc | STATUS | notes |
+ * - 3-column: | AC-N | desc | STATUS |
+ *
+ * Status cells may contain emoji prefixes (✅ MET), shorthand
+ * (PARTIAL), or trailing text (MET — explanation).
  *
  * @internal Exported for testing only
  */
 export function parseQaSummary(output: string): QaSummary | null {
   if (!output) return null;
 
-  // Parse AC statuses from the AC Coverage table rows
-  // Format: | AC-N | ... | MET/NOT_MET/PARTIALLY_MET/PENDING/N/A | ... |
-  const acStatusPattern =
-    /\|\s*AC-\d+\s*\|[^|]*\|[^|]*\|\s*(MET|NOT_MET|PARTIALLY_MET|PENDING|N\/A)\s*\|/gi;
-  const acMatches = [...output.matchAll(acStatusPattern)];
+  // Anchored pattern: cell content starts with optional emoji, then status keyword
+  // Uses alternation (not character class) to avoid ESLint no-misleading-character-class
+  const STATUS_CELL =
+    /^(?:\u2705|\u274C|\u26A0\uFE0F|\u2B50|\u2139\uFE0F|\u2753|\u2757)?\s*(MET|NOT_MET|PARTIALLY_MET|PARTIAL|PENDING|N\/A)\b/i;
 
-  if (acMatches.length === 0) {
-    // Try the compact table format: | AC-N | description | MET | notes |
-    const compactPattern =
-      /\|\s*AC-\d+\s*\|[^|]*\|\s*(MET|NOT_MET|PARTIALLY_MET|PENDING|N\/A)\s*\|/gi;
-    const compactMatches = [...output.matchAll(compactPattern)];
-    if (compactMatches.length === 0) return null;
-    return buildSummary(compactMatches, output);
-  }
+  const lines = output.split("\n");
+  const acRows = lines.filter((line) => /^\s*\|\s*\*?\*?AC-\d+/.test(line));
 
-  return buildSummary(acMatches, output);
-}
+  if (acRows.length === 0) return null;
 
-function buildSummary(
-  acMatches: RegExpMatchArray[],
-  output: string,
-): QaSummary {
-  const acTotal = acMatches.length;
-  const acMet = acMatches.filter((m) => m[1].toUpperCase() === "MET").length;
+  let acMet = 0;
+  let acTotal = 0;
 
-  // Extract gaps from "**Issues:**" section (bulleted list items)
-  const gaps: string[] = [];
-  const issuesMatch = output.match(/\*\*Issues:\*\*\s*\n((?:\s*-\s+.+\n?)*)/);
-  if (issuesMatch) {
-    const lines = issuesMatch[1].trim().split("\n");
-    for (const line of lines) {
-      const trimmed = line.replace(/^\s*-\s+/, "").trim();
-      if (trimmed && trimmed !== "None") {
-        gaps.push(trimmed);
+  for (const row of acRows) {
+    const cells = row
+      .split("|")
+      .map((c) => c.trim())
+      .filter(Boolean);
+
+    // Scan cells right-to-left to find the status cell
+    let found = false;
+    for (let i = cells.length - 1; i >= 1; i--) {
+      const match = cells[i].match(STATUS_CELL);
+      if (match) {
+        const status = match[1].toUpperCase();
+        acTotal++;
+        if (status === "MET") acMet++;
+        found = true;
+        break;
       }
     }
+    // Row with AC-N but no parseable status is skipped
+    if (!found) continue;
   }
 
-  // Extract suggestions from "**Suggestions:**" section (bulleted list items)
-  const suggestions: string[] = [];
-  const suggestionsMatch = output.match(
-    /\*\*Suggestions:\*\*\s*\n((?:\s*-\s+.+\n?)*)/,
-  );
-  if (suggestionsMatch) {
-    const lines = suggestionsMatch[1].trim().split("\n");
-    for (const line of lines) {
-      const trimmed = line.replace(/^\s*-\s+/, "").trim();
-      if (trimmed && trimmed !== "None") {
-        suggestions.push(trimmed);
-      }
-    }
-  }
+  if (acTotal === 0) return null;
+
+  const gaps = parseListSection(output, /\*\*(?:Issues|Gaps)/);
+  const suggestions = parseListSection(output, /\*\*Suggestions/);
 
   return { acMet, acTotal, gaps, suggestions };
+}
+
+/**
+ * Parse a markdown bullet list section, filtering out "None" variants.
+ */
+function parseListSection(output: string, headerPattern: RegExp): string[] {
+  const items: string[] = [];
+  const lines = output.split("\n");
+
+  let inSection = false;
+  for (const line of lines) {
+    if (headerPattern.test(line)) {
+      // If the header line itself contains a bullet (inline), capture it
+      inSection = true;
+      continue;
+    }
+
+    if (inSection) {
+      // Section ends at next markdown header or bold label
+      if (/^#{1,4}\s/.test(line) || /^\*\*[^*]+\*\*:/.test(line)) {
+        break;
+      }
+
+      const bulletMatch = line.match(/^\s*[-*]\s+(.+)/);
+      if (bulletMatch) {
+        const trimmed = bulletMatch[1].trim();
+        // Filter "None", "None found", "None — text", etc.
+        if (trimmed && !/^None\b/i.test(trimmed)) {
+          items.push(trimmed);
+        }
+      } else if (line.trim() === "") {
+        continue;
+      } else {
+        break;
+      }
+    }
+  }
+
+  return items;
 }
 
 /**
@@ -421,7 +452,7 @@ async function executePhase(
     // Agent "success" just means the execution completed — we need to parse the verdict
     if (phase === "qa" && agentResult.output) {
       const verdict = parseQaVerdict(agentResult.output);
-      const qaSummary = parseQaSummary(agentResult.output) ?? undefined;
+      const summary = parseQaSummary(agentResult.output) ?? undefined;
       if (
         verdict &&
         verdict !== "READY_FOR_MERGE" &&
@@ -435,7 +466,7 @@ async function executePhase(
           sessionId: agentResult.sessionId,
           output: agentResult.output,
           verdict,
-          qaSummary,
+          summary,
           ...tails,
         };
       }
@@ -446,7 +477,7 @@ async function executePhase(
         sessionId: agentResult.sessionId,
         output: agentResult.output,
         verdict: verdict ?? undefined,
-        qaSummary,
+        summary,
         ...tails,
       };
     }

--- a/src/lib/workflow/run-log-schema.test.ts
+++ b/src/lib/workflow/run-log-schema.test.ts
@@ -124,29 +124,29 @@ describe("Zod Schemas", () => {
       ).toThrow();
     });
 
-    it("accepts phase log with qaSummary (#434)", () => {
-      const withQaSummary = {
+    it("accepts phase log with summary (#434)", () => {
+      const withSummary = {
         ...validPhaseLog,
         phase: "qa",
         verdict: "READY_FOR_MERGE",
-        qaSummary: {
+        summary: {
           acMet: 3,
           acTotal: 3,
           gaps: [],
           suggestions: ["Consider adding SHA format regex validation"],
         },
       };
-      expect(() => PhaseLogSchema.parse(withQaSummary)).not.toThrow();
+      expect(() => PhaseLogSchema.parse(withSummary)).not.toThrow();
     });
 
-    it("accepts phase log without qaSummary (backward compat, #434)", () => {
-      const withoutQaSummary = {
+    it("accepts phase log without summary (backward compat, #434)", () => {
+      const withoutSummary = {
         ...validPhaseLog,
         phase: "qa",
         verdict: "READY_FOR_MERGE",
       };
-      const parsed = PhaseLogSchema.parse(withoutQaSummary);
-      expect(parsed.qaSummary).toBeUndefined();
+      const parsed = PhaseLogSchema.parse(withoutSummary);
+      expect(parsed.summary).toBeUndefined();
     });
   });
 

--- a/src/lib/workflow/run-log-schema.ts
+++ b/src/lib/workflow/run-log-schema.ts
@@ -160,7 +160,7 @@ export const PhaseLogSchema = z.object({
   /** Parsed QA verdict (only for qa phase) */
   verdict: QaVerdictSchema.optional(),
   /** Condensed QA summary with AC coverage (#434) */
-  qaSummary: QaSummarySchema.optional(),
+  summary: QaSummarySchema.optional(),
   /** Git commit SHA after phase completes (AC-2) */
   commitHash: z.string().optional(),
   /** Per-file diff statistics (AC-3) */
@@ -351,7 +351,7 @@ export function completePhaseLog(
       | "testsRun"
       | "testsPassed"
       | "verdict"
-      | "qaSummary"
+      | "summary"
       | "commitHash"
       | "fileDiffStats"
       | "cacheMetrics"

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -123,7 +123,7 @@ export interface PhaseResult {
   /** Parsed QA verdict (only for qa phase) */
   verdict?: QaVerdict;
   /** Condensed QA summary with AC coverage (#434) */
-  qaSummary?: QaSummary;
+  summary?: QaSummary;
   /** Last N lines of stderr captured from the agent process (#447) */
   stderrTail?: string[];
   /** Last N lines of stdout captured from the agent process (#447) */

--- a/src/mcp/tools/logs.ts
+++ b/src/mcp/tools/logs.ts
@@ -144,7 +144,7 @@ export function registerLogsTool(server: McpServer): void {
                       durationSeconds: p.durationSeconds,
                       error: p.error,
                       ...(p.verdict && { verdict: p.verdict }),
-                      ...(p.qaSummary && { qaSummary: p.qaSummary }),
+                      ...(p.summary && { summary: p.summary }),
                     })),
                   })),
                 })),


### PR DESCRIPTION
## Summary

- Expose existing `verdict` field in `sequant_logs` MCP response (was stored but omitted from mapping)
- Add `QaSummarySchema` with `acMet`, `acTotal`, `gaps[]`, `suggestions[]` to PhaseLog
- Parse AC coverage data from QA output text via new `parseQaSummary()` function
- Wire summary through phase-executor → batch-executor → log-writer → MCP response

## Test plan

- [x] Unit tests for `parseQaSummary` with various QA output formats (standard, compact, realistic)
- [x] Schema validation tests for `QaSummarySchema` and PhaseLog with/without qaSummary
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] All tests pass (2374/2375 — 1 known flaky unrelated timeout)

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)