### PR TITLE
feat(#515): compress spec skill prompt by 75% and add tiered context

### DIFF
--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -78,7 +78,14 @@ Mark tier in HTML comment for downstream parsing: `<!-- SEQUANT_SPEC_TIER: [tier
 
 1. **AC Extraction & Storage:** Use `extractAcceptanceCriteria` from `./src/lib/ac-parser.ts` and `StateManager` from `./src/lib/workflow/state-manager.ts` to parse and store AC in `.sequant/state.json`. Supports formats: `- [ ] **AC-1:** Desc`, `- [ ] AC-1: Desc`, `- [ ] **B2:** Desc`.
 
-2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Flags vague ("should work"), unmeasurable ("fast"), incomplete ("handle errors"), open-ended ("etc."). Warning-only — does not block planning.
+2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Warning-only — does not block planning. Flag these patterns:
+
+   | Pattern | Examples | Issue |
+   |---------|----------|-------|
+   | Vague | "should work", "properly" | No measurable outcome |
+   | Unmeasurable | "fast", "performant" | No threshold defined |
+   | Incomplete | "handle errors", "edge cases" | Scenarios not enumerated |
+   | Open-ended | "etc.", "and more" | Scope undefined |
 
 3. **Scope Assessment** (unless `--skip-scope-check`): Use `performScopeAssessment` from `./src/lib/scope/index.ts` with settings from `getSettings()`. Verdicts: SCOPE_OK (green), SCOPE_WARNING (yellow, auto-enables quality loop), SCOPE_SPLIT_RECOMMENDED (red). Store results in state.
 
@@ -135,6 +142,21 @@ Check for explicit dependencies: `gh issue view <issue> --json body,labels`. If 
 
 Check issue body/labels for feature branch references (`feature/`, `based on`, epic labels). If found, recommend `--base feature/<branch>` in the plan.
 
+## Verification Method Decision Framework
+
+Use this table when assigning verification methods to each AC:
+
+| AC Type | Method | When to Use |
+|---------|--------|-------------|
+| Pure logic/calculation | Unit Test | Clear input/output, no side effects |
+| API endpoint | Integration Test | HTTP handlers, DB queries, external calls |
+| User workflow | Browser Test | Multi-step UI interactions, forms |
+| Visual appearance | Manual Test | Styling, layout, animations |
+| CLI command | Integration Test | Script execution, stdout verification |
+| Error handling | Unit + Integration | Both isolated and realistic scenarios |
+
+See [verification-criteria.md](references/verification-criteria.md) for detailed examples.
+
 ## Output Template
 
 **Single authoritative template.** Include ALL sections in this order. Scale detail by complexity tier.
@@ -172,9 +194,8 @@ Check issue body/labels for feature branch references (`feature/`, `based on`, e
 **Scenario:** Given [state] → When [action] → Then [outcome]
 **Assumptions:** [List any that need pre-coding validation]
 
-<!-- Repeat for all ACs.
-     EVERY AC must have a Verification Method. If unclear, flag as "⚠️ UNCLEAR" with suggested refinement.
-     See references/verification-criteria.md for method selection guide. -->
+<!-- Repeat for all ACs. EVERY AC must have a Verification Method from the decision framework.
+     If unclear, flag as "⚠️ UNCLEAR" with suggested refinement. -->
 
 ---
 

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -2,9 +2,9 @@
 name: spec
 description: "Plan review vs Acceptance Criteria for a single GitHub issue, plus issue comment draft."
 license: MIT
+version: "2.1"
 metadata:
   author: sequant
-  version: "1.0"
 allowed-tools:
   - Bash(npm test:*)
   - Bash(gh issue view:*)
@@ -19,950 +19,138 @@ allowed-tools:
 
 # Planning Agent
 
-You are the Phase 1 "Planning Agent" for the current repository.
+Phase 1 "Planning Agent." Understands the issue and AC, reviews or synthesizes a plan, identifies gaps and risks, and drafts a GitHub issue comment.
 
-## Purpose
-
-When invoked as `/spec`, your job is to:
-
-1. Understand the issue and Acceptance Criteria (AC).
-2. Review or synthesize a clear plan to address the AC.
-3. Identify ambiguities, gaps, or risks.
-4. Draft a GitHub issue comment summarizing AC + the agreed plan.
-
-## Phase Detection (Smart Resumption)
-
-**Before executing**, check if this phase has already been completed by reading phase markers from issue comments:
+## Platform Detection — Run First
 
 ```bash
-# Check for existing phase markers
-phase_data=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]' | \
-  grep -o '{[^}]*}' | grep '"phase"' | tail -1 || true)
-
-if [[ -n "$phase_data" ]]; then
-  phase=$(echo "$phase_data" | jq -r '.phase')
-  status=$(echo "$phase_data" | jq -r '.status')
-
-  # Skip if spec is already completed or a later phase is completed
-  if [[ "$phase" == "spec" && "$status" == "completed" ]] || \
-     [[ "$phase" == "exec" || "$phase" == "test" || "$phase" == "qa" ]]; then
-    echo "⏭️ Spec phase already completed (detected: $phase:$status). Skipping."
-    # Exit early — no work needed
-  fi
-fi
+gh --version >/dev/null 2>&1 && GITHUB_AVAILABLE=true || GITHUB_AVAILABLE=false
+SETTINGS_AVAILABLE=false; [ -f ".sequant/settings.json" ] && SETTINGS_AVAILABLE=true
 ```
 
-**Behavior:**
-- If `spec:completed` or a later phase is detected → Skip with message
-- If `spec:failed` → Re-run spec (retry)
-- If no markers found → Normal execution (fresh start)
-- If detection fails (API error) → Fall through to normal execution
+- **GitHub unavailable:** Skip phase detection, label review, auto-comment. Prompt user for AC from description text.
+- **Settings unavailable:** Use defaults silently (sequential agents, no custom scope config).
 
-**Phase Marker Emission:**
+## Phase Detection
 
-When posting the spec plan comment to GitHub, append a phase marker at the end:
+If GitHub is available, check for prior phase completion:
 
-```markdown
+```bash
+phase_data=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]' | \
+  grep -o '{[^}]*}' | grep '"phase"' | tail -1 || true)
+```
+
+- `spec:completed` or later phase detected → Skip with message
+- `spec:failed` → Re-run
+- No markers / API error → Normal execution
+
+Append to every phase-completion comment:
+```
 <!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"<ISO-8601>"} -->
 ```
 
-Include this marker in every `gh issue comment` that represents phase completion.
-
 ## Behavior
 
-When called like `/spec 123`:
-1. Treat `123` as a GitHub issue number.
-2. **Read all GitHub issue comments** for complete context.
-3. Extract: problem statement, AC (explicit or inferred), clarifications from comments.
+**`/spec 123`** — GitHub issue number. Read all comments for full context. Extract AC.
+**`/spec <text>`** — Freeform problem/AC source. Ask clarifying questions if ambiguous.
 
-When called like `/spec <freeform description>`:
-1. Treat the text as the problem/AC source.
-2. Ask clarifying questions if AC are ambiguous or conflicting.
+**Flags:** `--skip-ac-lint` (skip AC quality check), `--skip-scope-check` (skip scope assessment).
 
-**Flag:** `--skip-ac-lint`
-- Usage: `/spec 123 --skip-ac-lint`
-- Effect: Skips the AC Quality Check step
-- Use when: AC are intentionally high-level or you want to defer linting
+## Complexity Tier Determination
 
-**Flag:** `--skip-scope-check`
-- Usage: `/spec 123 --skip-scope-check`
-- Effect: Skips the Scope Assessment step
-- Use when: Issue scope is intentionally complex or you want to defer assessment
+Determine the output tier **before** generating any output. Announce it as the first line.
 
-### AC Extraction and Storage — REQUIRED
+| Tier | Criteria | Output Scope | Target |
+|------|----------|--------------|--------|
+| **Simple** | `simple-fix`/`typo`/`docs-only` label, or `bug` with ≤2 AC | AC list + plan + Design Review Q1/Q3 only | <4,000 chars |
+| **Standard** | 3–8 AC, no complexity labels | Full output minus Polish, minus trivially-passing quality checks | <8,000 chars |
+| **Complex** | `complex`/`refactor`/`breaking` label, or 9+ AC | Full output including all quality dimensions | <15,000 chars |
 
-**After fetching the issue body**, extract and store acceptance criteria in workflow state:
+First line of output: `**Complexity: [Tier]** ([N] ACs, [N] directories)`
 
-```bash
-# Extract AC from issue body and store in state
-npx tsx -e "
-import { extractAcceptanceCriteria } from './src/lib/ac-parser.ts';
-import { StateManager } from './src/lib/workflow/state-manager.ts';
+Mark tier in HTML comment for downstream parsing: `<!-- SEQUANT_SPEC_TIER: [tier] -->`
 
-const issueBody = \`<ISSUE_BODY_HERE>\`;
-const issueNumber = <ISSUE_NUMBER>;
-const issueTitle = '<ISSUE_TITLE>';
+## Programmatic Checks (Conditional)
 
-const ac = extractAcceptanceCriteria(issueBody);
-console.log('Extracted AC:', JSON.stringify(ac, null, 2));
+**Guard:** Only run `npx tsx` blocks if `./src/lib/ac-parser.ts` exists (sequant repo). Otherwise, perform all analysis inline by reading the issue text directly.
 
-if (ac.items.length > 0) {
-  const manager = new StateManager();
-  (async () => {
-    const existing = await manager.getIssueState(issueNumber);
-    if (!existing) {
-      await manager.initializeIssue(issueNumber, issueTitle);
-    }
-    await manager.updateAcceptanceCriteria(issueNumber, ac);
-    console.log('AC stored in state for issue #' + issueNumber);
-  })();
-}
-"
-```
+### If guard passes:
 
-**Why this matters:** Storing AC in state enables:
-- Dashboard visibility of AC progress per issue
-- `/qa` skill to update AC status during review
-- Cross-skill AC tracking throughout the workflow
+1. **AC Extraction & Storage:** Use `extractAcceptanceCriteria` from `./src/lib/ac-parser.ts` and `StateManager` from `./src/lib/workflow/state-manager.ts` to parse and store AC in `.sequant/state.json`. Supports formats: `- [ ] **AC-1:** Desc`, `- [ ] AC-1: Desc`, `- [ ] **B2:** Desc`.
 
-**AC Format Detection:**
-The parser supports multiple formats:
-- `- [ ] **AC-1:** Description` (bold with hyphen)
-- `- [ ] **B2:** Description` (letter + number)
-- `- [ ] AC-1: Description` (no bold)
+2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Flags vague ("should work"), unmeasurable ("fast"), incomplete ("handle errors"), open-ended ("etc."). Warning-only — does not block planning.
 
-**If no AC found:**
-- Log a warning but continue with planning
-- The plan output should note that AC will need to be defined
+3. **Scope Assessment** (unless `--skip-scope-check`): Use `performScopeAssessment` from `./src/lib/scope/index.ts` with settings from `getSettings()`. Verdicts: SCOPE_OK (green), SCOPE_WARNING (yellow, auto-enables quality loop), SCOPE_SPLIT_RECOMMENDED (red). Store results in state.
 
-### AC Quality Check — REQUIRED (unless --skip-ac-lint)
+### If guard fails (consumer projects):
 
-**After extracting AC**, run the AC linter to flag vague, untestable, or incomplete requirements:
+Perform the same analysis inline:
+- Extract AC by pattern-matching the issue body
+- Flag vague/unmeasurable AC in the AC Quality Check section
+- Assess scope using the same green/yellow/red heuristics on feature count, AC count, directory spread
+
+## Context Gathering
+
+### Discover Project Structure — REQUIRED
+
+**Do NOT use hardcoded paths.** Discover what actually exists:
 
 ```bash
-# Lint AC for quality issues (skip if --skip-ac-lint flag is set)
-npx tsx -e "
-import { parseAcceptanceCriteria } from './src/lib/ac-parser.ts';
-import { lintAcceptanceCriteria, formatACLintResults } from './src/lib/ac-linter.ts';
-
-const issueBody = \`<ISSUE_BODY_HERE>\`;
-
-const criteria = parseAcceptanceCriteria(issueBody);
-const lintResults = lintAcceptanceCriteria(criteria);
-console.log(formatACLintResults(lintResults));
-"
+ls -d src/ app/ lib/ components/ pages/ routes/ docs/ 2>/dev/null || true
 ```
 
-**Why this matters:** Vague AC lead to:
-- Ambiguous implementations that don't match expectations
-- Subjective /qa verdicts ("does it work properly?")
-- Wasted iteration cycles when requirements are clarified late
+Use discovered paths in all agent prompts and search commands.
 
-**Pattern Detection:**
+### Agent Spawn Rules
 
-| Pattern Type | Examples | Issue |
-|--------------|----------|-------|
-| Vague | "should work", "properly", "correctly" | Subjective, no measurable outcome |
-| Unmeasurable | "fast", "performant", "responsive" | No threshold defined |
-| Incomplete | "handle errors", "edge cases" | Specific scenarios not enumerated |
-| Open-ended | "etc.", "and more", "such as" | Scope is undefined |
+Determine agent count from issue content — do NOT always spawn 3:
 
-**Example Output:**
+| Issue Content | Agents | What to Spawn |
+|---------------|--------|---------------|
+| Database/SQL/migration keywords in AC or labels | 3 | Similar features + Codebase area + Database schema |
+| UI/frontend (`.tsx`/`.jsx`/`components/` references) | 2 | Similar features + Codebase area |
+| CLI/script changes | 2 | Similar features + Codebase area |
+| Docs/config/`simple-fix` label | 1 | General context only |
 
-```markdown
-## AC Quality Check
+**Execution mode:** Read `.sequant/settings.json` → `agents.parallel` (default: false).
+- **Parallel:** Spawn all agents in a SINGLE message
+- **Sequential:** Spawn one at a time, waiting for each to complete
 
-⚠️ **AC-2:** "System should handle errors gracefully"
-   → Incomplete: error types not specified
-   → Suggest: List specific error types and expected responses (e.g., 400 for invalid input, 503 for service unavailable)
+Agent prompts MUST reference discovered paths from the step above, not hardcoded ones like `components/admin/` or `lib/queries/`.
 
-⚠️ **AC-4:** "Page loads quickly"
-   → Unmeasurable: "quickly" has no threshold
-   → Suggest: Specify time limit (e.g., completes in <5 seconds)
+### In-Flight Work Analysis
 
-✅ AC-1, AC-3, AC-5: Clear and testable
-
-**Summary:** 2/5 AC items flagged for review
-```
-
-**Behavior:**
-- **Warning-only**: AC Quality Check does NOT block planning
-- Issues are surfaced in the output but plan generation continues
-- Include flagged AC in the issue comment draft with suggestions
-- Recommend refining vague AC before implementation
-
-**If `--skip-ac-lint` flag is set:**
-- Output: `AC Quality Check: Skipped (--skip-ac-lint flag set)`
-- Continue directly to plan generation
-
-### Scope Assessment — REQUIRED (unless --skip-scope-check)
-
-**After AC Quality Check**, run scope assessment to detect overscoped issues:
+Scan for potential conflicts before planning:
 
 ```bash
-# Run scope assessment (skip if --skip-scope-check flag is set)
-npx tsx -e "
-import { parseAcceptanceCriteria } from './src/lib/ac-parser.ts';
-import { performScopeAssessment, formatScopeAssessment, convertSettingsToConfig } from './src/lib/scope/index.ts';
-import { getSettings } from './src/lib/settings.ts';
-
-const issueBody = \`<ISSUE_BODY_HERE>\`;
-const issueTitle = '<ISSUE_TITLE>';
-
-(async () => {
-  const settings = await getSettings();
-  const config = convertSettingsToConfig(settings.scopeAssessment);
-
-  const criteria = parseAcceptanceCriteria(issueBody);
-  const assessment = performScopeAssessment(criteria, issueBody, issueTitle, config);
-  console.log(formatScopeAssessment(assessment));
-})();
-"
+git worktree list --porcelain
+# For each worktree: git -C <path> diff --name-only origin/main...HEAD
 ```
 
-**Why this matters:**
-- Bundled features (3+ distinct features) should be separate issues
-- Missing non-goals lead to scope creep during implementation
-- High AC counts increase complexity and error rates
+If overlap detected → include **Conflict Risk Analysis** section with options (alternative approach / wait for merge / coordinate via /merger).
 
-**Scope Metrics:**
+Check for explicit dependencies: `gh issue view <issue> --json body,labels`. If "Depends on" found → include **Dependencies** section with status.
 
-| Metric | Green | Yellow | Red |
-|--------|-------|--------|-----|
-| Feature count | 1 | 2 | 3+ |
-| AC items | 1-5 | 6-8 | 9+ |
-| Directory spread | 1-2 | 3-4 | 5+ |
+### Feature Branch Context
 
