### PR TITLE
chore(#502): remove dead scripts/state/update.ts references from skill templates

### DIFF
--- a/.claude/skills/assess/SKILL.md
+++ b/.claude/skills/assess/SKILL.md
@@ -476,17 +476,6 @@ Every separator and section is conditional. If there are no warnings and no clea
 
 ---
 
-## State Tracking
-
-Initialize state for each assessed issue:
-
-```bash
-TITLE=$(gh issue view <N> --json title -q '.title')
-npx tsx scripts/state/update.ts init <N> "$TITLE"
-```
-
-Note: `/assess` only initializes issues — actual phase tracking happens during workflow execution.
-
 ## Persist Analysis
 
 After displaying output, prompt the user to save using `AskUserQuestion` with options "Yes (Recommended)" and "No".

--- a/.claude/skills/exec/SKILL.md
+++ b/.claude/skills/exec/SKILL.md
@@ -806,16 +806,6 @@ After implementation is complete and all checks pass, create and verify the PR:
    - If PR exists: Record the URL from `gh pr view` output
    - If PR creation failed: Record the error and include manual creation instructions
 
-6. **Record PR info in workflow state:**
-   ```bash
-   # Extract PR number and URL from gh pr view output, then update state
-   PR_INFO=$(gh pr view --json number,url)
-   PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
-   PR_URL=$(echo "$PR_INFO" | jq -r '.url')
-   npx tsx scripts/state/update.ts pr <issue-number> "$PR_NUMBER" "$PR_URL"
-   ```
-   This enables `--cleanup` to detect merged PRs and auto-remove state entries.
-
 **PR Verification Failure Handling:**
 
 If `gh pr view` fails after retry:
@@ -1921,37 +1911,6 @@ At the end of a session:
      ```
 
 You may be invoked multiple times for the same issue. Each time, re-establish context, ensure you're in the correct worktree, and continue iterating until we are as close as practical to meeting the AC.
-
----
-
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### Check Orchestration Mode
-
-The orchestration check happens automatically when you run the state update script - it exits silently if `SEQUANT_ORCHESTRATOR` is set.
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> exec
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> exec
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> exec "Error description"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
 
 ---
 

--- a/.claude/skills/fullsolve/SKILL.md
+++ b/.claude/skills/fullsolve/SKILL.md
@@ -854,33 +854,7 @@ As an orchestrator, `/fullsolve` must:
    export SEQUANT_WORKTREE=<worktree-path>
    ```
 
-2. **Initialize issue state at workflow start:**
-   ```bash
-   npx tsx scripts/state/update.ts init <issue-number> "<issue-title>"
-   ```
-
-3. **Update phase status** at each transition:
-   ```bash
-   # Before invoking child skill
-   npx tsx scripts/state/update.ts start <issue-number> <phase>
-
-   # After child skill completes
-   npx tsx scripts/state/update.ts complete <issue-number> <phase>
-
-   # If child skill fails
-   npx tsx scripts/state/update.ts fail <issue-number> <phase> "Error"
-   ```
-
-4. **Update final status** after workflow completes:
-   ```bash
-   # On READY_FOR_MERGE
-   npx tsx scripts/state/update.ts status <issue-number> ready_for_merge
-
-   # On failure
-   npx tsx scripts/state/update.ts status <issue-number> blocked
-   ```
-
-**Why child skills skip state updates:** When `SEQUANT_ORCHESTRATOR` is set, child skills defer state management to the orchestrator to avoid duplicate updates.
+2. **State tracking** is handled automatically by the orchestrator runtime when `SEQUANT_ORCHESTRATOR` is set. Child skills defer state management to the orchestrator to avoid duplicate updates.
 
 ---
 

--- a/.claude/skills/loop/SKILL.md
+++ b/.claude/skills/loop/SKILL.md
@@ -459,38 +459,6 @@ Please run /exec <N> first to create the worktree.
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> loop
-```
-
-**Update iteration count:**
-```bash
-npx tsx scripts/state/update.ts iteration <issue-number> <iteration-number>
-```
-
-**On successful completion (all issues fixed):**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> loop
-```
-
-**On max iterations reached:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> loop "Max iterations reached"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/.claude/skills/merger/SKILL.md
+++ b/.claude/skills/merger/SKILL.md
@@ -228,8 +228,7 @@ fi
 # Delete remote branch (previously handled by --delete-branch)
 gh api repos/{owner}/{repo}/git/refs/heads/$(gh pr view <PR_NUMBER> --json headRefName --jq '.headRefName') -X DELETE 2>/dev/null || true
 
-# REQUIRED: Update state to mark issue as merged (#305)
-npx tsx scripts/state/update.ts merged $ISSUE
+# State is tracked by the orchestrator runtime when available
 ```
 
 #### For conflicting changes (integration branch):
@@ -571,35 +570,6 @@ Environment variables:
 - `SEQUANT_MERGER_NO_CLEANUP` - If true, keep worktrees after merge
 - `SEQUANT_MERGER_FORCE` - If true, proceed even with conflicts or regressions (bypasses regression gate)
 - `SEQUANT_MERGER_SKIP_SMOKETEST` - If true, skip post-merge smoketest (also skips baseline capture)
-
-## State Tracking
-
-**IMPORTANT:** `/merger` updates state for merged issues.
-
-### State Updates
-
-When merging issues, update state to reflect the merge:
-
-**After successful merge of each issue:**
-```bash
-npx tsx scripts/state/update.ts merged <issue-number>
-```
-
-**For integration branches (multiple issues merged together):**
-```bash
-# Mark all integrated issues as merged
-npx tsx scripts/state/update.ts merged <issue-1>
-npx tsx scripts/state/update.ts merged <issue-2>
-```
-
-**On merge failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> merger "Merge conflict or CI failure"
-```
-
-**Why this matters:** The dashboard shows merged issues as complete, and state tracking enables accurate workflow metrics.
-
----
 
 ## Output Verification
 

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -344,33 +344,6 @@ EOF
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> security-review
-```
-
-**On successful completion (SECURE or WARNINGS):**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> security-review
-```
-
-**On failure (ISSUES_FOUND):**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> security-review "Security issues found"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -918,43 +918,6 @@ gh issue edit <issue-number> --add-label "planned"
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### Check Orchestration Mode
-
-At the start of the skill, check if running orchestrated:
-```bash
-# Check if orchestrated - if so, skip state updates
-if [[ -n "$SEQUANT_ORCHESTRATOR" ]]; then
-  echo "Running orchestrated - state managed by orchestrator"
-fi
-```
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> spec
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> spec
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> spec "Error description"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -805,33 +805,6 @@ Both can be used together:
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> test
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> test
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> test "X/Y tests failed"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/.claude/skills/testgen/SKILL.md
+++ b/.claude/skills/testgen/SKILL.md
@@ -672,33 +672,6 @@ Generated with [Claude Code](https://claude.com/claude-code)
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> testgen
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> testgen
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> testgen "Failed to generate test stubs"
-```
-
-**Note:** `/testgen` is an optional skill that generates test stubs. State tracking is informational - it doesn't block subsequent phases.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -267,33 +267,6 @@ Report infrastructure issues separately from feature issues.
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> verify
-```
-
-**On successful completion (human confirms):**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> verify
-```
-
-**On failure (human rejects or command fails):**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> verify "Verification failed"
-```
-
-**Note:** `/verify` is an optional skill for CLI/script verification. State tracking is informational - it helps track which issues have been manually verified.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -476,17 +476,6 @@ Every separator and section is conditional. If there are no warnings and no clea
 
 ---
 
-## State Tracking
-
-Initialize state for each assessed issue:
-
-```bash
-TITLE=$(gh issue view <N> --json title -q '.title')
-npx tsx scripts/state/update.ts init <N> "$TITLE"
-```
-
-Note: `/assess` only initializes issues — actual phase tracking happens during workflow execution.
-
 ## Persist Analysis
 
 After displaying output, prompt the user to save using `AskUserQuestion` with options "Yes (Recommended)" and "No".

--- a/skills/exec/SKILL.md
+++ b/skills/exec/SKILL.md
@@ -806,16 +806,6 @@ After implementation is complete and all checks pass, create and verify the PR:
    - If PR exists: Record the URL from `gh pr view` output
    - If PR creation failed: Record the error and include manual creation instructions
 
-6. **Record PR info in workflow state:**
-   ```bash
-   # Extract PR number and URL from gh pr view output, then update state
-   PR_INFO=$(gh pr view --json number,url)
-   PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
-   PR_URL=$(echo "$PR_INFO" | jq -r '.url')
-   npx tsx scripts/state/update.ts pr <issue-number> "$PR_NUMBER" "$PR_URL"
-   ```
-   This enables `--cleanup` to detect merged PRs and auto-remove state entries.
-
 **PR Verification Failure Handling:**
 
 If `gh pr view` fails after retry:
@@ -1921,37 +1911,6 @@ At the end of a session:
      ```
 
 You may be invoked multiple times for the same issue. Each time, re-establish context, ensure you're in the correct worktree, and continue iterating until we are as close as practical to meeting the AC.
-
----
-
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### Check Orchestration Mode
-
-The orchestration check happens automatically when you run the state update script - it exits silently if `SEQUANT_ORCHESTRATOR` is set.
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> exec
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> exec
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> exec "Error description"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
 
 ---
 

--- a/skills/fullsolve/SKILL.md
+++ b/skills/fullsolve/SKILL.md
@@ -854,33 +854,7 @@ As an orchestrator, `/fullsolve` must:
    export SEQUANT_WORKTREE=<worktree-path>
    ```
 
-2. **Initialize issue state at workflow start:**
-   ```bash
-   npx tsx scripts/state/update.ts init <issue-number> "<issue-title>"
-   ```
-
-3. **Update phase status** at each transition:
-   ```bash
-   # Before invoking child skill
-   npx tsx scripts/state/update.ts start <issue-number> <phase>
-
-   # After child skill completes
-   npx tsx scripts/state/update.ts complete <issue-number> <phase>
-
-   # If child skill fails
-   npx tsx scripts/state/update.ts fail <issue-number> <phase> "Error"
-   ```
-
-4. **Update final status** after workflow completes:
-   ```bash
-   # On READY_FOR_MERGE
-   npx tsx scripts/state/update.ts status <issue-number> ready_for_merge
-
-   # On failure
-   npx tsx scripts/state/update.ts status <issue-number> blocked
-   ```
-
-**Why child skills skip state updates:** When `SEQUANT_ORCHESTRATOR` is set, child skills defer state management to the orchestrator to avoid duplicate updates.
+2. **State tracking** is handled automatically by the orchestrator runtime when `SEQUANT_ORCHESTRATOR` is set. Child skills defer state management to the orchestrator to avoid duplicate updates.
 
 ---
 

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -805,33 +805,6 @@ Both can be used together:
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> test
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> test
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> test "X/Y tests failed"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/skills/testgen/SKILL.md
+++ b/skills/testgen/SKILL.md
@@ -672,33 +672,6 @@ Generated with [Claude Code](https://claude.com/claude-code)
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> testgen
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> testgen
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> testgen "Failed to generate test stubs"
-```
-
-**Note:** `/testgen` is an optional skill that generates test stubs. State tracking is informational - it doesn't block subsequent phases.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/templates/skills/assess/SKILL.md
+++ b/templates/skills/assess/SKILL.md
@@ -476,17 +476,6 @@ Every separator and section is conditional. If there are no warnings and no clea
 
 ---
 
-## State Tracking
-
-Initialize state for each assessed issue:
-
-```bash
-TITLE=$(gh issue view <N> --json title -q '.title')
-npx tsx scripts/state/update.ts init <N> "$TITLE"
-```
-
-Note: `/assess` only initializes issues — actual phase tracking happens during workflow execution.
-
 ## Persist Analysis
 
 After displaying output, prompt the user to save using `AskUserQuestion` with options "Yes (Recommended)" and "No".

--- a/templates/skills/exec/SKILL.md
+++ b/templates/skills/exec/SKILL.md
@@ -806,16 +806,6 @@ After implementation is complete and all checks pass, create and verify the PR:
    - If PR exists: Record the URL from `gh pr view` output
    - If PR creation failed: Record the error and include manual creation instructions
 
-6. **Record PR info in workflow state:**
-   ```bash
-   # Extract PR number and URL from gh pr view output, then update state
-   PR_INFO=$(gh pr view --json number,url)
-   PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
-   PR_URL=$(echo "$PR_INFO" | jq -r '.url')
-   npx tsx scripts/state/update.ts pr <issue-number> "$PR_NUMBER" "$PR_URL"
-   ```
-   This enables `--cleanup` to detect merged PRs and auto-remove state entries.
-
 **PR Verification Failure Handling:**
 
 If `gh pr view` fails after retry:
@@ -1921,37 +1911,6 @@ At the end of a session:
      ```
 
 You may be invoked multiple times for the same issue. Each time, re-establish context, ensure you're in the correct worktree, and continue iterating until we are as close as practical to meeting the AC.
-
----
-
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### Check Orchestration Mode
-
-The orchestration check happens automatically when you run the state update script - it exits silently if `SEQUANT_ORCHESTRATOR` is set.
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> exec
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> exec
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> exec "Error description"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
 
 ---
 

--- a/templates/skills/fullsolve/SKILL.md
+++ b/templates/skills/fullsolve/SKILL.md
@@ -854,33 +854,7 @@ As an orchestrator, `/fullsolve` must:
    export SEQUANT_WORKTREE=<worktree-path>
    ```
 
-2. **Initialize issue state at workflow start:**
-   ```bash
-   npx tsx scripts/state/update.ts init <issue-number> "<issue-title>"
-   ```
-
-3. **Update phase status** at each transition:
-   ```bash
-   # Before invoking child skill
-   npx tsx scripts/state/update.ts start <issue-number> <phase>
-
-   # After child skill completes
-   npx tsx scripts/state/update.ts complete <issue-number> <phase>
-
-   # If child skill fails
-   npx tsx scripts/state/update.ts fail <issue-number> <phase> "Error"
-   ```
-
-4. **Update final status** after workflow completes:
-   ```bash
-   # On READY_FOR_MERGE
-   npx tsx scripts/state/update.ts status <issue-number> ready_for_merge
-
-   # On failure
-   npx tsx scripts/state/update.ts status <issue-number> blocked
-   ```
-
-**Why child skills skip state updates:** When `SEQUANT_ORCHESTRATOR` is set, child skills defer state management to the orchestrator to avoid duplicate updates.
+2. **State tracking** is handled automatically by the orchestrator runtime when `SEQUANT_ORCHESTRATOR` is set. Child skills defer state management to the orchestrator to avoid duplicate updates.
 
 ---
 

--- a/templates/skills/spec/SKILL.md
+++ b/templates/skills/spec/SKILL.md
@@ -918,43 +918,6 @@ gh issue edit <issue-number> --add-label "planned"
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### Check Orchestration Mode
-
-At the start of the skill, check if running orchestrated:
-```bash
-# Check if orchestrated - if so, skip state updates
-if [[ -n "$SEQUANT_ORCHESTRATOR" ]]; then
-  echo "Running orchestrated - state managed by orchestrator"
-fi
-```
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> spec
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> spec
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> spec "Error description"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/templates/skills/test/SKILL.md
+++ b/templates/skills/test/SKILL.md
@@ -805,33 +805,6 @@ Both can be used together:
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> test
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> test
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> test "X/Y tests failed"
-```
-
-**Why this matters:** State tracking enables dashboard visibility, resume capability, and workflow orchestration. Skills update state when standalone; orchestrators handle state when running workflows.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**

--- a/templates/skills/testgen/SKILL.md
+++ b/templates/skills/testgen/SKILL.md
@@ -672,33 +672,6 @@ Generated with [Claude Code](https://claude.com/claude-code)
 
 ---
 
-## State Tracking
-
-**IMPORTANT:** Update workflow state when running standalone (not orchestrated).
-
-### State Updates (Standalone Only)
-
-When NOT orchestrated (`SEQUANT_ORCHESTRATOR` is not set):
-
-**At skill start:**
-```bash
-npx tsx scripts/state/update.ts start <issue-number> testgen
-```
-
-**On successful completion:**
-```bash
-npx tsx scripts/state/update.ts complete <issue-number> testgen
-```
-
-**On failure:**
-```bash
-npx tsx scripts/state/update.ts fail <issue-number> testgen "Failed to generate test stubs"
-```
-
-**Note:** `/testgen` is an optional skill that generates test stubs. State tracking is informational - it doesn't block subsequent phases.
-
----
-
 ## Output Verification
 
 **Before responding, verify your output includes ALL of these:**


### PR DESCRIPTION
## Summary

- Remove State Tracking sections referencing `scripts/state/update.ts` from 21 SKILL.md files across all 3 skill directories (`.claude/skills/`, `templates/skills/`, `skills/`)
- These references are dead code in consumer projects — the script exists in the sequant repo but is not copied by `sequant init`
- Fullsolve retains its orchestration context (env var exports) since those are runtime-used

## AC Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | Remove from `.claude/skills/` (10 skills) | ✅ |
| AC-2 | Remove from `templates/skills/` (6 skills) | ✅ |
| AC-3 | Remove from `skills/` (5 skills) | ✅ |
| AC-4 | Preserve `scripts/state/update.ts` itself | ✅ |
| AC-5 | No other content removed | ✅ |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` — 2576 pass, 3 pre-existing integration timeouts (unrelated)
- [x] `grep -r "scripts/state/update.ts" .claude/skills/ templates/skills/ skills/` returns 0 matches

Closes #502