### PR TITLE
feat(#499): add QA skill check for three-directory skill sync

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -838,6 +838,12 @@ issue_type="${SEQUANT_ISSUE_TYPE:-}"
 admin_modified=$(git diff main...HEAD --name-only | grep -E "^app/admin/" | head -1 || true)
 ```
 
+**Add skill sync check if skill files modified:**
+```bash
+skill_modified=$(git diff main...HEAD --name-only | grep -E "^\.(claude/skills|skills|templates/skills)/" | head -1 || true)
+```
+If skill files are modified, the quality-checks.sh script automatically runs the three-directory sync check (section 12). If divergence is detected, this blocks `READY_FOR_MERGE` — verdict becomes `AC_MET_BUT_NOT_A_PLUS` with a note to run `npx tsx scripts/check-skill-sync.ts --fix`.
+
 See [quality-gates.md](references/quality-gates.md) for detailed verdict synthesis.
 
 ### Using MCP Tools (Optional)

--- a/.claude/skills/qa/scripts/quality-checks.sh
+++ b/.claude/skills/qa/scripts/quality-checks.sh
@@ -457,7 +457,52 @@ else
 fi
 
 # =============================================================================
-# 12. Build Verification (cacheable - expensive operation)
+# 12. Skill Sync Check (when skill files modified)
+# =============================================================================
+echo ""
+skill_files_changed=$(git diff main...HEAD --name-only | grep -E '^\.(claude/skills|skills|templates/skills)/' || true)
+if [[ -n "$skill_files_changed" ]]; then
+  echo "🔍 Checking three-directory skill sync..."
+  if [[ -f "scripts/check-skill-sync.ts" ]]; then
+    sync_output=$(npx tsx scripts/check-skill-sync.ts 2>&1 || true)
+    sync_exit=$?
+    sync_summary=$(echo "$sync_output" | grep "^Summary:" || true)
+    if [[ $sync_exit -ne 0 ]]; then
+      echo "⚠️  Skill sync: DIVERGENCE DETECTED"
+      echo "$sync_summary"
+      echo "   Run: npx tsx scripts/check-skill-sync.ts --fix"
+    else
+      echo "✅ Skill sync: All files synced across 3 directories"
+    fi
+  else
+    echo "   (scripts/check-skill-sync.ts not found — using inline diff)"
+    diverged=0
+    for f in $skill_files_changed; do
+      if [[ "$f" == .claude/skills/* ]]; then
+        rel="${f#.claude/skills/}"
+        for mirror in "templates/skills" "skills"; do
+          if [[ -f "${mirror}/${rel}" ]]; then
+            if ! diff -q ".claude/skills/${rel}" "${mirror}/${rel}" > /dev/null 2>&1; then
+              echo "   ⚠️  DIVERGED: ${rel} (.claude/skills vs ${mirror})"
+              diverged=$((diverged + 1))
+            fi
+          fi
+        done
+      fi
+    done
+    if [[ $diverged -eq 0 ]]; then
+      echo "✅ Skill sync: Changed skill files are synced"
+    else
+      echo "⚠️  Skill sync: ${diverged} file(s) diverged"
+      echo "   Fix: copy from .claude/skills/ to templates/skills/ and skills/"
+    fi
+  fi
+else
+  echo "🔍 Skill sync: No skill files changed (skipped)"
+fi
+
+# =============================================================================
+# 13. Build Verification (cacheable - expensive operation)
 # =============================================================================
 
 verify_build_against_main() {

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -838,6 +838,12 @@ issue_type="${SEQUANT_ISSUE_TYPE:-}"
 admin_modified=$(git diff main...HEAD --name-only | grep -E "^app/admin/" | head -1 || true)
 ```
 
+**Add skill sync check if skill files modified:**
+```bash
+skill_modified=$(git diff main...HEAD --name-only | grep -E "^\.(claude/skills|skills|templates/skills)/" | head -1 || true)
+```
+If skill files are modified, the quality-checks.sh script automatically runs the three-directory sync check (section 12). If divergence is detected, this blocks `READY_FOR_MERGE` — verdict becomes `AC_MET_BUT_NOT_A_PLUS` with a note to run `npx tsx scripts/check-skill-sync.ts --fix`.
+
 See [quality-gates.md](references/quality-gates.md) for detailed verdict synthesis.
 
 ### Using MCP Tools (Optional)

--- a/skills/qa/scripts/quality-checks.sh
+++ b/skills/qa/scripts/quality-checks.sh
@@ -385,7 +385,53 @@ else
 fi
 
 # =============================================================================
-# 11. Build Verification (cacheable - expensive operation)
+# =============================================================================
+# 11.5. Skill Sync Check (when skill files modified)
+# =============================================================================
+echo ""
+skill_files_changed=$(git diff main...HEAD --name-only | grep -E '^\.(claude/skills|skills|templates/skills)/' || true)
+if [[ -n "$skill_files_changed" ]]; then
+  echo "🔍 Checking three-directory skill sync..."
+  if [[ -f "scripts/check-skill-sync.ts" ]]; then
+    sync_output=$(npx tsx scripts/check-skill-sync.ts 2>&1 || true)
+    sync_exit=$?
+    sync_summary=$(echo "$sync_output" | grep "^Summary:" || true)
+    if [[ $sync_exit -ne 0 ]]; then
+      echo "⚠️  Skill sync: DIVERGENCE DETECTED"
+      echo "$sync_summary"
+      echo "   Run: npx tsx scripts/check-skill-sync.ts --fix"
+    else
+      echo "✅ Skill sync: All files synced across 3 directories"
+    fi
+  else
+    echo "   (scripts/check-skill-sync.ts not found — using inline diff)"
+    diverged=0
+    for f in $skill_files_changed; do
+      if [[ "$f" == .claude/skills/* ]]; then
+        rel="${f#.claude/skills/}"
+        for mirror in "templates/skills" "skills"; do
+          if [[ -f "${mirror}/${rel}" ]]; then
+            if ! diff -q ".claude/skills/${rel}" "${mirror}/${rel}" > /dev/null 2>&1; then
+              echo "   ⚠️  DIVERGED: ${rel} (.claude/skills vs ${mirror})"
+              diverged=$((diverged + 1))
+            fi
+          fi
+        done
+      fi
+    done
+    if [[ $diverged -eq 0 ]]; then
+      echo "✅ Skill sync: Changed skill files are synced"
+    else
+      echo "⚠️  Skill sync: ${diverged} file(s) diverged"
+      echo "   Fix: copy from .claude/skills/ to templates/skills/ and skills/"
+    fi
+  fi
+else
+  echo "🔍 Skill sync: No skill files changed (skipped)"
+fi
+
+# =============================================================================
+# 12. Build Verification (cacheable - expensive operation)
 # =============================================================================
 
 verify_build_against_main() {

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -838,6 +838,12 @@ issue_type="${SEQUANT_ISSUE_TYPE:-}"
 admin_modified=$(git diff main...HEAD --name-only | grep -E "^app/admin/" | head -1 || true)
 ```
 
+**Add skill sync check if skill files modified:**
+```bash
+skill_modified=$(git diff main...HEAD --name-only | grep -E "^\.(claude/skills|skills|templates/skills)/" | head -1 || true)
+```
+If skill files are modified, the quality-checks.sh script automatically runs the three-directory sync check (section 12). If divergence is detected, this blocks `READY_FOR_MERGE` — verdict becomes `AC_MET_BUT_NOT_A_PLUS` with a note to run `npx tsx scripts/check-skill-sync.ts --fix`.
+
 See [quality-gates.md](references/quality-gates.md) for detailed verdict synthesis.
 
 ### Using MCP Tools (Optional)

--- a/templates/skills/qa/scripts/quality-checks.sh
+++ b/templates/skills/qa/scripts/quality-checks.sh
@@ -385,7 +385,53 @@ else
 fi
 
 # =============================================================================
-# 11. Build Verification (cacheable - expensive operation)
+# =============================================================================
+# 11.5. Skill Sync Check (when skill files modified)
+# =============================================================================
+echo ""
+skill_files_changed=$(git diff main...HEAD --name-only | grep -E '^\.(claude/skills|skills|templates/skills)/' || true)
+if [[ -n "$skill_files_changed" ]]; then
+  echo "🔍 Checking three-directory skill sync..."
+  if [[ -f "scripts/check-skill-sync.ts" ]]; then
+    sync_output=$(npx tsx scripts/check-skill-sync.ts 2>&1 || true)
+    sync_exit=$?
+    sync_summary=$(echo "$sync_output" | grep "^Summary:" || true)
+    if [[ $sync_exit -ne 0 ]]; then
+      echo "⚠️  Skill sync: DIVERGENCE DETECTED"
+      echo "$sync_summary"
+      echo "   Run: npx tsx scripts/check-skill-sync.ts --fix"
+    else
+      echo "✅ Skill sync: All files synced across 3 directories"
+    fi
+  else
+    echo "   (scripts/check-skill-sync.ts not found — using inline diff)"
+    diverged=0
+    for f in $skill_files_changed; do
+      if [[ "$f" == .claude/skills/* ]]; then
+        rel="${f#.claude/skills/}"
+        for mirror in "templates/skills" "skills"; do
+          if [[ -f "${mirror}/${rel}" ]]; then
+            if ! diff -q ".claude/skills/${rel}" "${mirror}/${rel}" > /dev/null 2>&1; then
+              echo "   ⚠️  DIVERGED: ${rel} (.claude/skills vs ${mirror})"
+              diverged=$((diverged + 1))
+            fi
+          fi
+        done
+      fi
+    done
+    if [[ $diverged -eq 0 ]]; then
+      echo "✅ Skill sync: Changed skill files are synced"
+    else
+      echo "⚠️  Skill sync: ${diverged} file(s) diverged"
+      echo "   Fix: copy from .claude/skills/ to templates/skills/ and skills/"
+    fi
+  fi
+else
+  echo "🔍 Skill sync: No skill files changed (skipped)"
+fi
+
+# =============================================================================
+# 12. Build Verification (cacheable - expensive operation)
 # =============================================================================
 
 verify_build_against_main() {


### PR DESCRIPTION
## Summary

- Add skill sync detection to QA quality-checks.sh (new section 12)
- Detects when `.claude/skills/**` files are modified in the diff
- Uses `scripts/check-skill-sync.ts` (from #498) if available, falls back to inline diff
- Divergence blocks `READY_FOR_MERGE` verdict, becomes `AC_MET_BUT_NOT_A_PLUS`
- QA SKILL.md updated with sync check guidance

## AC Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | Detects `.claude/skills/**` modifications in diff | ✅ |
| AC-2 | Runs sync verification across all three directories | ✅ |
| AC-3 | Reports sync status in QA output | ✅ |
| AC-4 | Divergence blocks READY_FOR_MERGE | ✅ |
| AC-5 | Uses check-skill-sync.ts if available, falls back to inline diff | ✅ |

## Test plan

- [x] `npm run build` passes
- [x] Changes mirrored across all 3 skill directories (6 files)
- [x] quality-checks.sh has correct bash syntax

Closes #499