-**Non-Goals Section:**
-
-Every `/spec` output MUST include a Non-Goals section. If the issue lacks one, output a warning:
-
-```markdown
-## Non-Goals
-
-⚠️ **Non-Goals section not found.** Consider adding scope boundaries.
-
-Example format:
-- [ ] [Adjacent feature we're deferring]
-- [ ] [Scope boundary we're respecting]
-- [ ] [Future work that's out of scope]
-```
-
-**Scope Verdicts:**
-
-| Verdict | Meaning | Action |
-|---------|---------|--------|
-| ✅ SCOPE_OK | Single focused feature | Proceed normally |
-| ⚠️ SCOPE_WARNING | Moderate complexity | Consider narrowing; quality loop auto-enabled |
-| ❌ SCOPE_SPLIT_RECOMMENDED | Multiple features bundled | Strongly recommend splitting |
-
-**Quality Loop Auto-Enable:**
-
-If scope verdict is SCOPE_WARNING or SCOPE_SPLIT_RECOMMENDED:
-- Quality loop is automatically enabled
-- Include note in Recommended Workflow section:
-  ```markdown
-  **Quality Loop:** enabled (auto-enabled due to scope concerns)
-  ```
-
-**If `--skip-scope-check` flag is set:**
-- Output: `Scope Assessment: Skipped (--skip-scope-check flag set)`
-- Continue to plan generation
-
-**Store in State:**
-
-After assessment, store results in workflow state for analytics:
-
-```bash
-npx tsx -e "
-import { StateManager } from './src/lib/workflow/state-manager.ts';
-import { performScopeAssessment, convertSettingsToConfig } from './src/lib/scope/index.ts';
-import { getSettings } from './src/lib/settings.ts';
-
-(async () => {
-  const settings = await getSettings();
-  const config = convertSettingsToConfig(settings.scopeAssessment);
-
-  // ... perform assessment with config ...
-  // const assessment = performScopeAssessment(criteria, issueBody, issueTitle, config);
-
-  const manager = new StateManager();
-  await manager.updateScopeAssessment(issueNumber, assessment);
-})();
-"
-```
-
-### Feature Worktree Workflow
-
-**Planning Phase:** No worktree needed. Planning happens in the main repository directory. The worktree will be created during the execution phase (`/exec`).
-
-### Parallel Context Gathering — REQUIRED
-
-**You MUST spawn sub-agents for context gathering.** Do NOT explore the codebase inline with Glob/Grep commands. Sub-agents provide parallel execution, better context isolation, and consistent reporting.
-
-**Check agent execution mode first:**
-Use the Read tool to check project settings:
-```
-Read(file_path=".sequant/settings.json")
-# Parse JSON and extract agents.parallel (default: false)
-```
-
-#### If parallel mode enabled:
-
-**Spawn ALL THREE agents in a SINGLE message:**
-
-1. `Agent(subagent_type="sequant-explorer", prompt="Find similar features for [FEATURE]. Check components/admin/, lib/queries/, docs/patterns/. Report: file paths, patterns, recommendations.")`
-
-2. `Agent(subagent_type="sequant-explorer", prompt="Explore [CODEBASE AREA] for [FEATURE]. Find: main components, data flow, key files. Report structure.")`
-
-3. `Agent(subagent_type="sequant-explorer", prompt="Inspect database for [FEATURE]. Check: table schema, RLS policies, existing queries. Report findings.")`
-
-#### If sequential mode (default):
-
-**Spawn each agent ONE AT A TIME, waiting for each to complete:**
-
-1. **First:** `Agent(subagent_type="sequant-explorer", prompt="Find similar features for [FEATURE]. Check components/admin/, lib/queries/, docs/patterns/. Report: file paths, patterns, recommendations.")`
-
-2. **After #1 completes:** `Agent(subagent_type="sequant-explorer", prompt="Explore [CODEBASE AREA] for [FEATURE]. Find: main components, data flow, key files. Report structure.")`
-
-3. **After #2 completes:** `Agent(subagent_type="sequant-explorer", prompt="Inspect database for [FEATURE]. Check: table schema, RLS policies, existing queries. Report findings.")`
-
-### Feature Branch Context Detection
-
-Before creating the implementation plan, check if a custom base branch should be recommended:
-
-1. **Check for feature branch references in issue body**:
-   ```bash
-   gh issue view <issue> --json body --jq '.body' | grep -iE "(feature/|branch from|based on|part of.*feature)" || true
-   ```
-
-2. **Check issue labels for feature context**:
-   ```bash
-   gh issue view <issue> --json labels --jq '.labels[].name' | grep -iE "(dashboard|feature-|epic-)" || true
-   ```
-
-3. **Check if project has defaultBase configured**:
-   Use the Read tool to check settings:
-   ```
-   Read(file_path=".sequant/settings.json")
-   # Extract .run.defaultBase from JSON
-   ```
-
-4. **If feature branch context detected**, include in plan output:
-   ```markdown
-   ## Feature Branch Context
-
-   **Detected base branch**: `feature/dashboard`
-   **Source**: Issue body mentions "Part of dashboard feature" / Project config / Label
-
-   **Recommended workflow**:
-   \`\`\`bash
-   npx sequant run <issue> --base feature/dashboard
-   \`\`\`
-   ```
-
-### In-Flight Work Analysis (Conflict Detection)
-
-Before creating the implementation plan, scan for potential conflicts with in-flight work:
-
-1. **List open worktrees**:
-   ```bash
-   git worktree list --porcelain
-   ```
-
-2. **For each worktree, get changed files** (use detected base branch or default to main):
-   ```bash
-   git -C <worktree-path> diff --name-only <base-branch>...HEAD
-   ```
-
-3. **Analyze this issue's likely file touches** based on:
-   - Issue description and AC
-   - Similar past issues
-   - Codebase structure
-
-4. **If overlap detected**, include in plan output:
-   ```markdown
-   ## Conflict Risk Analysis
-
-   **In-flight work detected**: Issue #<N> (feature/<branch-name>)
-   **Overlapping files**:
-   - `<file-path>`
-
-   **Recommended approach**:
-   - [ ] Option A: Use alternative file/approach (no conflict)
-   - [ ] Option B: Wait for #<N> to merge, then rebase
-   - [ ] Option C: Coordinate unified implementation via /merger
-
-   **Selected**: [To be decided during spec review]
-   ```
-
-5. **Check for explicit dependencies**:
-   ```bash
-   # Look for "Depends on" or "depends-on" labels
-   gh issue view <issue> --json body,labels
-   ```
-
-   If dependencies found:
-   ```markdown
-   ## Dependencies
-
-   **Depends on**: #<N>
-   **Reason**: [Why this issue depends on the other]
-   **Status**: [Open/Merged/Closed]
-   ```
-
-### Using MCP Tools (Optional)
-
-- **Sequential Thinking:** For complex analysis with multiple dependencies
-- **Context7:** For understanding existing patterns and architecture
-
-## Context Gathering Strategy
-
-1. **Check the Patterns Catalog first**
-   - Read `docs/patterns/README.md` for quick lookup
-   - Check HELPERS.md, COMPONENTS.md, TYPES.md
-   - **Do NOT propose creating new utilities if similar ones exist**
-
-2. **Look for similar features**
-   - Use `ls components/admin/[area]/` for existing components
-   - Read 1-2 examples to understand patterns
-   - Propose solutions matching established architecture
-
-3. **Check existing dependencies**
-   - Review `package.json` for libraries
-   - Prefer existing dependencies over new ones
-   - For "solved problem" domains, recommend established packages in the plan:
-     | Domain | Recommended Packages |
-     |--------|---------------------|
-     | Date/time | `date-fns`, `dayjs` |
-     | Validation | `zod`, `yup`, `valibot` |
-     | HTTP with retry | `ky`, `got`, `axios` |
-     | Form state | `react-hook-form` |
-     | State management | `zustand`, `jotai` |
-
-4. **For database-heavy features**
-   - Verify table schemas against TypeScript types
-   - Check proposed types match database columns
-
-5. **For complex features (>5 AC items)**
-   - Use Sequential Thinking to break down systematically
-   - Document key decision points and trade-offs
-
-## Output Structure
-
-### 1. AC Checklist with Verification Criteria (REQUIRED)
-
-**Every AC MUST have an explicit Verification Method.** Restate AC as a checklist with verification for each:
-
-```markdown
-### AC-1: [Description]
-
-**Verification Method:** Unit Test | Integration Test | Manual Test | Browser Test
-
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action taken]
-- Then: [Expected outcome]
-
-**Integration Points:**
-- [External system or component]
-
-**Assumptions to Validate:**
-- [ ] [Assumption that must be true]
-```
-
-#### Verification Method Decision Framework
-
-**REQUIRED:** Choose the most appropriate verification method for each AC:
-
-| AC Type | Verification Method | When to Use |
-|---------|---------------------|-------------|
-| Pure logic/calculation | **Unit Test** | Functions with clear input/output, no side effects |
-| API endpoint | **Integration Test** | HTTP handlers, database queries, external service calls |
-| User workflow | **Browser Test** | Multi-step UI interactions, form submissions |
-| Visual appearance | **Manual Test** | Styling, layout, animations (hard to automate) |
-| CLI command | **Integration Test** | Script execution, file operations, stdout verification |
-| Error handling | **Unit Test** + **Integration Test** | Both isolated behavior and realistic scenarios |
-| Performance | **Manual Test** + **Integration Test** | Timing thresholds, load testing |
-
-#### Verification Method Examples
-
-**Good (specific and testable):**
-```markdown
-**AC-1:** User can submit the registration form
-**Verification Method:** Browser Test
-**Test Scenario:**
-- Given: User on /register page
-- When: Fill form fields, click Submit
-- Then: Redirect to /dashboard, success toast appears
-```
-
-**Bad (vague, no clear verification):**
-```markdown
-**AC-1:** Registration should work properly
-**Verification Method:** ??? (cannot determine)
-```
-
-#### Flags for Missing Verification Methods
-
-If you cannot determine a verification method for an AC:
-
-1. **Flag the AC as unclear:**
-   ```markdown
-   **AC-3:** System handles errors gracefully
-   **Verification Method:** ⚠️ UNCLEAR - needs specific error scenarios
-   **Suggested Refinement:** List specific error types and expected responses
-   ```
-
-2. **Include in Open Questions:**
-   ```markdown
-   ## Open Questions
-
-   1. **AC-3 verification method unclear**
-      - Question: What specific error scenarios should be tested?
-      - Recommendation: Define 3-5 error types with expected behavior
-      - Impact: Without this, QA cannot objectively validate
-   ```
-
-**Why this matters:** AC without verification methods:
-- Cannot be objectively validated in `/qa`
-- Lead to subjective "does it work?" assessments
-- Cause rework when expectations don't match implementation
-
-See [verification-criteria.md](references/verification-criteria.md) for detailed examples including the #452 hooks failure case.
-
-### 2. Implementation Plan
-
-Propose a concrete plan in 3–7 steps that:
-- References specific codebase areas
-- Respects existing architecture
-- Groups related work into phases
-- Identifies dependencies between steps
-
-For each major decision:
-- Present 2-3 options when relevant
-- Recommend a default with rationale
-- Note if decision should be deferred
-
-**Open Questions Format:**
-- Question: [Clear question]
-- Recommendation: [Your suggested default]
-- Impact: [What happens if we get this wrong]
-
-See [parallel-groups.md](references/parallel-groups.md) for parallelization format.
-
-### 2.5. Design Review (REQUIRED)
-
-**Purpose:** Make design decisions explicit before implementation starts. This forces evaluation of *how* to build, not just *what* to build — catching wrong-layer, over-engineered, or pattern-mismatched approaches before code is written.
-
-**Why this matters:** Repeated pattern across issues: implementation passes QA functionally but uses the wrong design — wrong layer, hacky shortcut, over-engineered approach. The fix cycle is expensive. Making design explicit here prevents it.
-
-**Complexity Scaling:**
-- **Simple issues** (`simple-fix`, `typo`, `docs-only` labels): Abbreviated — answer Q1 and Q3 only
-- **Standard issues**: Answer all 4 questions
-- **Complex issues** (`complex`, `refactor`, `breaking` labels): Answer all 4 questions with detailed rationale
-
-**Answer these questions:**
-
-1. **Where does this logic belong?** — Which module/layer owns this change? Name the specific directory, file, or abstraction layer. If it spans layers, explain why.
-
-2. **What's the simplest correct approach?** — Actively reject over-engineering. What's the minimum implementation that satisfies all AC? What alternatives did you consider and reject?
-
-3. **What existing pattern does this follow?** — Name the specific pattern in the codebase. Confirm it fits this use case. If no existing pattern fits, explain why a new approach is needed.
-
-4. **What would a senior reviewer challenge?** — Anticipate design pushback. What's the most likely "why didn't you just...?" or "this should be in X instead" feedback?
-
-**Example (standard issue):**
-
-```markdown
-## Design Review
-
-1. **Where does this logic belong?** Spec skill's SKILL.md prompt files — purely prompt engineering, not TypeScript. Same layer as Feature Quality Planning and AC Checklist sections.
-
-2. **What's the simplest correct approach?** Add markdown prompt text to SKILL.md. Reuse the existing complexity scaling pattern from Feature Quality Planning. No code, no new files, no abstractions.
-
-3. **What existing pattern does this follow?** Mirrors Feature Quality Planning exactly: required section, purpose statement, complexity scaling table, question format.
-
-4. **What would a senior reviewer challenge?** (1) "Why after Implementation Plan, not before?" — Design review needs the plan as input to evaluate. (2) "Won't this bloat output?" — Adds ~15 lines for standard, ~5 for simple-fix.
-```
-
-**Example (simple-fix issue, abbreviated):**
-
-```markdown
-## Design Review
-
-1. **Where does this logic belong?** `src/lib/utils.ts` — utility function, same layer as existing helpers.
-
-3. **What existing pattern does this follow?** Same pattern as `formatDuration()` in the same file — pure function, no side effects, single responsibility.
-```
-
-### 3. Feature Quality Planning (REQUIRED)
-
-**Purpose:** Systematically consider professional implementation requirements beyond the minimum AC. This prevents gaps that slip through exec and QA because they were never planned.
-
-**Why this matters:** Spec currently plans the "minimum to satisfy AC" rather than "complete professional implementation." Gaps found in manual review are omissions from incomplete planning, not failures.
-
-**Complexity Scaling:**
-- **Simple issues** (`simple-fix`, `typo`, `docs-only` labels): Use abbreviated checklist (Completeness + one relevant section)
-- **Standard issues**: Complete all applicable sections
-- **Complex issues** (`complex`, `refactor`, `breaking` labels): Complete all sections with detailed items
-
-```markdown
-## Feature Quality Planning
-
-### Completeness Check
-- [ ] All AC items have corresponding implementation steps
-- [ ] Integration points with existing features identified
-- [ ] No partial implementations or TODOs planned
-- [ ] State management considered (if applicable)
-- [ ] Data flow is complete end-to-end
-
-### Error Handling
-- [ ] Invalid input scenarios identified
-- [ ] API/external service failures handled
-- [ ] Edge cases documented (empty, null, max values)
-- [ ] Error messages are user-friendly
-- [ ] Graceful degradation planned
-
-### Code Quality
-- [ ] Types fully defined (no `any` planned)
-- [ ] Follows existing patterns in codebase
-- [ ] Error boundaries where needed
-- [ ] No magic strings/numbers
-- [ ] Consistent naming conventions
-
-### Test Coverage Plan
-- [ ] Unit tests for business logic
-- [ ] Integration tests for data flow
-- [ ] Edge case tests identified
-- [ ] Mocking strategy appropriate
-- [ ] Critical paths have test coverage
-
-### Best Practices
-- [ ] Logging for debugging/observability
-- [ ] Accessibility considerations (if UI)
-- [ ] Performance implications considered
-- [ ] Security reviewed (auth, validation, sanitization)
-- [ ] Documentation updated (if behavior changes)
-
-### Polish (UI features only)
-- [ ] Loading states planned
-- [ ] Error states have UI
-- [ ] Empty states handled
-- [ ] Responsive design considered
-- [ ] Keyboard navigation works
-
-### Derived ACs
-
-Based on quality planning, identify additional ACs needed:
-
-| Source | Derived AC | Priority |
-|--------|-----------|----------|
-| Error Handling | AC-N: Handle [specific error] with [specific response] | High/Medium/Low |
-| Test Coverage | AC-N+1: Add tests for [specific scenario] | High/Medium/Low |
-| Best Practices | AC-N+2: Add logging for [specific operation] | High/Medium/Low |
-
-**Note:** Derived ACs are numbered sequentially after original ACs and follow the same format.
-```
-
-**Section Applicability:**
-
-| Issue Type | Sections Required |
-|------------|-------------------|
-| Bug fix | Completeness, Error Handling, Test Coverage |
-| New feature | All sections |
-| Refactor | Completeness, Code Quality, Test Coverage |
-| UI change | All sections including Polish |
-| Backend/API | Completeness, Error Handling, Code Quality, Test Coverage, Best Practices |
-| CLI/Script | Completeness, Error Handling, Test Coverage, Best Practices |
-| Docs only | Completeness only |
-
-**Example (API endpoint feature):**
-
-```markdown
-## Feature Quality Planning
-
-### Completeness Check
-- [x] All AC items have corresponding implementation steps
-- [x] Integration points: Auth middleware, database queries, response serializer
-- [x] No partial implementations planned
-- [ ] State management: N/A (stateless API)
-- [x] Data flow: Request → Validate → Query → Transform → Response
-
-### Error Handling
-- [x] Invalid input: Return 400 with validation errors
-- [x] Auth failure: Return 401 with "Unauthorized" message
-- [x] Not found: Return 404 with resource ID
-- [x] Server error: Return 500, log full error, return generic message
-- [x] Rate limit: Return 429 with retry-after header
-
-### Code Quality
-- [x] Types: Define RequestDTO, ResponseDTO, ErrorResponse
-- [x] Patterns: Follow existing controller pattern in `src/api/`
-- [ ] Error boundaries: N/A (API, not UI)
-- [x] No magic strings: Use constants for error messages
-
-### Test Coverage Plan
-- [x] Unit: Validation logic, data transformation
-- [x] Integration: Full request/response cycle
-- [x] Edge cases: Empty results, max pagination, invalid IDs
-- [x] Mocking: Mock database, not HTTP layer
-
-### Best Practices
-- [x] Logging: Log request ID, duration, status code
-- [ ] Accessibility: N/A (API)
-- [x] Performance: Add database index for query field
-- [x] Security: Validate input, sanitize output, check auth
-
-### Derived ACs
-
-| Source | Derived AC | Priority |
-|--------|-----------|----------|
-| Error Handling | AC-6: Return 429 with retry-after header on rate limit | Medium |
-| Best Practices | AC-7: Log request ID and duration for observability | High |
-| Test Coverage | AC-8: Add integration test for auth failure path | High |
-```
-
-### 4. Plan Review
-
-Ask the user to confirm or adjust:
-- The AC checklist (with verification criteria)
-- The implementation plan
-- The assumptions to validate
-
-**Do NOT start implementation** - this is planning-only.
-
-### 4.5. Assess Comment Detection (AC-4, AC-5)
-
-**Before making your own phase recommendation**, check if `/assess` has already posted an analysis comment to this issue:
-
-```bash
-# Check for assess analysis comment on the issue (includes legacy /solve format for backward compat)
-assess_comment=$(gh issue view <issue-number> --json comments \
-  --jq '[.comments[].body | select(test("## Assess Analysis|## Solve Analysis|<!-- assess:phases=|<!-- solve:phases="))] | last // empty')
-```
-
-**If an assess analysis comment exists:**
-
-1. Parse the HTML comment markers to extract the recommended phases:
-   ```
-   <!-- assess:phases=exec,qa -->        → phases: ["exec", "qa"] (spec not included = skip spec)
-   <!-- assess:browser-test=false -->    → no browser testing needed
-   <!-- assess:quality-loop=true -->     → enable quality loop
-   ```
-
-2. **Use the assess recommendation as your starting point** for the phase recommendation in step 5.
-
-3. **You may override the assess recommendation**, but you MUST document why:
-   ```markdown
-   ## Recommended Workflow
-
-   **Phases:** spec → exec → test → qa
-   **Quality Loop:** enabled
-   **Reasoning:** Assess recommended `exec → qa`, but codebase analysis reveals UI components
-   are affected (found `.tsx` files in change scope), so browser testing is needed.
-   Overriding assess recommendation with explanation.
-   ```
-
-4. If the assess comment recommends phases that don't include `spec` (e.g., `phases=exec,qa`), acknowledge this in your output but proceed with spec since `/spec` was explicitly invoked.
-
-**If no assess analysis comment exists:** Proceed with your own analysis as normal (step 5).
-
-### 5. Recommended Workflow
-
-Analyze the issue and recommend the optimal workflow phases:
-
-```markdown
-## Recommended Workflow
-
-**Phases:** spec → exec → qa
-**Quality Loop:** disabled
-**Reasoning:** [Brief explanation of why these phases were chosen]
-```
-
-**Phase Selection Logic:**
-- **UI/Frontend changes** → Add `test` phase (browser testing)
-- **`no-browser-test` label** → Skip `test` phase (explicit opt-out, overrides UI labels)
-- **Bug fixes** → Skip `spec` if already well-defined
-- **Complex refactors** → Enable quality loop
-- **Security-sensitive** → Add `security-review` phase
-- **Documentation only** → Skip `spec`, just `exec → qa`
-- **New features with testable ACs** → Add `testgen` phase after spec
-- **Refactors needing regression tests** → Add `testgen` phase
-
-#### Browser Testing Label Suggestion
-
-**When `.tsx` or `.jsx` file references are detected** in the issue body AND the issue does NOT have `ui`, `frontend`, or `admin` labels, include this warning in the spec output:
-
-```markdown
-> **Component files detected** — Issue body references `.tsx`/`.jsx` files or `components/` directory, but no `ui`/`frontend`/`admin` label is present.
-> - To enable browser testing: add the `ui` label → `gh issue edit <N> --add-label ui`
-> - To explicitly skip browser testing: add `no-browser-test` label → `gh issue edit <N> --add-label no-browser-test`
-> - Without either label, QA will note the missing browser test coverage.
-```
-
-**When NOT to show this warning:**
-- Issue already has `ui`, `frontend`, or `admin` label (browser testing already enabled)
-- Issue has `no-browser-test` label (explicit opt-out)
-- No `.tsx`/`.jsx`/`components/` references detected
-
-#### Testgen Phase Auto-Detection
-
-**When to recommend `testgen` phase:**
-
-| Condition | Recommend testgen? | Reasoning |
-|-----------|-------------------|-----------|
-| ACs have "Unit Test" verification method | ✅ Yes | Tests should be stubbed before implementation |
-| ACs have "Integration Test" verification method | ✅ Yes | Complex integration tests benefit from early structure |
-| Issue is a new feature (not bug fix) with >2 AC items | ✅ Yes | Features need test coverage |
-| Issue has `enhancement` or `feature` label | ✅ Yes | New functionality needs tests |
-| Project has test framework (Jest, Vitest, etc.) | ✅ Yes | Infrastructure exists to run tests |
-| Issue is a simple bug fix (`bug` label only) | ❌ No | Bug fixes typically have targeted tests |
-| Issue is docs-only (`docs` label) | ❌ No | Documentation doesn't need unit tests |
-| All ACs have "Manual Test" or "Browser Test" verification | ❌ No | These don't generate code stubs |
-
-**Detection Logic:**
-
-1. **Check verification methods in AC items:**
-   - Count ACs with "Unit Test" → If >0, recommend testgen
-   - Count ACs with "Integration Test" → If >0, recommend testgen
-
-2. **Check issue labels:**
-   ```bash
-   gh issue view <issue> --json labels --jq '.labels[].name'
-   ```
-   - If `bug` or `fix` is the ONLY label → Skip testgen
-   - If `docs` is present → Skip testgen
-   - If `enhancement`, `feature`, `refactor` → Consider testgen
-
-3. **Check project test infrastructure:**
-   ```bash
-   # Check for test framework in package.json
-   grep -E "jest|vitest|mocha" package.json || true
-   ```
-   - If no test framework detected → Skip testgen (no infrastructure)
-
-**Example output when testgen is recommended:**
-
-```markdown
-## Recommended Workflow
-
-**Phases:** spec → testgen → exec → qa
-**Quality Loop:** disabled
-**Reasoning:** ACs include Unit Test verification methods; testgen will create stubs before implementation
-```
-
-**Example output when testgen is NOT recommended:**
-
-```markdown
-## Recommended Workflow
-
-**Phases:** spec → exec → qa
-**Quality Loop:** disabled
-**Reasoning:** Bug fix with targeted scope; existing tests sufficient
-```
-
-### 6. Label Review
-
-Analyze current labels vs implementation plan and suggest updates:
-
-```markdown
-## Label Review
-
-**Current:** enhancement
-**Recommended:** enhancement, refactor
-**Reason:** Implementation plan involves structural changes to 5+ files
-**Quality Loop:** Will auto-enable due to `refactor` label
-
-→ `gh issue edit <N> --add-label refactor`
-```
-
-**Plan-Based Detection Logic:**
-- If plan has 5+ file changes → suggest `refactor`
-- If plan touches UI components → suggest `ui` or `frontend`
-- If plan has breaking API changes → suggest `breaking`
-- If plan involves database migrations → suggest `backend`, `complex`
-- If plan involves CLI/scripts → suggest `cli`
-- If plan is documentation-only → suggest `docs`
-- If recommended workflow includes quality loop → ensure matching label exists (`complex`, `refactor`, or `breaking`)
-
-**Label Inference from Plan Analysis:**
-- Count files in implementation plan steps
-- Identify component types being modified
-- Check if API contracts are changing
-- Match against quality loop trigger labels
-
-### 7. Issue Comment Draft
-
-Generate a Markdown snippet with:
-- AC checklist with verification criteria
-- Verification methods summary
-- Consolidated assumptions checklist
-- Implementation plan with phases
-- Key decisions and rationale
-- Open questions with recommendations
-- Effort breakdown
-
-Label clearly as:
-```md
---- DRAFT GITHUB ISSUE COMMENT (PLAN) ---
-```
-
-### 8. Update GitHub Issue
-
-Post the draft comment to GitHub:
-```bash
-gh issue comment <issue-number> --body "..."
-gh issue edit <issue-number> --add-label "planned"
-```
-
----
-
-## Output Verification
-
-**Before responding, verify your output includes ALL of these:**
-
-- [ ] **AC Quality Check** - Lint results (or "Skipped" if --skip-ac-lint)
-- [ ] **Scope Assessment** - Verdict and metrics (or "Skipped" if --skip-scope-check)
-- [ ] **Non-Goals Section** - Listed or warning if missing
-- [ ] **AC Checklist** - Numbered AC items (AC-1, AC-2, etc.) with descriptions
-- [ ] **Verification Criteria (REQUIRED)** - Each AC MUST have:
-  - Explicit Verification Method (Unit Test, Integration Test, Browser Test, or Manual Test)
-  - Test Scenario with Given/When/Then format
-  - If unclear, flag as "⚠️ UNCLEAR" and add to Open Questions
-- [ ] **Conflict Risk Analysis** - Check for in-flight work, include if conflicts found
-- [ ] **Implementation Plan** - 3-7 concrete steps with codebase references
-- [ ] **Design Review** - All 4 questions answered (abbreviated to Q1+Q3 for simple-fix/typo/docs-only labels)
-- [ ] **Feature Quality Planning** - Quality dimensions checklist completed (abbreviated for simple-fix/typo/docs-only labels)
-- [ ] **Recommended Workflow** - Phases, Quality Loop setting, and Reasoning (auto-enable quality loop if scope is yellow/red)
-- [ ] **Label Review** - Current vs recommended labels based on plan analysis
-- [ ] **Open Questions** - Any ambiguities with recommended defaults (including unclear verification methods)
-- [ ] **Issue Comment Draft** - Formatted for GitHub posting
-
-**CRITICAL:** Do NOT output AC items without verification methods. Either:
-1. Assign a verification method from the decision framework, or
-2. Flag as "⚠️ UNCLEAR" and include in Open Questions
-
-**DO NOT respond until all items are verified.**
+Check issue body/labels for feature branch references (`feature/`, `based on`, epic labels). If found, recommend `--base feature/<branch>` in the plan.
 
 ## Output Template
 
-You MUST include these sections in order:
+**Single authoritative template.** Include ALL sections in this order. Scale detail by complexity tier.
 
 ```markdown
+**Complexity: [Simple|Standard|Complex]** ([N] ACs, [N] directories)
+
 ## AC Quality Check
 
-[Output from AC linter, or "Skipped (--skip-ac-lint flag set)"]
+[Inline analysis results, or "Skipped (--skip-ac-lint)"]
 
 ---
 
 ## Scope Assessment
 
-### Non-Goals (Required)
-
-[List non-goals from issue, or warning if missing]
-
-### Scope Metrics
+**Non-Goals:** [From issue body. If missing: "⚠️ Non-Goals section not found. Consider adding scope boundaries."]
 
 | Metric | Value | Status |
 |--------|-------|--------|
@@ -970,9 +158,9 @@ You MUST include these sections in order:
 | AC items | [N] | [✅/⚠️/❌] |
 | Directory spread | [N] | [✅/⚠️/❌] |
 
-### Scope Verdict
+**Verdict:** [✅ SCOPE_OK | ⚠️ SCOPE_WARNING | ❌ SCOPE_SPLIT_RECOMMENDED]
 
-[✅/⚠️/❌] **[SCOPE_OK/SCOPE_WARNING/SCOPE_SPLIT_RECOMMENDED]** - [Recommendation]
+[Or "Skipped (--skip-scope-check)"]
 
 ---
 
@@ -980,116 +168,85 @@ You MUST include these sections in order:
 
 ### AC-1: [Description]
 
-**Verification Method:** [Unit Test | Integration Test | Browser Test | Manual Test]
+**Verification:** [Unit Test | Integration Test | Browser Test | Manual Test]
+**Scenario:** Given [state] → When [action] → Then [outcome]
+**Assumptions:** [List any that need pre-coding validation]
 
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action]
-- Then: [Expected outcome]
-
-### AC-2: [Description]
-
-**Verification Method:** [Choose from decision framework]
-
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action]
-- Then: [Expected outcome]
-
-### AC-N: [Unclear AC example]
-
-**Verification Method:** ⚠️ UNCLEAR - [reason why verification is unclear]
-
-**Suggested Refinement:** [How to make this AC testable]
-
-<!-- Continue for all AC items -->
+<!-- Repeat for all ACs.
+     EVERY AC must have a Verification Method. If unclear, flag as "⚠️ UNCLEAR" with suggested refinement.
+     See references/verification-criteria.md for method selection guide. -->
 
 ---
 
 ## Implementation Plan
 
-### Phase 1: [Phase Name]
-1. [Step with specific file/component references]
+### Phase 1: [Name]
+1. [Step referencing specific files/components from context gathering]
 2. [Step]
 
-### Phase 2: [Phase Name]
-<!-- Continue for all phases -->
+### Phase 2: [Name]
+<!-- 3-7 total steps. Group into phases. Note dependencies between steps.
+     For major decisions: present 2-3 options, recommend default with rationale.
+     See references/parallel-groups.md for parallel execution format (3+ independent tasks). -->
 
 ---
 
 ## Design Review
 
 1. **Where does this logic belong?** [Module/layer that owns this change]
-
 2. **What's the simplest correct approach?** [Minimum implementation, rejected alternatives]
+3. **What existing pattern does this follow?** [Named pattern, confirm it fits]
+4. **What would a senior reviewer challenge?** [Anticipated "why didn't you just...?" pushback]
 
-3. **What existing pattern does this follow?** [Named pattern, confirmation it fits]
-
-4. **What would a senior reviewer challenge?** [Anticipated pushback]
-
-<!-- For simple-fix/typo/docs-only: only Q1 and Q3 required -->
+<!-- Simple tier: Q1 and Q3 only. Standard/Complex: all four. -->
 
 ---
 
 ## Feature Quality Planning
 
-### Completeness Check
-- [ ] All AC items have corresponding implementation steps
-- [ ] Integration points identified
-- [ ] No partial implementations planned
+<!-- Exception-based: report only gaps and concerns. Full checklist in references/quality-checklist.md -->
 
-### Error Handling
-- [ ] Invalid input scenarios identified
-- [ ] External service failures handled
-- [ ] Edge cases documented
+**All standard checks pass.** Notable items:
+- [Gap or concern requiring attention]
+- [Another gap if applicable]
 
-### Code Quality
-- [ ] Types fully defined (no `any`)
-- [ ] Follows existing patterns
-- [ ] No magic strings/numbers
+### Derived ACs (if any)
 
-### Test Coverage Plan
-- [ ] Unit tests for business logic
-- [ ] Edge case tests identified
-- [ ] Critical paths covered
-
-### Best Practices
-- [ ] Logging for observability
-- [ ] Security reviewed
-- [ ] Documentation updated
-
-### Polish (UI only)
-- [ ] Loading/error/empty states
-- [ ] Responsive design
-
-### Derived ACs
 | Source | Derived AC | Priority |
 |--------|-----------|----------|
-| [Section] | AC-N: [Description] | High/Medium/Low |
+| [Quality dimension] | AC-N: [Description] | High/Medium/Low |
+
+<!-- Complex tier: walk through full checklist from references/quality-checklist.md -->
 
 ---
 
 ## Open Questions
 
-1. **[Question]**
-   - Recommendation: [Default choice]
-   - Impact: [What happens if wrong]
+1. **[Question]** — Recommendation: [default]. Impact: [if wrong].
 
 ---
 
 ## Recommended Workflow
 
-**Phases:** exec → qa
-**Quality Loop:** disabled
-**Reasoning:** [Why these phases based on issue analysis]
+**Phases:** [spec →] exec → qa
+**Quality Loop:** [enabled/disabled]
+**Reasoning:** [Brief explanation]
+
+<!-- Decision logic:
+     - UI/frontend → add `test` phase
+     - `no-browser-test` label → skip `test` (overrides UI labels)
+     - Complex refactor → enable quality loop
+     - Security-sensitive → add `security-review` phase
+     - New features with Unit/Integration Test verification ACs → add `testgen` phase
+     - Docs-only → skip spec, just exec → qa -->
 
 ---
 
 ## Label Review
 
-**Current:** [current labels]
-**Recommended:** [recommended labels]
-**Reason:** [Why these labels based on plan analysis]
+**Current:** [labels]
+**Recommended:** [labels]
+**Reason:** [Why, based on plan analysis]
 **Quality Loop:** [Will/Won't auto-enable and why]
 
 → `gh issue edit <N> --add-label [label]`
@@ -1098,5 +255,32 @@ You MUST include these sections in order:
 
 --- DRAFT GITHUB ISSUE COMMENT (PLAN) ---
 
-[Complete formatted comment for GitHub]
+[AC checklist with verification + implementation plan + key decisions + open questions]
 ```
+
+### Browser Testing Label Suggestion
+
+When `.tsx`/`.jsx` references detected in issue body AND no `ui`/`frontend`/`admin` label present:
+> **Component files detected** — add `ui` label for browser testing, or `no-browser-test` to explicitly skip.
+
+### Assess Comment Integration
+
+Before making phase recommendations, check for prior `/assess` analysis:
+
+```bash
+assess_comment=$(gh issue view <N> --json comments \
+  --jq '[.comments[].body | select(test("## Assess Analysis|<!-- assess:phases="))] | last // empty')
+```
+
+If found, use assess recommendation as starting point. You may override, but MUST document why.
+
+## Update GitHub Issue
+
+Post the draft comment and add label:
+
+```bash
+gh issue comment <issue-number> --body "..."
+gh issue edit <issue-number> --add-label "planned"
+```
+
+**Do NOT start implementation** — this is planning-only.

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -288,6 +288,30 @@ See [verification-criteria.md](references/verification-criteria.md) for detailed
 [AC checklist with verification + implementation plan + key decisions + open questions]
 ```
 
+### Testgen Phase Auto-Detection
+
+#### When to recommend `testgen` phase:
+
+| Condition | Recommend testgen? | Reasoning |
+|-----------|-------------------|-----------|
+| ACs have "Unit Test" verification method | Yes | Tests should be stubbed before implementation |
+| ACs have "Integration Test" verification method | Yes | Complex integration tests benefit from early structure |
+| New feature (`enhancement`/`feature` label) with >2 ACs | Yes | Features need test coverage |
+| Simple bug fix (`bug` label only) | No | Skip testgen — targeted tests sufficient |
+| Docs-only (`docs` label) | No | Skip testgen — no unit tests needed |
+| All ACs have "Manual Test" or "Browser Test" | No | Skip testgen — no code stubs to generate |
+
+**Detection logic:**
+1. Count ACs with "Unit Test" → If >0, recommend testgen
+2. Count ACs with "Integration Test" → If >0, recommend testgen
+3. Check labels: `bug`/`fix` only → Skip testgen. `docs` → Skip testgen.
+
+**Example when testgen recommended:**
+```markdown
+**Phases:** spec → testgen → exec → qa
+**Reasoning:** ACs include Unit Test verification methods; testgen will create stubs before implementation
+```
+
 ### Browser Testing Label Suggestion
 
 When `.tsx`/`.jsx` references detected in issue body AND no `ui`/`frontend`/`admin` label present:

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -2,9 +2,9 @@
 name: spec
 description: "Plan review vs Acceptance Criteria for a single GitHub issue, plus issue comment draft."
 license: MIT
-version: "2.1"
 metadata:
   author: sequant
+  version: "2.1"
 allowed-tools:
   - Bash(npm test:*)
   - Bash(gh issue view:*)

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -197,6 +197,15 @@ See [verification-criteria.md](references/verification-criteria.md) for detailed
 <!-- Repeat for all ACs. EVERY AC must have a Verification Method from the decision framework.
      If unclear, flag as "⚠️ UNCLEAR" with suggested refinement. -->
 
+<!-- Example of a completed AC entry:
+
+### AC-3: User can submit the registration form
+
+**Verification:** Browser Test
+**Scenario:** Given user on /register → When fill fields and click Submit → Then redirect to /dashboard with success toast
+**Assumptions:** Auth API returns 201 on valid input; email uniqueness enforced by DB constraint
+-->
+
 ---
 
 ## Implementation Plan

--- a/.claude/skills/spec/references/quality-checklist.md
+++ b/.claude/skills/spec/references/quality-checklist.md
@@ -1,0 +1,75 @@
+# Feature Quality Planning — Full Checklist
+
+Use this checklist for **Complex** tier issues or when the exception-based summary in SKILL.md flags significant gaps. For Simple/Standard tiers, the exception-based approach in the main prompt is sufficient.
+
+## Section Applicability
+
+| Issue Type | Sections Required |
+|------------|-------------------|
+| Bug fix | Completeness, Error Handling, Test Coverage |
+| New feature | All sections |
+| Refactor | Completeness, Code Quality, Test Coverage |
+| UI change | All sections including Polish |
+| Backend/API | Completeness, Error Handling, Code Quality, Test Coverage, Best Practices |
+| CLI/Script | Completeness, Error Handling, Test Coverage, Best Practices |
+| Docs only | Completeness only |
+
+## Completeness Check
+
+- [ ] All AC items have corresponding implementation steps
+- [ ] Integration points with existing features identified
+- [ ] No partial implementations or TODOs planned
+- [ ] State management considered (if applicable)
+- [ ] Data flow is complete end-to-end
+
+## Error Handling
+
+- [ ] Invalid input scenarios identified
+- [ ] API/external service failures handled
+- [ ] Edge cases documented (empty, null, max values)
+- [ ] Error messages are user-friendly
+- [ ] Graceful degradation planned
+
+## Code Quality
+
+- [ ] Types fully defined (no `any` planned)
+- [ ] Follows existing patterns in codebase
+- [ ] Error boundaries where needed
+- [ ] No magic strings/numbers
+- [ ] Consistent naming conventions
+
+## Test Coverage Plan
+
+- [ ] Unit tests for business logic
+- [ ] Integration tests for data flow
+- [ ] Edge case tests identified
+- [ ] Mocking strategy appropriate
+- [ ] Critical paths have test coverage
+
+## Best Practices
+
+- [ ] Logging for debugging/observability
+- [ ] Accessibility considerations (if UI)
+- [ ] Performance implications considered
+- [ ] Security reviewed (auth, validation, sanitization)
+- [ ] Documentation updated (if behavior changes)
+
+## Polish (UI features only)
+
+- [ ] Loading states planned
+- [ ] Error states have UI
+- [ ] Empty states handled
+- [ ] Responsive design considered
+- [ ] Keyboard navigation works
+
+## Derived ACs
+
+Based on quality planning, identify additional ACs:
+
+| Source | Derived AC | Priority |
+|--------|-----------|----------|
+| Error Handling | AC-N: Handle [specific error] with [specific response] | High/Medium/Low |
+| Test Coverage | AC-N+1: Add tests for [specific scenario] | High/Medium/Low |
+| Best Practices | AC-N+2: Add logging for [specific operation] | High/Medium/Low |
+
+Derived ACs are numbered sequentially after original ACs.

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -115,6 +115,10 @@ program
     "--mcp",
     "Add Sequant MCP server to detected clients (use with --yes)",
   )
+  .option(
+    "--upgrade-skills",
+    "Upgrade skill files from installed package templates (with diff preview)",
+  )
   .action(initCommand);
 
 program

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -78,7 +78,14 @@ Mark tier in HTML comment for downstream parsing: `<!-- SEQUANT_SPEC_TIER: [tier
 
 1. **AC Extraction & Storage:** Use `extractAcceptanceCriteria` from `./src/lib/ac-parser.ts` and `StateManager` from `./src/lib/workflow/state-manager.ts` to parse and store AC in `.sequant/state.json`. Supports formats: `- [ ] **AC-1:** Desc`, `- [ ] AC-1: Desc`, `- [ ] **B2:** Desc`.
 
-2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Flags vague ("should work"), unmeasurable ("fast"), incomplete ("handle errors"), open-ended ("etc."). Warning-only — does not block planning.
+2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Warning-only — does not block planning. Flag these patterns:
+
+   | Pattern | Examples | Issue |
+   |---------|----------|-------|
+   | Vague | "should work", "properly" | No measurable outcome |
+   | Unmeasurable | "fast", "performant" | No threshold defined |
+   | Incomplete | "handle errors", "edge cases" | Scenarios not enumerated |
+   | Open-ended | "etc.", "and more" | Scope undefined |
 
 3. **Scope Assessment** (unless `--skip-scope-check`): Use `performScopeAssessment` from `./src/lib/scope/index.ts` with settings from `getSettings()`. Verdicts: SCOPE_OK (green), SCOPE_WARNING (yellow, auto-enables quality loop), SCOPE_SPLIT_RECOMMENDED (red). Store results in state.
 
@@ -135,6 +142,21 @@ Check for explicit dependencies: `gh issue view <issue> --json body,labels`. If 
 
 Check issue body/labels for feature branch references (`feature/`, `based on`, epic labels). If found, recommend `--base feature/<branch>` in the plan.
 
+## Verification Method Decision Framework
+
+Use this table when assigning verification methods to each AC:
+
+| AC Type | Method | When to Use |
+|---------|--------|-------------|
+| Pure logic/calculation | Unit Test | Clear input/output, no side effects |
+| API endpoint | Integration Test | HTTP handlers, DB queries, external calls |
+| User workflow | Browser Test | Multi-step UI interactions, forms |
+| Visual appearance | Manual Test | Styling, layout, animations |
+| CLI command | Integration Test | Script execution, stdout verification |
+| Error handling | Unit + Integration | Both isolated and realistic scenarios |
+
+See [verification-criteria.md](references/verification-criteria.md) for detailed examples.
+
 ## Output Template
 
 **Single authoritative template.** Include ALL sections in this order. Scale detail by complexity tier.
@@ -172,9 +194,8 @@ Check issue body/labels for feature branch references (`feature/`, `based on`, e
 **Scenario:** Given [state] → When [action] → Then [outcome]
 **Assumptions:** [List any that need pre-coding validation]
 
-<!-- Repeat for all ACs.
-     EVERY AC must have a Verification Method. If unclear, flag as "⚠️ UNCLEAR" with suggested refinement.
-     See references/verification-criteria.md for method selection guide. -->
+<!-- Repeat for all ACs. EVERY AC must have a Verification Method from the decision framework.
+     If unclear, flag as "⚠️ UNCLEAR" with suggested refinement. -->
 
 ---
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -2,9 +2,9 @@
 name: spec
 description: "Plan review vs Acceptance Criteria for a single GitHub issue, plus issue comment draft."
 license: MIT
+version: "2.1"
 metadata:
   author: sequant
-  version: "1.0"
 allowed-tools:
   - Bash(npm test:*)
   - Bash(gh issue view:*)
@@ -13,414 +13,240 @@ allowed-tools:
   - Bash(gh label:*)
   - Bash(git worktree:*)
   - Bash(git -C:*)
-  - Task
+  - Agent(sequant-explorer)
   - AgentOutputTool
 ---
 
 # Planning Agent
 
-You are the Phase 1 "Planning Agent" for the current repository.
+Phase 1 "Planning Agent." Understands the issue and AC, reviews or synthesizes a plan, identifies gaps and risks, and drafts a GitHub issue comment.
 
-## Purpose
+## Platform Detection — Run First
 
-When invoked as `/spec`, your job is to:
+```bash
+gh --version >/dev/null 2>&1 && GITHUB_AVAILABLE=true || GITHUB_AVAILABLE=false
+SETTINGS_AVAILABLE=false; [ -f ".sequant/settings.json" ] && SETTINGS_AVAILABLE=true
+```
 
-1. Understand the issue and Acceptance Criteria (AC).
-2. Review or synthesize a clear plan to address the AC.
-3. Identify ambiguities, gaps, or risks.
-4. Draft a GitHub issue comment summarizing AC + the agreed plan.
+- **GitHub unavailable:** Skip phase detection, label review, auto-comment. Prompt user for AC from description text.
+- **Settings unavailable:** Use defaults silently (sequential agents, no custom scope config).
+
+## Phase Detection
+
+If GitHub is available, check for prior phase completion:
+
+```bash
+phase_data=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]' | \
+  grep -o '{[^}]*}' | grep '"phase"' | tail -1 || true)
+```
+
+- `spec:completed` or later phase detected → Skip with message
+- `spec:failed` → Re-run
+- No markers / API error → Normal execution
+
+Append to every phase-completion comment:
+```
+<!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"<ISO-8601>"} -->
+```
 
 ## Behavior
 
-When called like `/spec 123`:
-1. Treat `123` as a GitHub issue number.
-2. **Read all GitHub issue comments** for complete context.
-3. Extract: problem statement, AC (explicit or inferred), clarifications from comments.
+**`/spec 123`** — GitHub issue number. Read all comments for full context. Extract AC.
+**`/spec <text>`** — Freeform problem/AC source. Ask clarifying questions if ambiguous.
 
-When called like `/spec <freeform description>`:
-1. Treat the text as the problem/AC source.
-2. Ask clarifying questions if AC are ambiguous or conflicting.
+**Flags:** `--skip-ac-lint` (skip AC quality check), `--skip-scope-check` (skip scope assessment).
 
-### Feature Worktree Workflow
+## Complexity Tier Determination
 
-**Planning Phase:** No worktree needed. Planning happens in the main repository directory. The worktree will be created during the execution phase (`/exec`).
+Determine the output tier **before** generating any output. Announce it as the first line.
 
-### Parallel Context Gathering — REQUIRED
+| Tier | Criteria | Output Scope | Target |
+|------|----------|--------------|--------|
+| **Simple** | `simple-fix`/`typo`/`docs-only` label, or `bug` with ≤2 AC | AC list + plan + Design Review Q1/Q3 only | <4,000 chars |
+| **Standard** | 3–8 AC, no complexity labels | Full output minus Polish, minus trivially-passing quality checks | <8,000 chars |
+| **Complex** | `complex`/`refactor`/`breaking` label, or 9+ AC | Full output including all quality dimensions | <15,000 chars |
 
-**You MUST spawn sub-agents for context gathering.** Do NOT explore the codebase inline with Glob/Grep commands. Sub-agents provide parallel execution, better context isolation, and consistent reporting.
+First line of output: `**Complexity: [Tier]** ([N] ACs, [N] directories)`
 
-**Spawn ALL THREE agents in a SINGLE message:**
+Mark tier in HTML comment for downstream parsing: `<!-- SEQUANT_SPEC_TIER: [tier] -->`
 
-1. `Agent(subagent_type="sequant-explorer", prompt="Find similar features for [FEATURE]. Check components/admin/, lib/queries/, docs/patterns/. Report: file paths, patterns, recommendations.")`
+## Programmatic Checks (Conditional)
 
-2. `Agent(subagent_type="sequant-explorer", prompt="Explore [CODEBASE AREA] for [FEATURE]. Find: main components, data flow, key files. Report structure.")`
+**Guard:** Only run `npx tsx` blocks if `./src/lib/ac-parser.ts` exists (sequant repo). Otherwise, perform all analysis inline by reading the issue text directly.
 
-3. `Agent(subagent_type="sequant-explorer", prompt="Inspect database for [FEATURE]. Check: table schema, RLS policies, existing queries. Report findings.")`
+### If guard passes:
 
-### In-Flight Work Analysis (Conflict Detection)
+1. **AC Extraction & Storage:** Use `extractAcceptanceCriteria` from `./src/lib/ac-parser.ts` and `StateManager` from `./src/lib/workflow/state-manager.ts` to parse and store AC in `.sequant/state.json`. Supports formats: `- [ ] **AC-1:** Desc`, `- [ ] AC-1: Desc`, `- [ ] **B2:** Desc`.
 
-Before creating the implementation plan, scan for potential conflicts with in-flight work:
+2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Flags vague ("should work"), unmeasurable ("fast"), incomplete ("handle errors"), open-ended ("etc."). Warning-only — does not block planning.
 
-1. **List open worktrees**:
-   ```bash
-   git worktree list --porcelain
-   ```
+3. **Scope Assessment** (unless `--skip-scope-check`): Use `performScopeAssessment` from `./src/lib/scope/index.ts` with settings from `getSettings()`. Verdicts: SCOPE_OK (green), SCOPE_WARNING (yellow, auto-enables quality loop), SCOPE_SPLIT_RECOMMENDED (red). Store results in state.
 
-2. **For each worktree, get changed files**:
-   ```bash
-   git -C <worktree-path> diff --name-only main...HEAD
-   ```
+### If guard fails (consumer projects):
 
-3. **Analyze this issue's likely file touches** based on:
-   - Issue description and AC
-   - Similar past issues
-   - Codebase structure
+Perform the same analysis inline:
+- Extract AC by pattern-matching the issue body
+- Flag vague/unmeasurable AC in the AC Quality Check section
+- Assess scope using the same green/yellow/red heuristics on feature count, AC count, directory spread
 
-4. **If overlap detected**, include in plan output:
-   ```markdown
-   ## Conflict Risk Analysis
+## Context Gathering
 
-   **In-flight work detected**: Issue #<N> (feature/<branch-name>)
-   **Overlapping files**:
-   - `<file-path>`
+### Discover Project Structure — REQUIRED
 
-   **Recommended approach**:
-   - [ ] Option A: Use alternative file/approach (no conflict)
-   - [ ] Option B: Wait for #<N> to merge, then rebase
-   - [ ] Option C: Coordinate unified implementation via /merger
+**Do NOT use hardcoded paths.** Discover what actually exists:
 
-   **Selected**: [To be decided during spec review]
-   ```
-
-5. **Check for explicit dependencies**:
-   ```bash
-   # Look for "Depends on" or "depends-on" labels
-   gh issue view <issue> --json body,labels
-   ```
-
-   If dependencies found:
-   ```markdown
-   ## Dependencies
-
-   **Depends on**: #<N>
-   **Reason**: [Why this issue depends on the other]
-   **Status**: [Open/Merged/Closed]
-   ```
-
-### MCP Tools (Optional - Graceful Degradation)
-
-MCP tools enhance `/spec` but are **not required**. The skill works fully without them.
-
-#### MCP Availability Check
-
-Before using MCP tools, verify they are available. If unavailable, use the fallback strategies.
-
-| MCP Tool | Purpose | Fallback When Unavailable |
-|----------|---------|---------------------------|
-| Sequential Thinking | Complex multi-step analysis | Use explicit step-by-step reasoning in response |
-| Context7 | Library documentation lookup | Use WebSearch or read existing codebase patterns |
-
-#### Sequential Thinking Fallback
-
-**When to use Sequential Thinking:**
-- Issues with 5+ AC items requiring dependency analysis
-- Architectural decisions with multiple trade-offs
-- Complex conflict resolution between in-flight work
-
-**If unavailable:**
-1. Break analysis into explicit numbered steps in your response
-2. Create a pros/cons table for architectural decisions
-3. Document trade-offs before making recommendations
-
-```markdown
-## Analysis Steps (Manual Sequential Thinking)
-
-**Step 1:** [Analysis of first aspect]
-**Step 2:** [Analysis of second aspect]
-**Step 3:** [Synthesis and recommendation]
-```
-
-#### Context7 Fallback
-
-**When to use Context7:**
-- Planning features that use unfamiliar libraries
-- Checking for API patterns in third-party dependencies
-- Understanding framework-specific conventions
-
-**If unavailable:**
-1. Search codebase with Grep for existing usage patterns
-2. Use WebSearch to find official documentation
-3. Check library's package.json or README in node_modules
-4. Look for similar features in the codebase as reference
-
-## Context Gathering Strategy
-
-1. **Check the Patterns Catalog first**
-   - Read `docs/patterns/README.md` for quick lookup
-   - Check HELPERS.md, COMPONENTS.md, TYPES.md
-   - **Do NOT propose creating new utilities if similar ones exist**
-
-2. **Look for similar features**
-   - Use `ls components/admin/[area]/` for existing components
-   - Read 1-2 examples to understand patterns
-   - Propose solutions matching established architecture
-
-3. **Check existing dependencies**
-   - Review `package.json` for libraries
-   - Prefer existing dependencies over new ones
-
-4. **For database-heavy features**
-   - Verify table schemas against TypeScript types
-   - Check proposed types match database columns
-
-5. **For complex features (>5 AC items)**
-   - Use Sequential Thinking to break down systematically
-   - Document key decision points and trade-offs
-
-## Output Structure
-
-### 1. AC Checklist with Verification Criteria
-
-Restate AC as a checklist with verification for each:
-
-```markdown
-### AC-1: [Description]
-
-**Verification Method:** Unit Test | Integration Test | Manual Test | Browser Test
-
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action taken]
-- Then: [Expected outcome]
-
-**Integration Points:**
-- [External system or component]
-
-**Assumptions to Validate:**
-- [ ] [Assumption that must be true]
-```
-
-See [verification-criteria.md](references/verification-criteria.md) for detailed examples including the #452 hooks failure case.
-
-### 2. Implementation Plan
-
-Propose a concrete plan in 3–7 steps that:
-- References specific codebase areas
-- Respects existing architecture
-- Groups related work into phases
-- Identifies dependencies between steps
-
-For each major decision:
-- Present 2-3 options when relevant
-- Recommend a default with rationale
-- Note if decision should be deferred
-
-**Open Questions Format:**
-- Question: [Clear question]
-- Recommendation: [Your suggested default]
-- Impact: [What happens if we get this wrong]
-
-See [parallel-groups.md](references/parallel-groups.md) for parallelization format.
-
-### 2.5. Design Review (REQUIRED)
-
-**Purpose:** Make design decisions explicit before implementation starts — catch wrong-layer, over-engineered, or pattern-mismatched approaches before code is written.
-
-**Complexity Scaling:**
-- **Simple issues** (`simple-fix`, `typo`, `docs-only` labels): Answer Q1 and Q3 only
-- **Standard/Complex issues**: Answer all 4 questions
-
-**Questions:**
-
-1. **Where does this logic belong?** — Which module/layer owns this change?
-2. **What's the simplest correct approach?** — Reject over-engineering. Minimum implementation that satisfies all AC.
-3. **What existing pattern does this follow?** — Name the specific pattern, confirm it fits.
-4. **What would a senior reviewer challenge?** — Anticipate "why didn't you just...?" feedback.
-
-### 3. Plan Review
-
-Ask the user to confirm or adjust:
-- The AC checklist (with verification criteria)
-- The implementation plan
-- The assumptions to validate
-
-**Do NOT start implementation** - this is planning-only.
-
-### 4. Recommended Workflow
-
-Analyze the issue and recommend the optimal workflow phases:
-
-```markdown
-## Recommended Workflow
-
-**Phases:** spec → exec → qa
-**Quality Loop:** disabled
-**Reasoning:** [Brief explanation of why these phases were chosen]
-```
-
-**Phase Selection Logic:**
-- **UI/Frontend changes** → Add `test` phase (browser testing)
-- **`no-browser-test` label** → Skip `test` phase (explicit opt-out, overrides UI labels)
-- **Bug fixes** → Skip `spec` if already well-defined
-- **Complex refactors** → Enable quality loop
-- **Security-sensitive** → Add `security-review` phase
-- **Documentation only** → Skip `spec`, just `exec → qa`
-
-#### Browser Testing Label Suggestion
-
-**When `.tsx` or `.jsx` file references are detected** in the issue body AND the issue does NOT have `ui`, `frontend`, or `admin` labels, include this warning in the spec output:
-
-```markdown
-> **Component files detected** — Issue body references `.tsx`/`.jsx` files or `components/` directory, but no `ui`/`frontend`/`admin` label is present.
-> - To enable browser testing: add the `ui` label → `gh issue edit <N> --add-label ui`
-> - To explicitly skip browser testing: add `no-browser-test` label → `gh issue edit <N> --add-label no-browser-test`
-> - Without either label, QA will note the missing browser test coverage.
-```
-
-**When NOT to show this warning:**
-- Issue already has `ui`, `frontend`, or `admin` label (browser testing already enabled)
-- Issue has `no-browser-test` label (explicit opt-out)
-- No `.tsx`/`.jsx`/`components/` references detected
-
-### 5. Label Review
-
-Analyze current labels vs implementation plan and suggest updates:
-
-```markdown
-## Label Review
-
-**Current:** enhancement
-**Recommended:** enhancement, refactor
-**Reason:** Implementation plan involves structural changes to 5+ files
-**Quality Loop:** Will auto-enable due to `refactor` label
-
-→ `gh issue edit <N> --add-label refactor`
-```
-
-**Plan-Based Detection Logic:**
-- If plan has 5+ file changes → suggest `refactor`
-- If plan touches UI components → suggest `ui` or `frontend`
-- If plan has breaking API changes → suggest `breaking`
-- If plan involves database migrations → suggest `backend`, `complex`
-- If plan involves CLI/scripts → suggest `cli`
-- If plan is documentation-only → suggest `docs`
-- If recommended workflow includes quality loop → ensure matching label exists (`complex`, `refactor`, or `breaking`)
-
-**Label Inference from Plan Analysis:**
-- Count files in implementation plan steps
-- Identify component types being modified
-- Check if API contracts are changing
-- Match against quality loop trigger labels
-
-### 6. Issue Comment Draft
-
-Generate a Markdown snippet with:
-- AC checklist with verification criteria
-- Verification methods summary
-- Consolidated assumptions checklist
-- Implementation plan with phases
-- Key decisions and rationale
-- Open questions with recommendations
-- Effort breakdown
-
-Label clearly as:
-```md
---- DRAFT GITHUB ISSUE COMMENT (PLAN) ---
-```
-
-### 7. Update GitHub Issue
-
-Post the draft comment to GitHub:
 ```bash
-gh issue comment <issue-number> --body "..."
-gh issue edit <issue-number> --add-label "planned"
+ls -d src/ app/ lib/ components/ pages/ routes/ docs/ 2>/dev/null || true
 ```
 
----
+Use discovered paths in all agent prompts and search commands.
 
-## Output Verification
+### Agent Spawn Rules
 
-**Before responding, verify your output includes ALL of these:**
+Determine agent count from issue content — do NOT always spawn 3:
 
-- [ ] **AC Checklist** - Numbered AC items (AC-1, AC-2, etc.) with descriptions
-- [ ] **Verification Criteria** - Each AC has Verification Method and Test Scenario
-- [ ] **Conflict Risk Analysis** - Check for in-flight work, include if conflicts found
-- [ ] **Implementation Plan** - 3-7 concrete steps with codebase references
-- [ ] **Design Review** - All 4 questions answered (abbreviated to Q1+Q3 for simple-fix/typo/docs-only labels)
-- [ ] **Recommended Workflow** - Phases, Quality Loop setting, and Reasoning
-- [ ] **Label Review** - Current vs recommended labels based on plan analysis
-- [ ] **Open Questions** - Any ambiguities with recommended defaults
-- [ ] **Issue Comment Draft** - Formatted for GitHub posting
+| Issue Content | Agents | What to Spawn |
+|---------------|--------|---------------|
+| Database/SQL/migration keywords in AC or labels | 3 | Similar features + Codebase area + Database schema |
+| UI/frontend (`.tsx`/`.jsx`/`components/` references) | 2 | Similar features + Codebase area |
+| CLI/script changes | 2 | Similar features + Codebase area |
+| Docs/config/`simple-fix` label | 1 | General context only |
 
-**DO NOT respond until all items are verified.**
+**Execution mode:** Read `.sequant/settings.json` → `agents.parallel` (default: false).
+- **Parallel:** Spawn all agents in a SINGLE message
+- **Sequential:** Spawn one at a time, waiting for each to complete
+
+Agent prompts MUST reference discovered paths from the step above, not hardcoded ones like `components/admin/` or `lib/queries/`.
+
+### In-Flight Work Analysis
+
+Scan for potential conflicts before planning:
+
+```bash
+git worktree list --porcelain
+# For each worktree: git -C <path> diff --name-only origin/main...HEAD
+```
+
+If overlap detected → include **Conflict Risk Analysis** section with options (alternative approach / wait for merge / coordinate via /merger).
+
+Check for explicit dependencies: `gh issue view <issue> --json body,labels`. If "Depends on" found → include **Dependencies** section with status.
+
+### Feature Branch Context
+
+Check issue body/labels for feature branch references (`feature/`, `based on`, epic labels). If found, recommend `--base feature/<branch>` in the plan.
 
 ## Output Template
 
-You MUST include these sections in order:
+**Single authoritative template.** Include ALL sections in this order. Scale detail by complexity tier.
 
 ```markdown
+**Complexity: [Simple|Standard|Complex]** ([N] ACs, [N] directories)
+
+## AC Quality Check
+
+[Inline analysis results, or "Skipped (--skip-ac-lint)"]
+
+---
+
+## Scope Assessment
+
+**Non-Goals:** [From issue body. If missing: "⚠️ Non-Goals section not found. Consider adding scope boundaries."]
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Feature count | [N] | [✅/⚠️/❌] |
+| AC items | [N] | [✅/⚠️/❌] |
+| Directory spread | [N] | [✅/⚠️/❌] |
+
+**Verdict:** [✅ SCOPE_OK | ⚠️ SCOPE_WARNING | ❌ SCOPE_SPLIT_RECOMMENDED]
+
+[Or "Skipped (--skip-scope-check)"]
+
+---
+
 ## Acceptance Criteria
 
 ### AC-1: [Description]
 
-**Verification Method:** [Unit Test | Integration Test | Browser Test | Manual Test]
+**Verification:** [Unit Test | Integration Test | Browser Test | Manual Test]
+**Scenario:** Given [state] → When [action] → Then [outcome]
+**Assumptions:** [List any that need pre-coding validation]
 
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action]
-- Then: [Expected outcome]
-
-### AC-2: [Description]
-<!-- Continue for all AC items -->
+<!-- Repeat for all ACs.
+     EVERY AC must have a Verification Method. If unclear, flag as "⚠️ UNCLEAR" with suggested refinement.
+     See references/verification-criteria.md for method selection guide. -->
 
 ---
 
 ## Implementation Plan
 
-### Phase 1: [Phase Name]
-1. [Step with specific file/component references]
+### Phase 1: [Name]
+1. [Step referencing specific files/components from context gathering]
 2. [Step]
 
-### Phase 2: [Phase Name]
-<!-- Continue for all phases -->
+### Phase 2: [Name]
+<!-- 3-7 total steps. Group into phases. Note dependencies between steps.
+     For major decisions: present 2-3 options, recommend default with rationale.
+     See references/parallel-groups.md for parallel execution format (3+ independent tasks). -->
 
 ---
 
 ## Design Review
 
 1. **Where does this logic belong?** [Module/layer that owns this change]
-
 2. **What's the simplest correct approach?** [Minimum implementation, rejected alternatives]
+3. **What existing pattern does this follow?** [Named pattern, confirm it fits]
+4. **What would a senior reviewer challenge?** [Anticipated "why didn't you just...?" pushback]
 
-3. **What existing pattern does this follow?** [Named pattern, confirmation it fits]
+<!-- Simple tier: Q1 and Q3 only. Standard/Complex: all four. -->
 
-4. **What would a senior reviewer challenge?** [Anticipated pushback]
+---
 
-<!-- For simple-fix/typo/docs-only: only Q1 and Q3 required -->
+## Feature Quality Planning
+
+<!-- Exception-based: report only gaps and concerns. Full checklist in references/quality-checklist.md -->
+
+**All standard checks pass.** Notable items:
+- [Gap or concern requiring attention]
+- [Another gap if applicable]
+
+### Derived ACs (if any)
+
+| Source | Derived AC | Priority |
+|--------|-----------|----------|
+| [Quality dimension] | AC-N: [Description] | High/Medium/Low |
+
+<!-- Complex tier: walk through full checklist from references/quality-checklist.md -->
 
 ---
 
 ## Open Questions
 
-1. **[Question]**
-   - Recommendation: [Default choice]
-   - Impact: [What happens if wrong]
+1. **[Question]** — Recommendation: [default]. Impact: [if wrong].
 
 ---
 
 ## Recommended Workflow
 
-**Phases:** exec → qa
-**Quality Loop:** disabled
-**Reasoning:** [Why these phases based on issue analysis]
+**Phases:** [spec →] exec → qa
+**Quality Loop:** [enabled/disabled]
+**Reasoning:** [Brief explanation]
+
+<!-- Decision logic:
+     - UI/frontend → add `test` phase
+     - `no-browser-test` label → skip `test` (overrides UI labels)
+     - Complex refactor → enable quality loop
+     - Security-sensitive → add `security-review` phase
+     - New features with Unit/Integration Test verification ACs → add `testgen` phase
+     - Docs-only → skip spec, just exec → qa -->
 
 ---
 
 ## Label Review
 
-**Current:** [current labels]
-**Recommended:** [recommended labels]
-**Reason:** [Why these labels based on plan analysis]
+**Current:** [labels]
+**Recommended:** [labels]
+**Reason:** [Why, based on plan analysis]
 **Quality Loop:** [Will/Won't auto-enable and why]
 
 → `gh issue edit <N> --add-label [label]`
@@ -429,5 +255,32 @@ You MUST include these sections in order:
 
 --- DRAFT GITHUB ISSUE COMMENT (PLAN) ---
 
-[Complete formatted comment for GitHub]
+[AC checklist with verification + implementation plan + key decisions + open questions]
 ```
+
+### Browser Testing Label Suggestion
+
+When `.tsx`/`.jsx` references detected in issue body AND no `ui`/`frontend`/`admin` label present:
+> **Component files detected** — add `ui` label for browser testing, or `no-browser-test` to explicitly skip.
+
+### Assess Comment Integration
+
+Before making phase recommendations, check for prior `/assess` analysis:
+
+```bash
+assess_comment=$(gh issue view <N> --json comments \
+  --jq '[.comments[].body | select(test("## Assess Analysis|<!-- assess:phases="))] | last // empty')
+```
+
+If found, use assess recommendation as starting point. You may override, but MUST document why.
+
+## Update GitHub Issue
+
+Post the draft comment and add label:
+
+```bash
+gh issue comment <issue-number> --body "..."
+gh issue edit <issue-number> --add-label "planned"
+```
+
+**Do NOT start implementation** — this is planning-only.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -288,6 +288,30 @@ See [verification-criteria.md](references/verification-criteria.md) for detailed
 [AC checklist with verification + implementation plan + key decisions + open questions]
 ```
 
+### Testgen Phase Auto-Detection
+
+#### When to recommend `testgen` phase:
+
+| Condition | Recommend testgen? | Reasoning |
+|-----------|-------------------|-----------|
+| ACs have "Unit Test" verification method | Yes | Tests should be stubbed before implementation |
+| ACs have "Integration Test" verification method | Yes | Complex integration tests benefit from early structure |
+| New feature (`enhancement`/`feature` label) with >2 ACs | Yes | Features need test coverage |
+| Simple bug fix (`bug` label only) | No | Skip testgen — targeted tests sufficient |
+| Docs-only (`docs` label) | No | Skip testgen — no unit tests needed |
+| All ACs have "Manual Test" or "Browser Test" | No | Skip testgen — no code stubs to generate |
+
+**Detection logic:**
+1. Count ACs with "Unit Test" → If >0, recommend testgen
+2. Count ACs with "Integration Test" → If >0, recommend testgen
+3. Check labels: `bug`/`fix` only → Skip testgen. `docs` → Skip testgen.
+
+**Example when testgen recommended:**
+```markdown
+**Phases:** spec → testgen → exec → qa
+**Reasoning:** ACs include Unit Test verification methods; testgen will create stubs before implementation
+```
+
 ### Browser Testing Label Suggestion
 
 When `.tsx`/`.jsx` references detected in issue body AND no `ui`/`frontend`/`admin` label present:

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -2,9 +2,9 @@
 name: spec
 description: "Plan review vs Acceptance Criteria for a single GitHub issue, plus issue comment draft."
 license: MIT
-version: "2.1"
 metadata:
   author: sequant
+  version: "2.1"
 allowed-tools:
   - Bash(npm test:*)
   - Bash(gh issue view:*)

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -197,6 +197,15 @@ See [verification-criteria.md](references/verification-criteria.md) for detailed
 <!-- Repeat for all ACs. EVERY AC must have a Verification Method from the decision framework.
      If unclear, flag as "⚠️ UNCLEAR" with suggested refinement. -->
 
+<!-- Example of a completed AC entry:
+
+### AC-3: User can submit the registration form
+
+**Verification:** Browser Test
+**Scenario:** Given user on /register → When fill fields and click Submit → Then redirect to /dashboard with success toast
+**Assumptions:** Auth API returns 201 on valid input; email uniqueness enforced by DB constraint
+-->
+
 ---
 
 ## Implementation Plan

--- a/skills/spec/references/quality-checklist.md
+++ b/skills/spec/references/quality-checklist.md
@@ -1,0 +1,75 @@
+# Feature Quality Planning — Full Checklist
+
+Use this checklist for **Complex** tier issues or when the exception-based summary in SKILL.md flags significant gaps. For Simple/Standard tiers, the exception-based approach in the main prompt is sufficient.
+
+## Section Applicability
+
+| Issue Type | Sections Required |
+|------------|-------------------|
+| Bug fix | Completeness, Error Handling, Test Coverage |
+| New feature | All sections |
+| Refactor | Completeness, Code Quality, Test Coverage |
+| UI change | All sections including Polish |
+| Backend/API | Completeness, Error Handling, Code Quality, Test Coverage, Best Practices |
+| CLI/Script | Completeness, Error Handling, Test Coverage, Best Practices |
+| Docs only | Completeness only |
+
+## Completeness Check
+
+- [ ] All AC items have corresponding implementation steps
+- [ ] Integration points with existing features identified
+- [ ] No partial implementations or TODOs planned
+- [ ] State management considered (if applicable)
+- [ ] Data flow is complete end-to-end
+
+## Error Handling
+
+- [ ] Invalid input scenarios identified
+- [ ] API/external service failures handled
+- [ ] Edge cases documented (empty, null, max values)
+- [ ] Error messages are user-friendly
+- [ ] Graceful degradation planned
+
+## Code Quality
+
+- [ ] Types fully defined (no `any` planned)
+- [ ] Follows existing patterns in codebase
+- [ ] Error boundaries where needed
+- [ ] No magic strings/numbers
+- [ ] Consistent naming conventions
+
+## Test Coverage Plan
+
+- [ ] Unit tests for business logic
+- [ ] Integration tests for data flow
+- [ ] Edge case tests identified
+- [ ] Mocking strategy appropriate
+- [ ] Critical paths have test coverage
+
+## Best Practices
+
+- [ ] Logging for debugging/observability
+- [ ] Accessibility considerations (if UI)
+- [ ] Performance implications considered
+- [ ] Security reviewed (auth, validation, sanitization)
+- [ ] Documentation updated (if behavior changes)
+
+## Polish (UI features only)
+
+- [ ] Loading states planned
+- [ ] Error states have UI
+- [ ] Empty states handled
+- [ ] Responsive design considered
+- [ ] Keyboard navigation works
+
+## Derived ACs
+
+Based on quality planning, identify additional ACs:
+
+| Source | Derived AC | Priority |
+|--------|-----------|----------|
+| Error Handling | AC-N: Handle [specific error] with [specific response] | High/Medium/Low |
+| Test Coverage | AC-N+1: Add tests for [specific scenario] | High/Medium/Low |
+| Best Practices | AC-N+2: Add logging for [specific operation] | High/Medium/Low |
+
+Derived ACs are numbered sequentially after original ACs.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,11 @@
  */
 
 import chalk from "chalk";
+import { diffLines } from "diff";
 import inquirer from "inquirer";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { readdir } from "fs/promises";
 import { ui, colors } from "../lib/cli-ui.js";
 import {
   detectStack,
@@ -77,6 +81,7 @@ interface InitOptions {
   noSymlinks?: boolean;
   agentsMd?: boolean;
   mcp?: boolean;
+  upgradeSkills?: boolean;
 }
 
 /**
@@ -119,6 +124,12 @@ function logDefault(label: string, value: string): void {
 }
 
 export async function initCommand(options: InitOptions): Promise<void> {
+  // Handle --upgrade-skills: update skill files from installed package templates
+  if (options.upgradeSkills) {
+    await upgradeSkills();
+    return;
+  }
+
   // Show banner
   console.log(ui.banner());
   console.log(colors.success("\nInitializing Sequant...\n"));
@@ -650,6 +661,145 @@ export async function initCommand(options: InitOptions): Promise<void> {
   console.log(
     chalk.gray(
       "\nDocumentation: https://github.com/sequant-io/sequant#readme\n",
+    ),
+  );
+}
+
+/**
+ * Upgrade installed skill files from the sequant package's templates.
+ * Shows a diff preview for each changed file and asks for confirmation.
+ */
+async function upgradeSkills(): Promise<void> {
+  console.log(chalk.bold("\nUpgrading skills from package templates...\n"));
+
+  const installedDir = ".claude/skills";
+  if (!(await fileExists(installedDir))) {
+    console.log(
+      chalk.red("No skills directory found. Run `sequant init` first."),
+    );
+    return;
+  }
+
+  // Resolve the package's templates/skills directory
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const templateSkillsDir = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "templates",
+    "skills",
+  );
+
+  // Collect all files from both directories
+  const changes: { path: string; installed: string; template: string }[] = [];
+  const newFiles: { path: string; content: string }[] = [];
+
+  async function compareDir(
+    templateDir: string,
+    installedBaseDir: string,
+    relativePrefix: string,
+  ): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(templateDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const relPath = join(relativePrefix, entry.name);
+      const templatePath = join(templateDir, entry.name);
+      const installedPath = join(installedBaseDir, relPath);
+
+      if (entry.isDirectory()) {
+        await compareDir(templatePath, installedBaseDir, relPath);
+      } else {
+        const templateContent = await readFile(templatePath);
+        const exists = await fileExists(installedPath);
+
+        if (!exists) {
+          newFiles.push({ path: relPath, content: templateContent });
+        } else {
+          const installedContent = await readFile(installedPath);
+          if (installedContent !== templateContent) {
+            changes.push({
+              path: relPath,
+              installed: installedContent,
+              template: templateContent,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  await compareDir(templateSkillsDir, installedDir, "");
+
+  if (changes.length === 0 && newFiles.length === 0) {
+    console.log(chalk.green("All skills are up to date."));
+    return;
+  }
+
+  // Show summary
+  console.log(chalk.bold("Changes found:"));
+  if (changes.length > 0) {
+    console.log(chalk.yellow(`  Modified: ${changes.length} file(s)`));
+  }
+  if (newFiles.length > 0) {
+    console.log(chalk.green(`  New: ${newFiles.length} file(s)`));
+  }
+  console.log();
+
+  // Show diffs for modified files
+  for (const change of changes) {
+    console.log(chalk.yellow(`--- ${change.path} ---`));
+    const diff = diffLines(change.installed, change.template);
+    for (const part of diff) {
+      if (part.added) {
+        process.stdout.write(chalk.green(part.value));
+      } else if (part.removed) {
+        process.stdout.write(chalk.red(part.value));
+      }
+      // Skip unchanged lines in diff output
+    }
+    console.log();
+  }
+
+  // Show new files
+  for (const file of newFiles) {
+    console.log(chalk.green(`+++ ${file.path} (new)`));
+  }
+
+  // Ask for confirmation
+  const isInteractive = shouldUseInteractiveMode();
+  if (isInteractive) {
+    const { proceed } = await inquirer.prompt([
+      {
+        type: "confirm",
+        name: "proceed",
+        message: `Apply ${changes.length + newFiles.length} skill update(s)?`,
+        default: true,
+      },
+    ]);
+    if (!proceed) {
+      console.log(chalk.gray("Aborted."));
+      return;
+    }
+  }
+
+  // Apply changes
+  for (const change of changes) {
+    await writeFile(join(installedDir, change.path), change.template);
+  }
+  for (const file of newFiles) {
+    await ensureDir(dirname(join(installedDir, file.path)));
+    await writeFile(join(installedDir, file.path), file.content);
+  }
+
+  console.log(
+    chalk.green(
+      `\nUpgraded ${changes.length + newFiles.length} skill file(s).`,
     ),
   );
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,6 @@ import chalk from "chalk";
 import { diffLines } from "diff";
 import inquirer from "inquirer";
 import { join, dirname } from "path";
-import { fileURLToPath } from "url";
 import { readdir } from "fs/promises";
 import { ui, colors } from "../lib/cli-ui.js";
 import {
@@ -681,15 +680,8 @@ async function upgradeSkills(): Promise<void> {
   }
 
   // Resolve the package's templates/skills directory
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const templateSkillsDir = join(
-    __dirname,
-    "..",
-    "..",
-    "..",
-    "templates",
-    "skills",
-  );
+  const { getTemplatesDir } = await import("../lib/templates.js");
+  const templateSkillsDir = join(getTemplatesDir(), "skills");
 
   // Collect all files from both directories
   const changes: { path: string; installed: string; template: string }[] = [];

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -24,6 +24,7 @@ import {
   type Phase,
 } from "../lib/workflow/state-schema.js";
 import { getSettingsWithWarnings } from "../lib/settings.js";
+import { getSkillVersions } from "../lib/skill-version.js";
 
 export interface StatusCommandOptions {
   /** Show only issues state */
@@ -349,13 +350,36 @@ export async function statusCommand(
     }
   }
 
-  // Count skills
+  // Count skills and check versions
   const skillsDir = ".claude/skills";
   if (await fileExists(skillsDir)) {
     try {
       const skills = await readdir(skillsDir);
       const skillCount = skills.filter((s) => !s.startsWith(".")).length;
       console.log(chalk.gray(`Skills: ${skillCount}`));
+
+      // Show skill version info
+      const { getTemplatesDir } = await import("../lib/templates.js");
+      const { join } = await import("path");
+      const templateSkillsDir = join(getTemplatesDir(), "skills");
+      const skillVersions = await getSkillVersions(templateSkillsDir);
+      const outdated = skillVersions.filter((s) => s.updateAvailable);
+
+      if (outdated.length > 0) {
+        console.log(
+          chalk.yellow(`\n  Skill updates available (${outdated.length}):`),
+        );
+        for (const s of outdated) {
+          console.log(
+            chalk.yellow(
+              `    ${s.name}: v${s.installedVersion} → v${s.templateVersion}`,
+            ),
+          );
+        }
+        console.log(
+          chalk.gray("    Run `sequant init --upgrade-skills` to update."),
+        );
+      }
     } catch {
       // Ignore errors
     }

--- a/src/lib/skill-version.ts
+++ b/src/lib/skill-version.ts
@@ -1,0 +1,88 @@
+/**
+ * Skill version utilities — reads version from SKILL.md YAML frontmatter
+ */
+
+import { readdir } from "fs/promises";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+import { readFile, fileExists } from "./fs.js";
+
+export interface SkillVersionInfo {
+  name: string;
+  installedVersion: string | null;
+  templateVersion: string | null;
+  updateAvailable: boolean;
+}
+
+/**
+ * Parse YAML frontmatter from a SKILL.md file and extract the version field.
+ * Returns null if no version is found or file doesn't exist.
+ */
+export function parseSkillVersion(content: string): string | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  try {
+    const frontmatter = parseYaml(match[1]);
+    return frontmatter?.version ?? frontmatter?.metadata?.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read version from a single skill's SKILL.md file.
+ */
+async function readSkillVersion(skillDir: string): Promise<string | null> {
+  const skillPath = join(skillDir, "SKILL.md");
+  if (!(await fileExists(skillPath))) return null;
+
+  const content = await readFile(skillPath);
+  return parseSkillVersion(content);
+}
+
+/**
+ * Get version info for all installed skills, comparing installed (.claude/skills/)
+ * with template versions (from the sequant package's templates/skills/).
+ */
+export async function getSkillVersions(
+  templateDir?: string,
+): Promise<SkillVersionInfo[]> {
+  const installedDir = ".claude/skills";
+  const results: SkillVersionInfo[] = [];
+
+  if (!(await fileExists(installedDir))) return results;
+
+  try {
+    const entries = await readdir(installedDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+
+      const installedVersion = await readSkillVersion(
+        join(installedDir, entry.name),
+      );
+
+      let templateVersion: string | null = null;
+      if (templateDir) {
+        templateVersion = await readSkillVersion(join(templateDir, entry.name));
+      }
+
+      const updateAvailable =
+        installedVersion !== null &&
+        templateVersion !== null &&
+        installedVersion !== templateVersion;
+
+      results.push({
+        name: entry.name,
+        installedVersion,
+        templateVersion,
+        updateAvailable,
+      });
+    }
+  } catch {
+    // Ignore errors reading skills directory
+  }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -22,7 +22,7 @@ import { isNativeWindows } from "./system.js";
 import { getProjectName } from "./project-name.js";
 
 // Get the package templates directory
-function getTemplatesDir(): string {
+export function getTemplatesDir(): string {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   // Compiled structure: dist/src/lib/templates.js
   // So we need ../../../templates to reach project root templates/

--- a/templates/skills/spec/SKILL.md
+++ b/templates/skills/spec/SKILL.md
@@ -78,7 +78,14 @@ Mark tier in HTML comment for downstream parsing: `<!-- SEQUANT_SPEC_TIER: [tier
 
 1. **AC Extraction & Storage:** Use `extractAcceptanceCriteria` from `./src/lib/ac-parser.ts` and `StateManager` from `./src/lib/workflow/state-manager.ts` to parse and store AC in `.sequant/state.json`. Supports formats: `- [ ] **AC-1:** Desc`, `- [ ] AC-1: Desc`, `- [ ] **B2:** Desc`.
 
-2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Flags vague ("should work"), unmeasurable ("fast"), incomplete ("handle errors"), open-ended ("etc."). Warning-only — does not block planning.
+2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Warning-only — does not block planning. Flag these patterns:
+
+   | Pattern | Examples | Issue |
+   |---------|----------|-------|
+   | Vague | "should work", "properly" | No measurable outcome |
+   | Unmeasurable | "fast", "performant" | No threshold defined |
+   | Incomplete | "handle errors", "edge cases" | Scenarios not enumerated |
+   | Open-ended | "etc.", "and more" | Scope undefined |
 
 3. **Scope Assessment** (unless `--skip-scope-check`): Use `performScopeAssessment` from `./src/lib/scope/index.ts` with settings from `getSettings()`. Verdicts: SCOPE_OK (green), SCOPE_WARNING (yellow, auto-enables quality loop), SCOPE_SPLIT_RECOMMENDED (red). Store results in state.
 
@@ -135,6 +142,21 @@ Check for explicit dependencies: `gh issue view <issue> --json body,labels`. If 
 
 Check issue body/labels for feature branch references (`feature/`, `based on`, epic labels). If found, recommend `--base feature/<branch>` in the plan.
 
+## Verification Method Decision Framework
+
+Use this table when assigning verification methods to each AC:
+
+| AC Type | Method | When to Use |
+|---------|--------|-------------|
+| Pure logic/calculation | Unit Test | Clear input/output, no side effects |
+| API endpoint | Integration Test | HTTP handlers, DB queries, external calls |
+| User workflow | Browser Test | Multi-step UI interactions, forms |
+| Visual appearance | Manual Test | Styling, layout, animations |
+| CLI command | Integration Test | Script execution, stdout verification |
+| Error handling | Unit + Integration | Both isolated and realistic scenarios |
+
+See [verification-criteria.md](references/verification-criteria.md) for detailed examples.
+
 ## Output Template
 
 **Single authoritative template.** Include ALL sections in this order. Scale detail by complexity tier.
@@ -172,9 +194,8 @@ Check issue body/labels for feature branch references (`feature/`, `based on`, e
 **Scenario:** Given [state] → When [action] → Then [outcome]
 **Assumptions:** [List any that need pre-coding validation]
 
-<!-- Repeat for all ACs.
-     EVERY AC must have a Verification Method. If unclear, flag as "⚠️ UNCLEAR" with suggested refinement.
-     See references/verification-criteria.md for method selection guide. -->
+<!-- Repeat for all ACs. EVERY AC must have a Verification Method from the decision framework.
+     If unclear, flag as "⚠️ UNCLEAR" with suggested refinement. -->
 
 ---
 

--- a/templates/skills/spec/SKILL.md
+++ b/templates/skills/spec/SKILL.md
@@ -2,9 +2,9 @@
 name: spec
 description: "Plan review vs Acceptance Criteria for a single GitHub issue, plus issue comment draft."
 license: MIT
+version: "2.1"
 metadata:
   author: sequant
-  version: "1.0"
 allowed-tools:
   - Bash(npm test:*)
   - Bash(gh issue view:*)
@@ -19,950 +19,138 @@ allowed-tools:
 
 # Planning Agent
 
-You are the Phase 1 "Planning Agent" for the current repository.
+Phase 1 "Planning Agent." Understands the issue and AC, reviews or synthesizes a plan, identifies gaps and risks, and drafts a GitHub issue comment.
 
-## Purpose
-
-When invoked as `/spec`, your job is to:
-
-1. Understand the issue and Acceptance Criteria (AC).
-2. Review or synthesize a clear plan to address the AC.
-3. Identify ambiguities, gaps, or risks.
-4. Draft a GitHub issue comment summarizing AC + the agreed plan.
-
-## Phase Detection (Smart Resumption)
-
-**Before executing**, check if this phase has already been completed by reading phase markers from issue comments:
+## Platform Detection — Run First
 
 ```bash
-# Check for existing phase markers
-phase_data=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]' | \
-  grep -o '{[^}]*}' | grep '"phase"' | tail -1 || true)
-
-if [[ -n "$phase_data" ]]; then
-  phase=$(echo "$phase_data" | jq -r '.phase')
-  status=$(echo "$phase_data" | jq -r '.status')
-
-  # Skip if spec is already completed or a later phase is completed
-  if [[ "$phase" == "spec" && "$status" == "completed" ]] || \
-     [[ "$phase" == "exec" || "$phase" == "test" || "$phase" == "qa" ]]; then
-    echo "⏭️ Spec phase already completed (detected: $phase:$status). Skipping."
-    # Exit early — no work needed
-  fi
-fi
+gh --version >/dev/null 2>&1 && GITHUB_AVAILABLE=true || GITHUB_AVAILABLE=false
+SETTINGS_AVAILABLE=false; [ -f ".sequant/settings.json" ] && SETTINGS_AVAILABLE=true
 ```
 
-**Behavior:**
-- If `spec:completed` or a later phase is detected → Skip with message
-- If `spec:failed` → Re-run spec (retry)
-- If no markers found → Normal execution (fresh start)
-- If detection fails (API error) → Fall through to normal execution
+- **GitHub unavailable:** Skip phase detection, label review, auto-comment. Prompt user for AC from description text.
+- **Settings unavailable:** Use defaults silently (sequential agents, no custom scope config).
 
-**Phase Marker Emission:**
+## Phase Detection
 
-When posting the spec plan comment to GitHub, append a phase marker at the end:
+If GitHub is available, check for prior phase completion:
 
-```markdown
+```bash
+phase_data=$(gh issue view <issue-number> --json comments --jq '[.comments[].body]' | \
+  grep -o '{[^}]*}' | grep '"phase"' | tail -1 || true)
+```
+
+- `spec:completed` or later phase detected → Skip with message
+- `spec:failed` → Re-run
+- No markers / API error → Normal execution
+
+Append to every phase-completion comment:
+```
 <!-- SEQUANT_PHASE: {"phase":"spec","status":"completed","timestamp":"<ISO-8601>"} -->
 ```
 
-Include this marker in every `gh issue comment` that represents phase completion.
-
 ## Behavior
 
-When called like `/spec 123`:
-1. Treat `123` as a GitHub issue number.
-2. **Read all GitHub issue comments** for complete context.
-3. Extract: problem statement, AC (explicit or inferred), clarifications from comments.
+**`/spec 123`** — GitHub issue number. Read all comments for full context. Extract AC.
+**`/spec <text>`** — Freeform problem/AC source. Ask clarifying questions if ambiguous.
 
-When called like `/spec <freeform description>`:
-1. Treat the text as the problem/AC source.
-2. Ask clarifying questions if AC are ambiguous or conflicting.
+**Flags:** `--skip-ac-lint` (skip AC quality check), `--skip-scope-check` (skip scope assessment).
 
-**Flag:** `--skip-ac-lint`
-- Usage: `/spec 123 --skip-ac-lint`
-- Effect: Skips the AC Quality Check step
-- Use when: AC are intentionally high-level or you want to defer linting
+## Complexity Tier Determination
 
-**Flag:** `--skip-scope-check`
-- Usage: `/spec 123 --skip-scope-check`
-- Effect: Skips the Scope Assessment step
-- Use when: Issue scope is intentionally complex or you want to defer assessment
+Determine the output tier **before** generating any output. Announce it as the first line.
 
-### AC Extraction and Storage — REQUIRED
+| Tier | Criteria | Output Scope | Target |
+|------|----------|--------------|--------|
+| **Simple** | `simple-fix`/`typo`/`docs-only` label, or `bug` with ≤2 AC | AC list + plan + Design Review Q1/Q3 only | <4,000 chars |
+| **Standard** | 3–8 AC, no complexity labels | Full output minus Polish, minus trivially-passing quality checks | <8,000 chars |
+| **Complex** | `complex`/`refactor`/`breaking` label, or 9+ AC | Full output including all quality dimensions | <15,000 chars |
 
-**After fetching the issue body**, extract and store acceptance criteria in workflow state:
+First line of output: `**Complexity: [Tier]** ([N] ACs, [N] directories)`
 
-```bash
-# Extract AC from issue body and store in state
-npx tsx -e "
-import { extractAcceptanceCriteria } from './src/lib/ac-parser.ts';
-import { StateManager } from './src/lib/workflow/state-manager.ts';
+Mark tier in HTML comment for downstream parsing: `<!-- SEQUANT_SPEC_TIER: [tier] -->`
 
-const issueBody = \`<ISSUE_BODY_HERE>\`;
-const issueNumber = <ISSUE_NUMBER>;
-const issueTitle = '<ISSUE_TITLE>';
+## Programmatic Checks (Conditional)
 
-const ac = extractAcceptanceCriteria(issueBody);
-console.log('Extracted AC:', JSON.stringify(ac, null, 2));
+**Guard:** Only run `npx tsx` blocks if `./src/lib/ac-parser.ts` exists (sequant repo). Otherwise, perform all analysis inline by reading the issue text directly.
 
-if (ac.items.length > 0) {
-  const manager = new StateManager();
-  (async () => {
-    const existing = await manager.getIssueState(issueNumber);
-    if (!existing) {
-      await manager.initializeIssue(issueNumber, issueTitle);
-    }
-    await manager.updateAcceptanceCriteria(issueNumber, ac);
-    console.log('AC stored in state for issue #' + issueNumber);
-  })();
-}
-"
-```
+### If guard passes:
 
-**Why this matters:** Storing AC in state enables:
-- Dashboard visibility of AC progress per issue
-- `/qa` skill to update AC status during review
-- Cross-skill AC tracking throughout the workflow
+1. **AC Extraction & Storage:** Use `extractAcceptanceCriteria` from `./src/lib/ac-parser.ts` and `StateManager` from `./src/lib/workflow/state-manager.ts` to parse and store AC in `.sequant/state.json`. Supports formats: `- [ ] **AC-1:** Desc`, `- [ ] AC-1: Desc`, `- [ ] **B2:** Desc`.
 
-**AC Format Detection:**
-The parser supports multiple formats:
-- `- [ ] **AC-1:** Description` (bold with hyphen)
-- `- [ ] **B2:** Description` (letter + number)
-- `- [ ] AC-1: Description` (no bold)
+2. **AC Quality Check** (unless `--skip-ac-lint`): Use `lintAcceptanceCriteria` from `./src/lib/ac-linter.ts`. Flags vague ("should work"), unmeasurable ("fast"), incomplete ("handle errors"), open-ended ("etc."). Warning-only — does not block planning.
 
-**If no AC found:**
-- Log a warning but continue with planning
-- The plan output should note that AC will need to be defined
+3. **Scope Assessment** (unless `--skip-scope-check`): Use `performScopeAssessment` from `./src/lib/scope/index.ts` with settings from `getSettings()`. Verdicts: SCOPE_OK (green), SCOPE_WARNING (yellow, auto-enables quality loop), SCOPE_SPLIT_RECOMMENDED (red). Store results in state.
 
-### AC Quality Check — REQUIRED (unless --skip-ac-lint)
+### If guard fails (consumer projects):
 
-**After extracting AC**, run the AC linter to flag vague, untestable, or incomplete requirements:
+Perform the same analysis inline:
+- Extract AC by pattern-matching the issue body
+- Flag vague/unmeasurable AC in the AC Quality Check section
+- Assess scope using the same green/yellow/red heuristics on feature count, AC count, directory spread
+
+## Context Gathering
+
+### Discover Project Structure — REQUIRED
+
+**Do NOT use hardcoded paths.** Discover what actually exists:
 
 ```bash
-# Lint AC for quality issues (skip if --skip-ac-lint flag is set)
-npx tsx -e "
-import { parseAcceptanceCriteria } from './src/lib/ac-parser.ts';
-import { lintAcceptanceCriteria, formatACLintResults } from './src/lib/ac-linter.ts';
-
-const issueBody = \`<ISSUE_BODY_HERE>\`;
-
-const criteria = parseAcceptanceCriteria(issueBody);
-const lintResults = lintAcceptanceCriteria(criteria);
-console.log(formatACLintResults(lintResults));
-"
+ls -d src/ app/ lib/ components/ pages/ routes/ docs/ 2>/dev/null || true
 ```
 
-**Why this matters:** Vague AC lead to:
-- Ambiguous implementations that don't match expectations
-- Subjective /qa verdicts ("does it work properly?")
-- Wasted iteration cycles when requirements are clarified late
+Use discovered paths in all agent prompts and search commands.
 
-**Pattern Detection:**
+### Agent Spawn Rules
 
-| Pattern Type | Examples | Issue |
-|--------------|----------|-------|
-| Vague | "should work", "properly", "correctly" | Subjective, no measurable outcome |
-| Unmeasurable | "fast", "performant", "responsive" | No threshold defined |
-| Incomplete | "handle errors", "edge cases" | Specific scenarios not enumerated |
-| Open-ended | "etc.", "and more", "such as" | Scope is undefined |
+Determine agent count from issue content — do NOT always spawn 3:
 
-**Example Output:**
+| Issue Content | Agents | What to Spawn |
+|---------------|--------|---------------|
+| Database/SQL/migration keywords in AC or labels | 3 | Similar features + Codebase area + Database schema |
+| UI/frontend (`.tsx`/`.jsx`/`components/` references) | 2 | Similar features + Codebase area |
+| CLI/script changes | 2 | Similar features + Codebase area |
+| Docs/config/`simple-fix` label | 1 | General context only |
 
-```markdown
-## AC Quality Check
+**Execution mode:** Read `.sequant/settings.json` → `agents.parallel` (default: false).
+- **Parallel:** Spawn all agents in a SINGLE message
+- **Sequential:** Spawn one at a time, waiting for each to complete
 
-⚠️ **AC-2:** "System should handle errors gracefully"
-   → Incomplete: error types not specified
-   → Suggest: List specific error types and expected responses (e.g., 400 for invalid input, 503 for service unavailable)
+Agent prompts MUST reference discovered paths from the step above, not hardcoded ones like `components/admin/` or `lib/queries/`.
 
-⚠️ **AC-4:** "Page loads quickly"
-   → Unmeasurable: "quickly" has no threshold
-   → Suggest: Specify time limit (e.g., completes in <5 seconds)
+### In-Flight Work Analysis
 
-✅ AC-1, AC-3, AC-5: Clear and testable
-
-**Summary:** 2/5 AC items flagged for review
-```
-
-**Behavior:**
-- **Warning-only**: AC Quality Check does NOT block planning
-- Issues are surfaced in the output but plan generation continues
-- Include flagged AC in the issue comment draft with suggestions
-- Recommend refining vague AC before implementation
-
-**If `--skip-ac-lint` flag is set:**
-- Output: `AC Quality Check: Skipped (--skip-ac-lint flag set)`
-- Continue directly to plan generation
-
-### Scope Assessment — REQUIRED (unless --skip-scope-check)
-
-**After AC Quality Check**, run scope assessment to detect overscoped issues:
+Scan for potential conflicts before planning:
 
 ```bash
-# Run scope assessment (skip if --skip-scope-check flag is set)
-npx tsx -e "
-import { parseAcceptanceCriteria } from './src/lib/ac-parser.ts';
-import { performScopeAssessment, formatScopeAssessment, convertSettingsToConfig } from './src/lib/scope/index.ts';
-import { getSettings } from './src/lib/settings.ts';
-
-const issueBody = \`<ISSUE_BODY_HERE>\`;
-const issueTitle = '<ISSUE_TITLE>';
-
-(async () => {
-  const settings = await getSettings();
-  const config = convertSettingsToConfig(settings.scopeAssessment);
-
-  const criteria = parseAcceptanceCriteria(issueBody);
-  const assessment = performScopeAssessment(criteria, issueBody, issueTitle, config);
-  console.log(formatScopeAssessment(assessment));
-})();
-"
+git worktree list --porcelain
+# For each worktree: git -C <path> diff --name-only origin/main...HEAD
 ```
 
-**Why this matters:**
-- Bundled features (3+ distinct features) should be separate issues
-- Missing non-goals lead to scope creep during implementation
-- High AC counts increase complexity and error rates
+If overlap detected → include **Conflict Risk Analysis** section with options (alternative approach / wait for merge / coordinate via /merger).
 
-**Scope Metrics:**
+Check for explicit dependencies: `gh issue view <issue> --json body,labels`. If "Depends on" found → include **Dependencies** section with status.
 
-| Metric | Green | Yellow | Red |
-|--------|-------|--------|-----|
-| Feature count | 1 | 2 | 3+ |
-| AC items | 1-5 | 6-8 | 9+ |
-| Directory spread | 1-2 | 3-4 | 5+ |
+### Feature Branch Context
 
-**Non-Goals Section:**
-
-Every `/spec` output MUST include a Non-Goals section. If the issue lacks one, output a warning:
-
-```markdown
-## Non-Goals
-
-⚠️ **Non-Goals section not found.** Consider adding scope boundaries.
-
-Example format:
-- [ ] [Adjacent feature we're deferring]
-- [ ] [Scope boundary we're respecting]
-- [ ] [Future work that's out of scope]
-```
-
-**Scope Verdicts:**
-
-| Verdict | Meaning | Action |
-|---------|---------|--------|
-| ✅ SCOPE_OK | Single focused feature | Proceed normally |
-| ⚠️ SCOPE_WARNING | Moderate complexity | Consider narrowing; quality loop auto-enabled |
-| ❌ SCOPE_SPLIT_RECOMMENDED | Multiple features bundled | Strongly recommend splitting |
-
-**Quality Loop Auto-Enable:**
-
-If scope verdict is SCOPE_WARNING or SCOPE_SPLIT_RECOMMENDED:
-- Quality loop is automatically enabled
-- Include note in Recommended Workflow section:
-  ```markdown
-  **Quality Loop:** enabled (auto-enabled due to scope concerns)
-  ```
-
-**If `--skip-scope-check` flag is set:**
-- Output: `Scope Assessment: Skipped (--skip-scope-check flag set)`
-- Continue to plan generation
-
-**Store in State:**
-
-After assessment, store results in workflow state for analytics:
-
-```bash
-npx tsx -e "
-import { StateManager } from './src/lib/workflow/state-manager.ts';
-import { performScopeAssessment, convertSettingsToConfig } from './src/lib/scope/index.ts';
-import { getSettings } from './src/lib/settings.ts';
-
-(async () => {
-  const settings = await getSettings();
-  const config = convertSettingsToConfig(settings.scopeAssessment);
-
-  // ... perform assessment with config ...
-  // const assessment = performScopeAssessment(criteria, issueBody, issueTitle, config);
-
-  const manager = new StateManager();
-  await manager.updateScopeAssessment(issueNumber, assessment);
-})();
-"
-```
-
-### Feature Worktree Workflow
-
-**Planning Phase:** No worktree needed. Planning happens in the main repository directory. The worktree will be created during the execution phase (`/exec`).
-
-### Parallel Context Gathering — REQUIRED
-
-**You MUST spawn sub-agents for context gathering.** Do NOT explore the codebase inline with Glob/Grep commands. Sub-agents provide parallel execution, better context isolation, and consistent reporting.
-
-**Check agent execution mode first:**
-Use the Read tool to check project settings:
-```
-Read(file_path=".sequant/settings.json")
-# Parse JSON and extract agents.parallel (default: false)
-```
-
-#### If parallel mode enabled:
-
-**Spawn ALL THREE agents in a SINGLE message:**
-
-1. `Agent(subagent_type="sequant-explorer", prompt="Find similar features for [FEATURE]. Check components/admin/, lib/queries/, docs/patterns/. Report: file paths, patterns, recommendations.")`
-
-2. `Agent(subagent_type="sequant-explorer", prompt="Explore [CODEBASE AREA] for [FEATURE]. Find: main components, data flow, key files. Report structure.")`
-
-3. `Agent(subagent_type="sequant-explorer", prompt="Inspect database for [FEATURE]. Check: table schema, RLS policies, existing queries. Report findings.")`
-
-#### If sequential mode (default):
-
-**Spawn each agent ONE AT A TIME, waiting for each to complete:**
-
-1. **First:** `Agent(subagent_type="sequant-explorer", prompt="Find similar features for [FEATURE]. Check components/admin/, lib/queries/, docs/patterns/. Report: file paths, patterns, recommendations.")`
-
-2. **After #1 completes:** `Agent(subagent_type="sequant-explorer", prompt="Explore [CODEBASE AREA] for [FEATURE]. Find: main components, data flow, key files. Report structure.")`
-
-3. **After #2 completes:** `Agent(subagent_type="sequant-explorer", prompt="Inspect database for [FEATURE]. Check: table schema, RLS policies, existing queries. Report findings.")`
-
-### Feature Branch Context Detection
-
-Before creating the implementation plan, check if a custom base branch should be recommended:
-
-1. **Check for feature branch references in issue body**:
-   ```bash
-   gh issue view <issue> --json body --jq '.body' | grep -iE "(feature/|branch from|based on|part of.*feature)" || true
-   ```
-
-2. **Check issue labels for feature context**:
-   ```bash
-   gh issue view <issue> --json labels --jq '.labels[].name' | grep -iE "(dashboard|feature-|epic-)" || true
-   ```
-
-3. **Check if project has defaultBase configured**:
-   Use the Read tool to check settings:
-   ```
-   Read(file_path=".sequant/settings.json")
-   # Extract .run.defaultBase from JSON
-   ```
-
-4. **If feature branch context detected**, include in plan output:
-   ```markdown
-   ## Feature Branch Context
-
-   **Detected base branch**: `feature/dashboard`
-   **Source**: Issue body mentions "Part of dashboard feature" / Project config / Label
-
-   **Recommended workflow**:
-   \`\`\`bash
-   npx sequant run <issue> --base feature/dashboard
-   \`\`\`
-   ```
-
-### In-Flight Work Analysis (Conflict Detection)
-
-Before creating the implementation plan, scan for potential conflicts with in-flight work:
-
-1. **List open worktrees**:
-   ```bash
-   git worktree list --porcelain
-   ```
-
-2. **For each worktree, get changed files** (use detected base branch or default to main):
-   ```bash
-   git -C <worktree-path> diff --name-only <base-branch>...HEAD
-   ```
-
-3. **Analyze this issue's likely file touches** based on:
-   - Issue description and AC
-   - Similar past issues
-   - Codebase structure
-
-4. **If overlap detected**, include in plan output:
-   ```markdown
-   ## Conflict Risk Analysis
-
-   **In-flight work detected**: Issue #<N> (feature/<branch-name>)
-   **Overlapping files**:
-   - `<file-path>`
-
-   **Recommended approach**:
-   - [ ] Option A: Use alternative file/approach (no conflict)
-   - [ ] Option B: Wait for #<N> to merge, then rebase
-   - [ ] Option C: Coordinate unified implementation via /merger
-
-   **Selected**: [To be decided during spec review]
-   ```
-
-5. **Check for explicit dependencies**:
-   ```bash
-   # Look for "Depends on" or "depends-on" labels
-   gh issue view <issue> --json body,labels
-   ```
-
-   If dependencies found:
-   ```markdown
-   ## Dependencies
-
-   **Depends on**: #<N>
-   **Reason**: [Why this issue depends on the other]
-   **Status**: [Open/Merged/Closed]
-   ```
-
-### Using MCP Tools (Optional)
-
-- **Sequential Thinking:** For complex analysis with multiple dependencies
-- **Context7:** For understanding existing patterns and architecture
-
-## Context Gathering Strategy
-
-1. **Check the Patterns Catalog first**
-   - Read `docs/patterns/README.md` for quick lookup
-   - Check HELPERS.md, COMPONENTS.md, TYPES.md
-   - **Do NOT propose creating new utilities if similar ones exist**
-
-2. **Look for similar features**
-   - Use `ls components/admin/[area]/` for existing components
-   - Read 1-2 examples to understand patterns
-   - Propose solutions matching established architecture
-
-3. **Check existing dependencies**
-   - Review `package.json` for libraries
-   - Prefer existing dependencies over new ones
-   - For "solved problem" domains, recommend established packages in the plan:
-     | Domain | Recommended Packages |
-     |--------|---------------------|
-     | Date/time | `date-fns`, `dayjs` |
-     | Validation | `zod`, `yup`, `valibot` |
-     | HTTP with retry | `ky`, `got`, `axios` |
-     | Form state | `react-hook-form` |
-     | State management | `zustand`, `jotai` |
-
-4. **For database-heavy features**
-   - Verify table schemas against TypeScript types
-   - Check proposed types match database columns
-
-5. **For complex features (>5 AC items)**
-   - Use Sequential Thinking to break down systematically
-   - Document key decision points and trade-offs
-
-## Output Structure
-
-### 1. AC Checklist with Verification Criteria (REQUIRED)
-
-**Every AC MUST have an explicit Verification Method.** Restate AC as a checklist with verification for each:
-
-```markdown
-### AC-1: [Description]
-
-**Verification Method:** Unit Test | Integration Test | Manual Test | Browser Test
-
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action taken]
-- Then: [Expected outcome]
-
-**Integration Points:**
-- [External system or component]
-
-**Assumptions to Validate:**
-- [ ] [Assumption that must be true]
-```
-
-#### Verification Method Decision Framework
-
-**REQUIRED:** Choose the most appropriate verification method for each AC:
-
-| AC Type | Verification Method | When to Use |
-|---------|---------------------|-------------|
-| Pure logic/calculation | **Unit Test** | Functions with clear input/output, no side effects |
-| API endpoint | **Integration Test** | HTTP handlers, database queries, external service calls |
-| User workflow | **Browser Test** | Multi-step UI interactions, form submissions |
-| Visual appearance | **Manual Test** | Styling, layout, animations (hard to automate) |
-| CLI command | **Integration Test** | Script execution, file operations, stdout verification |
-| Error handling | **Unit Test** + **Integration Test** | Both isolated behavior and realistic scenarios |
-| Performance | **Manual Test** + **Integration Test** | Timing thresholds, load testing |
-
-#### Verification Method Examples
-
-**Good (specific and testable):**
-```markdown
-**AC-1:** User can submit the registration form
-**Verification Method:** Browser Test
-**Test Scenario:**
-- Given: User on /register page
-- When: Fill form fields, click Submit
-- Then: Redirect to /dashboard, success toast appears
-```
-
-**Bad (vague, no clear verification):**
-```markdown
-**AC-1:** Registration should work properly
-**Verification Method:** ??? (cannot determine)
-```
-
-#### Flags for Missing Verification Methods
-
-If you cannot determine a verification method for an AC:
-
-1. **Flag the AC as unclear:**
-   ```markdown
-   **AC-3:** System handles errors gracefully
-   **Verification Method:** ⚠️ UNCLEAR - needs specific error scenarios
-   **Suggested Refinement:** List specific error types and expected responses
-   ```
-
-2. **Include in Open Questions:**
-   ```markdown
-   ## Open Questions
-
-   1. **AC-3 verification method unclear**
-      - Question: What specific error scenarios should be tested?
-      - Recommendation: Define 3-5 error types with expected behavior
-      - Impact: Without this, QA cannot objectively validate
-   ```
-
-**Why this matters:** AC without verification methods:
-- Cannot be objectively validated in `/qa`
-- Lead to subjective "does it work?" assessments
-- Cause rework when expectations don't match implementation
-
-See [verification-criteria.md](references/verification-criteria.md) for detailed examples including the #452 hooks failure case.
-
-### 2. Implementation Plan
-
-Propose a concrete plan in 3–7 steps that:
-- References specific codebase areas
-- Respects existing architecture
-- Groups related work into phases
-- Identifies dependencies between steps
-
-For each major decision:
-- Present 2-3 options when relevant
-- Recommend a default with rationale
-- Note if decision should be deferred
-
-**Open Questions Format:**
-- Question: [Clear question]
-- Recommendation: [Your suggested default]
-- Impact: [What happens if we get this wrong]
-
-See [parallel-groups.md](references/parallel-groups.md) for parallelization format.
-
-### 2.5. Design Review (REQUIRED)
-
-**Purpose:** Make design decisions explicit before implementation starts. This forces evaluation of *how* to build, not just *what* to build — catching wrong-layer, over-engineered, or pattern-mismatched approaches before code is written.
-
-**Why this matters:** Repeated pattern across issues: implementation passes QA functionally but uses the wrong design — wrong layer, hacky shortcut, over-engineered approach. The fix cycle is expensive. Making design explicit here prevents it.
-
-**Complexity Scaling:**
-- **Simple issues** (`simple-fix`, `typo`, `docs-only` labels): Abbreviated — answer Q1 and Q3 only
-- **Standard issues**: Answer all 4 questions
-- **Complex issues** (`complex`, `refactor`, `breaking` labels): Answer all 4 questions with detailed rationale
-
-**Answer these questions:**
-
-1. **Where does this logic belong?** — Which module/layer owns this change? Name the specific directory, file, or abstraction layer. If it spans layers, explain why.
-
-2. **What's the simplest correct approach?** — Actively reject over-engineering. What's the minimum implementation that satisfies all AC? What alternatives did you consider and reject?
-
-3. **What existing pattern does this follow?** — Name the specific pattern in the codebase. Confirm it fits this use case. If no existing pattern fits, explain why a new approach is needed.
-
-4. **What would a senior reviewer challenge?** — Anticipate design pushback. What's the most likely "why didn't you just...?" or "this should be in X instead" feedback?
-
-**Example (standard issue):**
-
-```markdown
-## Design Review
-
-1. **Where does this logic belong?** Spec skill's SKILL.md prompt files — purely prompt engineering, not TypeScript. Same layer as Feature Quality Planning and AC Checklist sections.
-
-2. **What's the simplest correct approach?** Add markdown prompt text to SKILL.md. Reuse the existing complexity scaling pattern from Feature Quality Planning. No code, no new files, no abstractions.
-
-3. **What existing pattern does this follow?** Mirrors Feature Quality Planning exactly: required section, purpose statement, complexity scaling table, question format.
-
-4. **What would a senior reviewer challenge?** (1) "Why after Implementation Plan, not before?" — Design review needs the plan as input to evaluate. (2) "Won't this bloat output?" — Adds ~15 lines for standard, ~5 for simple-fix.
-```
-
-**Example (simple-fix issue, abbreviated):**
-
-```markdown
-## Design Review
-
-1. **Where does this logic belong?** `src/lib/utils.ts` — utility function, same layer as existing helpers.
-
-3. **What existing pattern does this follow?** Same pattern as `formatDuration()` in the same file — pure function, no side effects, single responsibility.
-```
-
-### 3. Feature Quality Planning (REQUIRED)
-
-**Purpose:** Systematically consider professional implementation requirements beyond the minimum AC. This prevents gaps that slip through exec and QA because they were never planned.
-
-**Why this matters:** Spec currently plans the "minimum to satisfy AC" rather than "complete professional implementation." Gaps found in manual review are omissions from incomplete planning, not failures.
-
-**Complexity Scaling:**
-- **Simple issues** (`simple-fix`, `typo`, `docs-only` labels): Use abbreviated checklist (Completeness + one relevant section)
-- **Standard issues**: Complete all applicable sections
-- **Complex issues** (`complex`, `refactor`, `breaking` labels): Complete all sections with detailed items
-
-```markdown
-## Feature Quality Planning
-
-### Completeness Check
-- [ ] All AC items have corresponding implementation steps
-- [ ] Integration points with existing features identified
-- [ ] No partial implementations or TODOs planned
-- [ ] State management considered (if applicable)
-- [ ] Data flow is complete end-to-end
-
-### Error Handling
-- [ ] Invalid input scenarios identified
-- [ ] API/external service failures handled
-- [ ] Edge cases documented (empty, null, max values)
-- [ ] Error messages are user-friendly
-- [ ] Graceful degradation planned
-
-### Code Quality
-- [ ] Types fully defined (no `any` planned)
-- [ ] Follows existing patterns in codebase
-- [ ] Error boundaries where needed
-- [ ] No magic strings/numbers
-- [ ] Consistent naming conventions
-
-### Test Coverage Plan
-- [ ] Unit tests for business logic
-- [ ] Integration tests for data flow
-- [ ] Edge case tests identified
-- [ ] Mocking strategy appropriate
-- [ ] Critical paths have test coverage
-
-### Best Practices
-- [ ] Logging for debugging/observability
-- [ ] Accessibility considerations (if UI)
-- [ ] Performance implications considered
-- [ ] Security reviewed (auth, validation, sanitization)
-- [ ] Documentation updated (if behavior changes)
-
-### Polish (UI features only)
-- [ ] Loading states planned
-- [ ] Error states have UI
-- [ ] Empty states handled
-- [ ] Responsive design considered
-- [ ] Keyboard navigation works
-
-### Derived ACs
-
-Based on quality planning, identify additional ACs needed:
-
-| Source | Derived AC | Priority |
-|--------|-----------|----------|
-| Error Handling | AC-N: Handle [specific error] with [specific response] | High/Medium/Low |
-| Test Coverage | AC-N+1: Add tests for [specific scenario] | High/Medium/Low |
-| Best Practices | AC-N+2: Add logging for [specific operation] | High/Medium/Low |
-
-**Note:** Derived ACs are numbered sequentially after original ACs and follow the same format.
-```
-
-**Section Applicability:**
-
-| Issue Type | Sections Required |
-|------------|-------------------|
-| Bug fix | Completeness, Error Handling, Test Coverage |
-| New feature | All sections |
-| Refactor | Completeness, Code Quality, Test Coverage |
-| UI change | All sections including Polish |
-| Backend/API | Completeness, Error Handling, Code Quality, Test Coverage, Best Practices |
-| CLI/Script | Completeness, Error Handling, Test Coverage, Best Practices |
-| Docs only | Completeness only |
-
-**Example (API endpoint feature):**
-
-```markdown
-## Feature Quality Planning
-
-### Completeness Check
-- [x] All AC items have corresponding implementation steps
-- [x] Integration points: Auth middleware, database queries, response serializer
-- [x] No partial implementations planned
-- [ ] State management: N/A (stateless API)
-- [x] Data flow: Request → Validate → Query → Transform → Response
-
-### Error Handling
-- [x] Invalid input: Return 400 with validation errors
-- [x] Auth failure: Return 401 with "Unauthorized" message
-- [x] Not found: Return 404 with resource ID
-- [x] Server error: Return 500, log full error, return generic message
-- [x] Rate limit: Return 429 with retry-after header
-
-### Code Quality
-- [x] Types: Define RequestDTO, ResponseDTO, ErrorResponse
-- [x] Patterns: Follow existing controller pattern in `src/api/`
-- [ ] Error boundaries: N/A (API, not UI)
-- [x] No magic strings: Use constants for error messages
-
-### Test Coverage Plan
-- [x] Unit: Validation logic, data transformation
-- [x] Integration: Full request/response cycle
-- [x] Edge cases: Empty results, max pagination, invalid IDs
-- [x] Mocking: Mock database, not HTTP layer
-
-### Best Practices
-- [x] Logging: Log request ID, duration, status code
-- [ ] Accessibility: N/A (API)
-- [x] Performance: Add database index for query field
-- [x] Security: Validate input, sanitize output, check auth
-
-### Derived ACs
-
-| Source | Derived AC | Priority |
-|--------|-----------|----------|
-| Error Handling | AC-6: Return 429 with retry-after header on rate limit | Medium |
-| Best Practices | AC-7: Log request ID and duration for observability | High |
-| Test Coverage | AC-8: Add integration test for auth failure path | High |
-```
-
-### 4. Plan Review
-
-Ask the user to confirm or adjust:
-- The AC checklist (with verification criteria)
-- The implementation plan
-- The assumptions to validate
-
-**Do NOT start implementation** - this is planning-only.
-
-### 4.5. Assess Comment Detection (AC-4, AC-5)
-
-**Before making your own phase recommendation**, check if `/assess` has already posted an analysis comment to this issue:
-
-```bash
-# Check for assess analysis comment on the issue (includes legacy /solve format for backward compat)
-assess_comment=$(gh issue view <issue-number> --json comments \
-  --jq '[.comments[].body | select(test("## Assess Analysis|## Solve Analysis|<!-- assess:phases=|<!-- solve:phases="))] | last // empty')
-```
-
-**If an assess analysis comment exists:**
-
-1. Parse the HTML comment markers to extract the recommended phases:
-   ```
-   <!-- assess:phases=exec,qa -->        → phases: ["exec", "qa"] (spec not included = skip spec)
-   <!-- assess:browser-test=false -->    → no browser testing needed
-   <!-- assess:quality-loop=true -->     → enable quality loop
-   ```
-
-2. **Use the assess recommendation as your starting point** for the phase recommendation in step 5.
-
-3. **You may override the assess recommendation**, but you MUST document why:
-   ```markdown
-   ## Recommended Workflow
-
-   **Phases:** spec → exec → test → qa
-   **Quality Loop:** enabled
-   **Reasoning:** Assess recommended `exec → qa`, but codebase analysis reveals UI components
-   are affected (found `.tsx` files in change scope), so browser testing is needed.
-   Overriding assess recommendation with explanation.
-   ```
-
-4. If the assess comment recommends phases that don't include `spec` (e.g., `phases=exec,qa`), acknowledge this in your output but proceed with spec since `/spec` was explicitly invoked.
-
-**If no assess analysis comment exists:** Proceed with your own analysis as normal (step 5).
-
-### 5. Recommended Workflow
-
-Analyze the issue and recommend the optimal workflow phases:
-
-```markdown
-## Recommended Workflow
-
-**Phases:** spec → exec → qa
-**Quality Loop:** disabled
-**Reasoning:** [Brief explanation of why these phases were chosen]
-```
-
-**Phase Selection Logic:**
-- **UI/Frontend changes** → Add `test` phase (browser testing)
-- **`no-browser-test` label** → Skip `test` phase (explicit opt-out, overrides UI labels)
-- **Bug fixes** → Skip `spec` if already well-defined
-- **Complex refactors** → Enable quality loop
-- **Security-sensitive** → Add `security-review` phase
-- **Documentation only** → Skip `spec`, just `exec → qa`
-- **New features with testable ACs** → Add `testgen` phase after spec
-- **Refactors needing regression tests** → Add `testgen` phase
-
-#### Browser Testing Label Suggestion
-
-**When `.tsx` or `.jsx` file references are detected** in the issue body AND the issue does NOT have `ui`, `frontend`, or `admin` labels, include this warning in the spec output:
-
-```markdown
-> **Component files detected** — Issue body references `.tsx`/`.jsx` files or `components/` directory, but no `ui`/`frontend`/`admin` label is present.
-> - To enable browser testing: add the `ui` label → `gh issue edit <N> --add-label ui`
-> - To explicitly skip browser testing: add `no-browser-test` label → `gh issue edit <N> --add-label no-browser-test`
-> - Without either label, QA will note the missing browser test coverage.
-```
-
-**When NOT to show this warning:**
-- Issue already has `ui`, `frontend`, or `admin` label (browser testing already enabled)
-- Issue has `no-browser-test` label (explicit opt-out)
-- No `.tsx`/`.jsx`/`components/` references detected
-
-#### Testgen Phase Auto-Detection
-
-**When to recommend `testgen` phase:**
-
-| Condition | Recommend testgen? | Reasoning |
-|-----------|-------------------|-----------|
-| ACs have "Unit Test" verification method | ✅ Yes | Tests should be stubbed before implementation |
-| ACs have "Integration Test" verification method | ✅ Yes | Complex integration tests benefit from early structure |
-| Issue is a new feature (not bug fix) with >2 AC items | ✅ Yes | Features need test coverage |
-| Issue has `enhancement` or `feature` label | ✅ Yes | New functionality needs tests |
-| Project has test framework (Jest, Vitest, etc.) | ✅ Yes | Infrastructure exists to run tests |
-| Issue is a simple bug fix (`bug` label only) | ❌ No | Bug fixes typically have targeted tests |
-| Issue is docs-only (`docs` label) | ❌ No | Documentation doesn't need unit tests |
-| All ACs have "Manual Test" or "Browser Test" verification | ❌ No | These don't generate code stubs |
-
-**Detection Logic:**
-
-1. **Check verification methods in AC items:**
-   - Count ACs with "Unit Test" → If >0, recommend testgen
-   - Count ACs with "Integration Test" → If >0, recommend testgen
-
-2. **Check issue labels:**
-   ```bash
-   gh issue view <issue> --json labels --jq '.labels[].name'
-   ```
-   - If `bug` or `fix` is the ONLY label → Skip testgen
-   - If `docs` is present → Skip testgen
-   - If `enhancement`, `feature`, `refactor` → Consider testgen
-
-3. **Check project test infrastructure:**
-   ```bash
-   # Check for test framework in package.json
-   grep -E "jest|vitest|mocha" package.json || true
-   ```
-   - If no test framework detected → Skip testgen (no infrastructure)
-
-**Example output when testgen is recommended:**
-
-```markdown
-## Recommended Workflow
-
-**Phases:** spec → testgen → exec → qa
-**Quality Loop:** disabled
-**Reasoning:** ACs include Unit Test verification methods; testgen will create stubs before implementation
-```
-
-**Example output when testgen is NOT recommended:**
-
-```markdown
-## Recommended Workflow
-
-**Phases:** spec → exec → qa
-**Quality Loop:** disabled
-**Reasoning:** Bug fix with targeted scope; existing tests sufficient
-```
-
-### 6. Label Review
-
-Analyze current labels vs implementation plan and suggest updates:
-
-```markdown
-## Label Review
-
-**Current:** enhancement
-**Recommended:** enhancement, refactor
-**Reason:** Implementation plan involves structural changes to 5+ files
-**Quality Loop:** Will auto-enable due to `refactor` label
-
-→ `gh issue edit <N> --add-label refactor`
-```
-
-**Plan-Based Detection Logic:**
-- If plan has 5+ file changes → suggest `refactor`
-- If plan touches UI components → suggest `ui` or `frontend`
-- If plan has breaking API changes → suggest `breaking`
-- If plan involves database migrations → suggest `backend`, `complex`
-- If plan involves CLI/scripts → suggest `cli`
-- If plan is documentation-only → suggest `docs`
-- If recommended workflow includes quality loop → ensure matching label exists (`complex`, `refactor`, or `breaking`)
-
-**Label Inference from Plan Analysis:**
-- Count files in implementation plan steps
-- Identify component types being modified
-- Check if API contracts are changing
-- Match against quality loop trigger labels
-
-### 7. Issue Comment Draft
-
-Generate a Markdown snippet with:
-- AC checklist with verification criteria
-- Verification methods summary
-- Consolidated assumptions checklist
-- Implementation plan with phases
-- Key decisions and rationale
-- Open questions with recommendations
-- Effort breakdown
-
-Label clearly as:
-```md
---- DRAFT GITHUB ISSUE COMMENT (PLAN) ---
-```
-
-### 8. Update GitHub Issue
-
-Post the draft comment to GitHub:
-```bash
-gh issue comment <issue-number> --body "..."
-gh issue edit <issue-number> --add-label "planned"
-```
-
----
-
-## Output Verification
-
-**Before responding, verify your output includes ALL of these:**
-
-- [ ] **AC Quality Check** - Lint results (or "Skipped" if --skip-ac-lint)
-- [ ] **Scope Assessment** - Verdict and metrics (or "Skipped" if --skip-scope-check)
-- [ ] **Non-Goals Section** - Listed or warning if missing
-- [ ] **AC Checklist** - Numbered AC items (AC-1, AC-2, etc.) with descriptions
-- [ ] **Verification Criteria (REQUIRED)** - Each AC MUST have:
-  - Explicit Verification Method (Unit Test, Integration Test, Browser Test, or Manual Test)
-  - Test Scenario with Given/When/Then format
-  - If unclear, flag as "⚠️ UNCLEAR" and add to Open Questions
-- [ ] **Conflict Risk Analysis** - Check for in-flight work, include if conflicts found
-- [ ] **Implementation Plan** - 3-7 concrete steps with codebase references
-- [ ] **Design Review** - All 4 questions answered (abbreviated to Q1+Q3 for simple-fix/typo/docs-only labels)
-- [ ] **Feature Quality Planning** - Quality dimensions checklist completed (abbreviated for simple-fix/typo/docs-only labels)
-- [ ] **Recommended Workflow** - Phases, Quality Loop setting, and Reasoning (auto-enable quality loop if scope is yellow/red)
-- [ ] **Label Review** - Current vs recommended labels based on plan analysis
-- [ ] **Open Questions** - Any ambiguities with recommended defaults (including unclear verification methods)
-- [ ] **Issue Comment Draft** - Formatted for GitHub posting
-
-**CRITICAL:** Do NOT output AC items without verification methods. Either:
-1. Assign a verification method from the decision framework, or
-2. Flag as "⚠️ UNCLEAR" and include in Open Questions
-
-**DO NOT respond until all items are verified.**
+Check issue body/labels for feature branch references (`feature/`, `based on`, epic labels). If found, recommend `--base feature/<branch>` in the plan.
 
 ## Output Template
 
-You MUST include these sections in order:
+**Single authoritative template.** Include ALL sections in this order. Scale detail by complexity tier.
 
 ```markdown
+**Complexity: [Simple|Standard|Complex]** ([N] ACs, [N] directories)
+
 ## AC Quality Check
 
-[Output from AC linter, or "Skipped (--skip-ac-lint flag set)"]
+[Inline analysis results, or "Skipped (--skip-ac-lint)"]
 
 ---
 
 ## Scope Assessment
 
-### Non-Goals (Required)
-
-[List non-goals from issue, or warning if missing]
-
-### Scope Metrics
+**Non-Goals:** [From issue body. If missing: "⚠️ Non-Goals section not found. Consider adding scope boundaries."]
 
 | Metric | Value | Status |
 |--------|-------|--------|
@@ -970,9 +158,9 @@ You MUST include these sections in order:
 | AC items | [N] | [✅/⚠️/❌] |
 | Directory spread | [N] | [✅/⚠️/❌] |
 
-### Scope Verdict
+**Verdict:** [✅ SCOPE_OK | ⚠️ SCOPE_WARNING | ❌ SCOPE_SPLIT_RECOMMENDED]
 
-[✅/⚠️/❌] **[SCOPE_OK/SCOPE_WARNING/SCOPE_SPLIT_RECOMMENDED]** - [Recommendation]
+[Or "Skipped (--skip-scope-check)"]
 
 ---
 
@@ -980,116 +168,85 @@ You MUST include these sections in order:
 
 ### AC-1: [Description]
 
-**Verification Method:** [Unit Test | Integration Test | Browser Test | Manual Test]
+**Verification:** [Unit Test | Integration Test | Browser Test | Manual Test]
+**Scenario:** Given [state] → When [action] → Then [outcome]
+**Assumptions:** [List any that need pre-coding validation]
 
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action]
-- Then: [Expected outcome]
-
-### AC-2: [Description]
-
-**Verification Method:** [Choose from decision framework]
-
-**Test Scenario:**
-- Given: [Initial state]
-- When: [Action]
-- Then: [Expected outcome]
-
-### AC-N: [Unclear AC example]
-
-**Verification Method:** ⚠️ UNCLEAR - [reason why verification is unclear]
-
-**Suggested Refinement:** [How to make this AC testable]
-
-<!-- Continue for all AC items -->
+<!-- Repeat for all ACs.
+     EVERY AC must have a Verification Method. If unclear, flag as "⚠️ UNCLEAR" with suggested refinement.
+     See references/verification-criteria.md for method selection guide. -->
 
 ---
 
 ## Implementation Plan
 
-### Phase 1: [Phase Name]
-1. [Step with specific file/component references]
+### Phase 1: [Name]
+1. [Step referencing specific files/components from context gathering]
 2. [Step]
 
-### Phase 2: [Phase Name]
-<!-- Continue for all phases -->
+### Phase 2: [Name]
+<!-- 3-7 total steps. Group into phases. Note dependencies between steps.
+     For major decisions: present 2-3 options, recommend default with rationale.
+     See references/parallel-groups.md for parallel execution format (3+ independent tasks). -->
 
 ---
 
 ## Design Review
 
 1. **Where does this logic belong?** [Module/layer that owns this change]
-
 2. **What's the simplest correct approach?** [Minimum implementation, rejected alternatives]
+3. **What existing pattern does this follow?** [Named pattern, confirm it fits]
+4. **What would a senior reviewer challenge?** [Anticipated "why didn't you just...?" pushback]
 
-3. **What existing pattern does this follow?** [Named pattern, confirmation it fits]
-
-4. **What would a senior reviewer challenge?** [Anticipated pushback]
-
-<!-- For simple-fix/typo/docs-only: only Q1 and Q3 required -->
+<!-- Simple tier: Q1 and Q3 only. Standard/Complex: all four. -->
 
 ---
 
 ## Feature Quality Planning
 
-### Completeness Check
-- [ ] All AC items have corresponding implementation steps
-- [ ] Integration points identified
-- [ ] No partial implementations planned
+<!-- Exception-based: report only gaps and concerns. Full checklist in references/quality-checklist.md -->
 
-### Error Handling
-- [ ] Invalid input scenarios identified
-- [ ] External service failures handled
-- [ ] Edge cases documented
+**All standard checks pass.** Notable items:
+- [Gap or concern requiring attention]
+- [Another gap if applicable]
 
-### Code Quality
-- [ ] Types fully defined (no `any`)
-- [ ] Follows existing patterns
-- [ ] No magic strings/numbers
+### Derived ACs (if any)
 
-### Test Coverage Plan
-- [ ] Unit tests for business logic
-- [ ] Edge case tests identified
-- [ ] Critical paths covered
-
-### Best Practices
-- [ ] Logging for observability
-- [ ] Security reviewed
-- [ ] Documentation updated
-
-### Polish (UI only)
-- [ ] Loading/error/empty states
-- [ ] Responsive design
-
-### Derived ACs
 | Source | Derived AC | Priority |
 |--------|-----------|----------|
-| [Section] | AC-N: [Description] | High/Medium/Low |
+| [Quality dimension] | AC-N: [Description] | High/Medium/Low |
+
+<!-- Complex tier: walk through full checklist from references/quality-checklist.md -->
 
 ---
 
 ## Open Questions
 
-1. **[Question]**
-   - Recommendation: [Default choice]
-   - Impact: [What happens if wrong]
+1. **[Question]** — Recommendation: [default]. Impact: [if wrong].
 
 ---
 
 ## Recommended Workflow
 
-**Phases:** exec → qa
-**Quality Loop:** disabled
-**Reasoning:** [Why these phases based on issue analysis]
+**Phases:** [spec →] exec → qa
+**Quality Loop:** [enabled/disabled]
+**Reasoning:** [Brief explanation]
+
+<!-- Decision logic:
+     - UI/frontend → add `test` phase
+     - `no-browser-test` label → skip `test` (overrides UI labels)
+     - Complex refactor → enable quality loop
+     - Security-sensitive → add `security-review` phase
+     - New features with Unit/Integration Test verification ACs → add `testgen` phase
+     - Docs-only → skip spec, just exec → qa -->
 
 ---
 
 ## Label Review
 
-**Current:** [current labels]
-**Recommended:** [recommended labels]
-**Reason:** [Why these labels based on plan analysis]
+**Current:** [labels]
+**Recommended:** [labels]
+**Reason:** [Why, based on plan analysis]
 **Quality Loop:** [Will/Won't auto-enable and why]
 
 → `gh issue edit <N> --add-label [label]`
@@ -1098,5 +255,32 @@ You MUST include these sections in order:
 
 --- DRAFT GITHUB ISSUE COMMENT (PLAN) ---
 
-[Complete formatted comment for GitHub]
+[AC checklist with verification + implementation plan + key decisions + open questions]
 ```
+
+### Browser Testing Label Suggestion
+
+When `.tsx`/`.jsx` references detected in issue body AND no `ui`/`frontend`/`admin` label present:
+> **Component files detected** — add `ui` label for browser testing, or `no-browser-test` to explicitly skip.
+
+### Assess Comment Integration
+
+Before making phase recommendations, check for prior `/assess` analysis:
+
+```bash
+assess_comment=$(gh issue view <N> --json comments \
+  --jq '[.comments[].body | select(test("## Assess Analysis|<!-- assess:phases="))] | last // empty')
+```
+
+If found, use assess recommendation as starting point. You may override, but MUST document why.
+
+## Update GitHub Issue
+
+Post the draft comment and add label:
+
+```bash
+gh issue comment <issue-number> --body "..."
+gh issue edit <issue-number> --add-label "planned"
+```
+
+**Do NOT start implementation** — this is planning-only.

--- a/templates/skills/spec/SKILL.md
+++ b/templates/skills/spec/SKILL.md
@@ -288,6 +288,30 @@ See [verification-criteria.md](references/verification-criteria.md) for detailed
 [AC checklist with verification + implementation plan + key decisions + open questions]
 ```
 
+### Testgen Phase Auto-Detection
+
+#### When to recommend `testgen` phase:
+
+| Condition | Recommend testgen? | Reasoning |
+|-----------|-------------------|-----------|
+| ACs have "Unit Test" verification method | Yes | Tests should be stubbed before implementation |
+| ACs have "Integration Test" verification method | Yes | Complex integration tests benefit from early structure |
+| New feature (`enhancement`/`feature` label) with >2 ACs | Yes | Features need test coverage |
+| Simple bug fix (`bug` label only) | No | Skip testgen — targeted tests sufficient |
+| Docs-only (`docs` label) | No | Skip testgen — no unit tests needed |
+| All ACs have "Manual Test" or "Browser Test" | No | Skip testgen — no code stubs to generate |
+
+**Detection logic:**
+1. Count ACs with "Unit Test" → If >0, recommend testgen
+2. Count ACs with "Integration Test" → If >0, recommend testgen
+3. Check labels: `bug`/`fix` only → Skip testgen. `docs` → Skip testgen.
+
+**Example when testgen recommended:**
+```markdown
+**Phases:** spec → testgen → exec → qa
+**Reasoning:** ACs include Unit Test verification methods; testgen will create stubs before implementation
+```
+
 ### Browser Testing Label Suggestion
 
 When `.tsx`/`.jsx` references detected in issue body AND no `ui`/`frontend`/`admin` label present:

--- a/templates/skills/spec/SKILL.md
+++ b/templates/skills/spec/SKILL.md
@@ -2,9 +2,9 @@
 name: spec
 description: "Plan review vs Acceptance Criteria for a single GitHub issue, plus issue comment draft."
 license: MIT
-version: "2.1"
 metadata:
   author: sequant
+  version: "2.1"
 allowed-tools:
   - Bash(npm test:*)
   - Bash(gh issue view:*)

--- a/templates/skills/spec/SKILL.md
+++ b/templates/skills/spec/SKILL.md
@@ -197,6 +197,15 @@ See [verification-criteria.md](references/verification-criteria.md) for detailed
 <!-- Repeat for all ACs. EVERY AC must have a Verification Method from the decision framework.
      If unclear, flag as "⚠️ UNCLEAR" with suggested refinement. -->
 
+<!-- Example of a completed AC entry:
+
+### AC-3: User can submit the registration form
+
+**Verification:** Browser Test
+**Scenario:** Given user on /register → When fill fields and click Submit → Then redirect to /dashboard with success toast
+**Assumptions:** Auth API returns 201 on valid input; email uniqueness enforced by DB constraint
+-->
+
 ---
 
 ## Implementation Plan

--- a/templates/skills/spec/references/quality-checklist.md
+++ b/templates/skills/spec/references/quality-checklist.md
@@ -1,0 +1,75 @@
+# Feature Quality Planning — Full Checklist
+
+Use this checklist for **Complex** tier issues or when the exception-based summary in SKILL.md flags significant gaps. For Simple/Standard tiers, the exception-based approach in the main prompt is sufficient.
+
+## Section Applicability
+
+| Issue Type | Sections Required |
+|------------|-------------------|
+| Bug fix | Completeness, Error Handling, Test Coverage |
+| New feature | All sections |
+| Refactor | Completeness, Code Quality, Test Coverage |
+| UI change | All sections including Polish |
+| Backend/API | Completeness, Error Handling, Code Quality, Test Coverage, Best Practices |
+| CLI/Script | Completeness, Error Handling, Test Coverage, Best Practices |
+| Docs only | Completeness only |
+
+## Completeness Check
+
+- [ ] All AC items have corresponding implementation steps
+- [ ] Integration points with existing features identified
+- [ ] No partial implementations or TODOs planned
+- [ ] State management considered (if applicable)
+- [ ] Data flow is complete end-to-end
+
+## Error Handling
+
+- [ ] Invalid input scenarios identified
+- [ ] API/external service failures handled
+- [ ] Edge cases documented (empty, null, max values)
+- [ ] Error messages are user-friendly
+- [ ] Graceful degradation planned
+
+## Code Quality
+
+- [ ] Types fully defined (no `any` planned)
+- [ ] Follows existing patterns in codebase
+- [ ] Error boundaries where needed
+- [ ] No magic strings/numbers
+- [ ] Consistent naming conventions
+
+## Test Coverage Plan
+
+- [ ] Unit tests for business logic
+- [ ] Integration tests for data flow
+- [ ] Edge case tests identified
+- [ ] Mocking strategy appropriate
+- [ ] Critical paths have test coverage
+
+## Best Practices
+
+- [ ] Logging for debugging/observability
+- [ ] Accessibility considerations (if UI)
+- [ ] Performance implications considered
+- [ ] Security reviewed (auth, validation, sanitization)
+- [ ] Documentation updated (if behavior changes)
+
+## Polish (UI features only)
+
+- [ ] Loading states planned
+- [ ] Error states have UI
+- [ ] Empty states handled
+- [ ] Responsive design considered
+- [ ] Keyboard navigation works
+
+## Derived ACs
+
+Based on quality planning, identify additional ACs:
+
+| Source | Derived AC | Priority |
+|--------|-----------|----------|
+| Error Handling | AC-N: Handle [specific error] with [specific response] | High/Medium/Low |
+| Test Coverage | AC-N+1: Add tests for [specific scenario] | High/Medium/Low |
+| Best Practices | AC-N+2: Add logging for [specific operation] | High/Medium/Low |
+
+Derived ACs are numbered sequentially after original ACs.


### PR DESCRIPTION
## Summary

- Compress spec skill SKILL.md from 5,508 to 1,370 words (75% reduction, exceeding 60% target)
- Add complexity-gated output tiers (Simple/Standard/Complex) with char targets
- Make agent count conditional on issue content (DB→3, UI→2, CLI→2, docs→1)
- Add platform detection preamble for non-GitHub environments
- Add skill version tracking in frontmatter + `sequant status` display
- Add `sequant init --upgrade-skills` with diff preview before overwriting

## AC Coverage (12/12 MET)

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | Consolidate triple output spec into single template | MET |
| AC-2 | Guard dead `npx tsx` blocks with conditional | MET |
| AC-3 | Reduce example verbosity (100% removed from SKILL.md) | MET |
| AC-4 | Exception-based Feature Quality Planning | MET |
| AC-5 | Simple/Standard/Complex output tiers | MET |
| AC-6 | Tier announcement at top of output | MET |
| AC-7 | Conditional agent count by issue content | MET |
| AC-8 | Dynamic agent search paths | MET |
| AC-9 | Platform detection preamble | MET |
| AC-10 | Project structure discovery | MET |
| AC-11 | Skill version in frontmatter + status display | MET |
| AC-12 | `--upgrade-skills` with diff preview | MET |

## Key Metrics

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Words | 5,508 | 1,370 | -75% |
| Lines | 1,103 | 286 | -74% |
| Code blocks | ~45 | ~8 | -82% |
| Output specs | 3 (redundant) | 1 (unified) | -67% |
| Mandatory agents | 3 | 1-3 (conditional) | dynamic |

## Files Changed

- `.claude/skills/spec/SKILL.md` — Compressed prompt (all 3 directories synced)
- `references/quality-checklist.md` — New Tier 3 reference for full quality checklist
- `src/lib/skill-version.ts` — New utility for reading skill YAML frontmatter versions
- `src/lib/templates.ts` — Export `getTemplatesDir()` for reuse
- `src/commands/status.ts` — Show outdated skill versions
- `src/commands/init.ts` — Add `upgradeSkills()` with diff preview
- `bin/cli.ts` — Register `--upgrade-skills` flag

## Test plan

- [x] Build passes (`tsc`)
- [x] 53 targeted tests pass (status: 8, init: 34, templates: 11)
- [x] Skill sync check: spec/ 5/5 synced across all 3 directories
- [x] No type safety issues, no deleted tests, no security patterns
- [ ] Manual: run `/spec` on a simple-fix issue and verify output tier
- [ ] Manual: run `/spec` on a complex issue and verify full output
- [ ] Manual: run `sequant status` with outdated skill versions
- [ ] Manual: test on Haiku model for output quality regression

Closes #515