### PR TITLE
fix(#528): scope chain-mode checkpoint to feature paths, not git add -A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chain-mode checkpoint scoping** — `createCheckpointCommit` no longer runs `git add -A`; stages only files touched by the issue's commits relative to the chain base branch. Unrelated dirty files (e.g. `.claude/*`, `.sequant-manifest.json`) trigger a warning and skip the checkpoint instead of being swept in (#528)
+
 ### Changed
 
 - Restore `/solve` feature parity in `/assess` output (#522)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Chain-mode checkpoint scoping** — `createCheckpointCommit` no longer runs `git add -A`; stages only files touched by the issue's commits relative to the chain base branch. Unrelated dirty files (e.g. `.claude/*`, `.sequant-manifest.json`) trigger a warning and skip the checkpoint instead of being swept in (#528)
+- **Chain-mode checkpoint scoping** — `createCheckpointCommit` no longer runs `git add -A`; stages only files touched by the issue's commits relative to the chain base branch. Unrelated dirty files (e.g. `.claude/*`, `.sequant-manifest.json`) trigger a warning and skip the checkpoint instead of being swept in. Uses NUL-terminated git output (`-z`) for robust handling of paths with unicode or special characters (#528)
 
 ### Changed
 

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -476,7 +476,7 @@ describe("chain mode", () => {
       expect(mockSpawnSync).toHaveBeenCalledTimes(1);
       expect(mockSpawnSync).toHaveBeenCalledWith(
         "git",
-        ["-C", "/path/to/worktree", "status", "--porcelain"],
+        ["-C", "/path/to/worktree", "status", "--porcelain", "-z"],
         { stdio: "pipe" },
       );
     });
@@ -487,8 +487,8 @@ describe("chain mode", () => {
       // 3: git add -- <scoped files>
       // 4: git commit
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
-        .mockReturnValueOnce(spawnOk("src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\0"))
+        .mockReturnValueOnce(spawnOk("src/file.ts\0"))
         .mockReturnValueOnce(spawnOk())
         .mockReturnValueOnce(spawnOk());
 
@@ -506,7 +506,7 @@ describe("chain mode", () => {
       expect(mockSpawnSync).toHaveBeenNthCalledWith(
         2,
         "git",
-        ["-C", "/path/to/worktree", "diff", "--name-only", "main...HEAD"],
+        ["-C", "/path/to/worktree", "diff", "--name-only", "-z", "main...HEAD"],
         { stdio: "pipe" },
       );
 
@@ -531,8 +531,8 @@ describe("chain mode", () => {
       // 1: git status (has dirty file outside feature scope)
       // 2: git diff --name-only (feature paths don't include the dirty file)
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk(" M .claude/settings.json\n"))
-        .mockReturnValueOnce(spawnOk("src/feature.ts\n"));
+        .mockReturnValueOnce(spawnOk(" M .claude/settings.json\0"))
+        .mockReturnValueOnce(spawnOk("src/feature.ts\0"));
 
       const result = createCheckpointCommit(
         "/path/to/worktree",
@@ -562,9 +562,9 @@ describe("chain mode", () => {
       // Both feature file and unrelated file are dirty
       mockSpawnSync
         .mockReturnValueOnce(
-          spawnOk(" M src/file.ts\n M .sequant-manifest.json\n"),
+          spawnOk(" M src/file.ts\0 M .sequant-manifest.json\0"),
         )
-        .mockReturnValueOnce(spawnOk("src/file.ts\n"));
+        .mockReturnValueOnce(spawnOk("src/file.ts\0"));
 
       const result = createCheckpointCommit(
         "/path/to/worktree",
@@ -592,8 +592,8 @@ describe("chain mode", () => {
 
     it("should return false when git add fails", () => {
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
-        .mockReturnValueOnce(spawnOk("src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\0"))
+        .mockReturnValueOnce(spawnOk("src/file.ts\0"))
         .mockReturnValueOnce(spawnFail());
 
       const result = createCheckpointCommit(
@@ -608,8 +608,8 @@ describe("chain mode", () => {
 
     it("should return false when git commit fails", () => {
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
-        .mockReturnValueOnce(spawnOk("src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\0"))
+        .mockReturnValueOnce(spawnOk("src/file.ts\0"))
         .mockReturnValueOnce(spawnOk())
         .mockReturnValueOnce(spawnFail("commit failed"));
 
@@ -626,7 +626,7 @@ describe("chain mode", () => {
     it("should treat all dirty files as in-scope when no baseBranch provided (non-chain)", () => {
       // Without baseBranch: status → add all dirty → commit (no diff needed)
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\0"))
         .mockReturnValueOnce(spawnOk())
         .mockReturnValueOnce(spawnOk());
 
@@ -651,9 +651,9 @@ describe("chain mode", () => {
       // Feature commits only touched src/feature.ts, not .claude/memory.md
       mockSpawnSync
         .mockReturnValueOnce(
-          spawnOk(" M src/feature.ts\n M .claude/memory.md\n"),
+          spawnOk(" M src/feature.ts\0 M .claude/memory.md\0"),
         )
-        .mockReturnValueOnce(spawnOk("src/feature.ts\n"));
+        .mockReturnValueOnce(spawnOk("src/feature.ts\0"));
 
       const result = createCheckpointCommit(
         "/path/to/worktree",
@@ -680,8 +680,8 @@ describe("chain mode", () => {
     it("should checkpoint only feature files when both feature and non-feature are dirty but all committed (AC-4 clean variant)", () => {
       // All dirty files are in the feature scope — checkpoint proceeds
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk(" M src/index.ts\n M src/utils.ts\n"))
-        .mockReturnValueOnce(spawnOk("src/index.ts\nsrc/utils.ts\n"))
+        .mockReturnValueOnce(spawnOk(" M src/index.ts\0 M src/utils.ts\0"))
+        .mockReturnValueOnce(spawnOk("src/index.ts\0src/utils.ts\0"))
         .mockReturnValueOnce(spawnOk())
         .mockReturnValueOnce(spawnOk());
 
@@ -710,12 +710,14 @@ describe("chain mode", () => {
       );
     });
 
-    it("should extract rename target path from porcelain R entries", () => {
-      // Porcelain rename format: "R  old -> new" (note: 2 spaces after R for index/worktree status)
-      // slice(3) yields "old -> new"; split(" -> ").pop() yields "new"
+    it("should extract rename target path from porcelain R entries (-z)", () => {
+      // With -z, rename format is two NUL-separated entries:
+      //   "R  newpath\0oldpath\0"
+      // The first entry's path is the new name; the second (oldpath) is consumed
+      // by the parser and NOT staged.
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk("R  src/old.ts -> src/new.ts\n"))
-        .mockReturnValueOnce(spawnOk("src/new.ts\n"))
+        .mockReturnValueOnce(spawnOk("R  src/new.ts\0src/old.ts\0"))
+        .mockReturnValueOnce(spawnOk("src/new.ts\0"))
         .mockReturnValueOnce(spawnOk())
         .mockReturnValueOnce(spawnOk());
 
@@ -727,11 +729,37 @@ describe("chain mode", () => {
       );
 
       expect(result).toBe(true);
-      // Verify the rename target (new path) was staged, not the original
+      // Only the new path is staged — old path is consumed by the rename-pair parser
       expect(mockSpawnSync).toHaveBeenNthCalledWith(
         3,
         "git",
         ["-C", "/path/to/worktree", "add", "--", "src/new.ts"],
+        { stdio: "pipe" },
+      );
+    });
+
+    it("should handle paths with unicode/special characters (-z, no quoting)", () => {
+      // With -z, git does not quote non-ASCII paths. This is the key
+      // robustness win over --porcelain without -z.
+      mockSpawnSync
+        .mockReturnValueOnce(spawnOk(" M src/café.ts\0"))
+        .mockReturnValueOnce(spawnOk("src/café.ts\0"))
+        .mockReturnValueOnce(spawnOk())
+        .mockReturnValueOnce(spawnOk());
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
+
+      expect(result).toBe(true);
+      // Unicode path passed verbatim — no escape sequences, no quote chars
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(
+        3,
+        "git",
+        ["-C", "/path/to/worktree", "add", "--", "src/café.ts"],
         { stdio: "pipe" },
       );
     });
@@ -743,7 +771,7 @@ describe("chain mode", () => {
       const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       mockSpawnSync
-        .mockReturnValueOnce(spawnOk("?? src/untracked-new.ts\n"))
+        .mockReturnValueOnce(spawnOk("?? src/untracked-new.ts\0"))
         .mockReturnValueOnce(spawnOk("")); // no committed feature paths
 
       const result = createCheckpointCommit(

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -450,21 +450,29 @@ describe("chain mode", () => {
   });
 
   describe("createCheckpointCommit", () => {
-    it("should return true when no changes to commit", () => {
-      // Mock git status returning empty (no changes)
-      mockSpawnSync.mockReturnValue({
-        status: 0,
-        stdout: Buffer.from(""),
-        stderr: Buffer.from(""),
-        pid: 1234,
-        signal: null,
-        output: [],
-      });
+    const spawnOk = (stdout = "") => ({
+      status: 0,
+      stdout: Buffer.from(stdout),
+      stderr: Buffer.from(""),
+      pid: 1234,
+      signal: null as null,
+      output: [],
+    });
+    const spawnFail = (stderr = "error") => ({
+      status: 1,
+      stdout: Buffer.from(""),
+      stderr: Buffer.from(stderr),
+      pid: 1234,
+      signal: null as null,
+      output: [],
+    });
+
+    it("should return true when no changes to commit (AC-5)", () => {
+      mockSpawnSync.mockReturnValue(spawnOk(""));
 
       const result = createCheckpointCommit("/path/to/worktree", 123, false);
 
       expect(result).toBe(true);
-      // Only status should be called since there are no changes
       expect(mockSpawnSync).toHaveBeenCalledTimes(1);
       expect(mockSpawnSync).toHaveBeenCalledWith(
         "git",
@@ -473,70 +481,109 @@ describe("chain mode", () => {
       );
     });
 
-    it("should create checkpoint commit when there are uncommitted changes", () => {
-      // First call: git status (has changes)
-      // Second call: git add -A
-      // Third call: git commit
+    it("should stage only in-scope feature paths, not git add -A (AC-1)", () => {
+      // 1: git status (dirty file is in-scope)
+      // 2: git diff --name-only (feature paths)
+      // 3: git add -- <scoped files>
+      // 4: git commit
       mockSpawnSync
-        .mockReturnValueOnce({
-          status: 0,
-          stdout: Buffer.from("M src/file.ts\n"),
-          stderr: Buffer.from(""),
-          pid: 1234,
-          signal: null,
-          output: [],
-        })
-        .mockReturnValueOnce({
-          status: 0,
-          stdout: Buffer.from(""),
-          stderr: Buffer.from(""),
-          pid: 1234,
-          signal: null,
-          output: [],
-        })
-        .mockReturnValueOnce({
-          status: 0,
-          stdout: Buffer.from(""),
-          stderr: Buffer.from(""),
-          pid: 1234,
-          signal: null,
-          output: [],
-        });
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk("src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk())
+        .mockReturnValueOnce(spawnOk());
 
-      const result = createCheckpointCommit("/path/to/worktree", 123, false);
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
 
       expect(result).toBe(true);
-      expect(mockSpawnSync).toHaveBeenCalledTimes(3);
+      expect(mockSpawnSync).toHaveBeenCalledTimes(4);
 
-      // Verify git add was called
+      // Verify git diff was called with baseBranch
       expect(mockSpawnSync).toHaveBeenNthCalledWith(
         2,
         "git",
-        ["-C", "/path/to/worktree", "add", "-A"],
+        ["-C", "/path/to/worktree", "diff", "--name-only", "main...HEAD"],
         { stdio: "pipe" },
       );
 
-      // Verify git commit was called with checkpoint message
-      const commitCall = mockSpawnSync.mock.calls[2];
-      expect(commitCall[0]).toBe("git");
-      expect(commitCall[1]).toContain("-C");
-      expect(commitCall[1]).toContain("commit");
-      expect(commitCall[1]).toContain("-m");
-      // Verify commit message contains issue number
+      // Verify scoped git add (not -A)
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(
+        3,
+        "git",
+        ["-C", "/path/to/worktree", "add", "--", "src/file.ts"],
+        { stdio: "pipe" },
+      );
+
+      // Verify commit message
+      const commitCall = mockSpawnSync.mock.calls[3];
       const commitMessage = commitCall[1][commitCall[1].indexOf("-m") + 1];
       expect(commitMessage).toContain("checkpoint(#123)");
       expect(commitMessage).toContain("QA passed");
     });
 
+    it("should skip checkpoint and warn when unrelated dirty files exist (AC-2)", () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      // 1: git status (has dirty file outside feature scope)
+      // 2: git diff --name-only (feature paths don't include the dirty file)
+      mockSpawnSync
+        .mockReturnValueOnce(spawnOk(" M .claude/settings.json\n"))
+        .mockReturnValueOnce(spawnOk("src/feature.ts\n"));
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
+
+      expect(result).toBe(false);
+      // Should NOT call git add or git commit
+      expect(mockSpawnSync).toHaveBeenCalledTimes(2);
+
+      // Verify warning was emitted
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping checkpoint"),
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(".claude/settings.json"),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should skip checkpoint when mix of in-scope and out-of-scope dirty files (AC-2)", () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      // Both feature file and unrelated file are dirty
+      mockSpawnSync
+        .mockReturnValueOnce(
+          spawnOk(" M src/file.ts\n M .sequant-manifest.json\n"),
+        )
+        .mockReturnValueOnce(spawnOk("src/file.ts\n"));
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
+
+      expect(result).toBe(false);
+      expect(mockSpawnSync).toHaveBeenCalledTimes(2);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(".sequant-manifest.json"),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
     it("should return false when git status fails", () => {
-      mockSpawnSync.mockReturnValue({
-        status: 1,
-        stdout: Buffer.from(""),
-        stderr: Buffer.from("error"),
-        pid: 1234,
-        signal: null,
-        output: [],
-      });
+      mockSpawnSync.mockReturnValue(spawnFail());
 
       const result = createCheckpointCommit("/path/to/worktree", 123, false);
 
@@ -545,58 +592,122 @@ describe("chain mode", () => {
 
     it("should return false when git add fails", () => {
       mockSpawnSync
-        .mockReturnValueOnce({
-          status: 0,
-          stdout: Buffer.from("M src/file.ts\n"),
-          stderr: Buffer.from(""),
-          pid: 1234,
-          signal: null,
-          output: [],
-        })
-        .mockReturnValueOnce({
-          status: 1, // git add fails
-          stdout: Buffer.from(""),
-          stderr: Buffer.from("error"),
-          pid: 1234,
-          signal: null,
-          output: [],
-        });
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk("src/file.ts\n"))
+        .mockReturnValueOnce(spawnFail());
 
-      const result = createCheckpointCommit("/path/to/worktree", 123, false);
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
 
       expect(result).toBe(false);
     });
 
     it("should return false when git commit fails", () => {
       mockSpawnSync
-        .mockReturnValueOnce({
-          status: 0,
-          stdout: Buffer.from("M src/file.ts\n"),
-          stderr: Buffer.from(""),
-          pid: 1234,
-          signal: null,
-          output: [],
-        })
-        .mockReturnValueOnce({
-          status: 0,
-          stdout: Buffer.from(""),
-          stderr: Buffer.from(""),
-          pid: 1234,
-          signal: null,
-          output: [],
-        })
-        .mockReturnValueOnce({
-          status: 1, // git commit fails
-          stdout: Buffer.from(""),
-          stderr: Buffer.from("commit failed"),
-          pid: 1234,
-          signal: null,
-          output: [],
-        });
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk("src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk())
+        .mockReturnValueOnce(spawnFail("commit failed"));
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("should treat all dirty files as in-scope when no baseBranch provided (non-chain)", () => {
+      // Without baseBranch: status → add all dirty → commit (no diff needed)
+      mockSpawnSync
+        .mockReturnValueOnce(spawnOk(" M src/file.ts\n"))
+        .mockReturnValueOnce(spawnOk())
+        .mockReturnValueOnce(spawnOk());
 
       const result = createCheckpointCommit("/path/to/worktree", 123, false);
 
+      expect(result).toBe(true);
+      expect(mockSpawnSync).toHaveBeenCalledTimes(3);
+
+      // No diff call — all dirty files are in-scope
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(
+        2,
+        "git",
+        ["-C", "/path/to/worktree", "add", "--", "src/file.ts"],
+        { stdio: "pipe" },
+      );
+    });
+
+    it("should exclude dirty non-feature file in chain mode and skip checkpoint (AC-4 integration)", () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      // Simulate chain run: feature file + unrelated infra file both dirty
+      // Feature commits only touched src/feature.ts, not .claude/memory.md
+      mockSpawnSync
+        .mockReturnValueOnce(
+          spawnOk(" M src/feature.ts\n M .claude/memory.md\n"),
+        )
+        .mockReturnValueOnce(spawnOk("src/feature.ts\n"));
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        42,
+        true,
+        "main",
+      );
+
+      // Checkpoint should be skipped (not sweep the dirty file)
       expect(result).toBe(false);
+      // Only status + diff — no add or commit
+      expect(mockSpawnSync).toHaveBeenCalledTimes(2);
+      // Warning should list the unrelated file
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping checkpoint"),
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(".claude/memory.md"),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should checkpoint only feature files when both feature and non-feature are dirty but all committed (AC-4 clean variant)", () => {
+      // All dirty files are in the feature scope — checkpoint proceeds
+      mockSpawnSync
+        .mockReturnValueOnce(spawnOk(" M src/index.ts\n M src/utils.ts\n"))
+        .mockReturnValueOnce(spawnOk("src/index.ts\nsrc/utils.ts\n"))
+        .mockReturnValueOnce(spawnOk())
+        .mockReturnValueOnce(spawnOk());
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        42,
+        false,
+        "main",
+      );
+
+      expect(result).toBe(true);
+      expect(mockSpawnSync).toHaveBeenCalledTimes(4);
+      // Verify both files are staged
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(
+        3,
+        "git",
+        [
+          "-C",
+          "/path/to/worktree",
+          "add",
+          "--",
+          "src/index.ts",
+          "src/utils.ts",
+        ],
+        { stdio: "pipe" },
+      );
     });
   });
 

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -709,6 +709,61 @@ describe("chain mode", () => {
         { stdio: "pipe" },
       );
     });
+
+    it("should extract rename target path from porcelain R entries", () => {
+      // Porcelain rename format: "R  old -> new" (note: 2 spaces after R for index/worktree status)
+      // slice(3) yields "old -> new"; split(" -> ").pop() yields "new"
+      mockSpawnSync
+        .mockReturnValueOnce(spawnOk("R  src/old.ts -> src/new.ts\n"))
+        .mockReturnValueOnce(spawnOk("src/new.ts\n"))
+        .mockReturnValueOnce(spawnOk())
+        .mockReturnValueOnce(spawnOk());
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
+
+      expect(result).toBe(true);
+      // Verify the rename target (new path) was staged, not the original
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(
+        3,
+        "git",
+        ["-C", "/path/to/worktree", "add", "--", "src/new.ts"],
+        { stdio: "pipe" },
+      );
+    });
+
+    it("should classify untracked files as out-of-scope in chain mode", () => {
+      // Untracked files appear in porcelain as "?? path" but are not in git diff
+      // (diff only shows committed changes). Per AC-1, only paths touched by commits
+      // are in-scope, so untracked files trigger the warn+skip path.
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      mockSpawnSync
+        .mockReturnValueOnce(spawnOk("?? src/untracked-new.ts\n"))
+        .mockReturnValueOnce(spawnOk("")); // no committed feature paths
+
+      const result = createCheckpointCommit(
+        "/path/to/worktree",
+        123,
+        false,
+        "main",
+      );
+
+      expect(result).toBe(false);
+      expect(mockSpawnSync).toHaveBeenCalledTimes(2);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping checkpoint"),
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("src/untracked-new.ts"),
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe("chain mode validation", () => {

--- a/src/lib/workflow/batch-executor.ts
+++ b/src/lib/workflow/batch-executor.ts
@@ -995,7 +995,12 @@ export async function runIssueWithLogging(
 
   // Create checkpoint commit in chain mode after QA passes
   if (success && chainMode && worktreePath) {
-    createCheckpointCommit(worktreePath, issueNumber, config.verbose);
+    createCheckpointCommit(
+      worktreePath,
+      issueNumber,
+      config.verbose,
+      baseBranch,
+    );
   }
 
   // Rebase onto the base branch before PR creation (unless --no-rebase)

--- a/src/lib/workflow/checkpoint.integration.test.ts
+++ b/src/lib/workflow/checkpoint.integration.test.ts
@@ -122,4 +122,36 @@ describe("createCheckpointCommit (integration)", () => {
     expect(result).toBe(true);
     expect(headAfter).toBe(headBefore);
   });
+
+  it("checkpoints paths with unicode/non-ASCII characters", () => {
+    // Without -z, git quotes non-ASCII paths ("caf\\303\\251.ts"), which would
+    // break path-based staging. This test proves -z avoids that class of bug.
+    const unicodePath = "src/café.ts";
+    writeFileSync(join(repoDir, unicodePath), "export const v = 1;\n");
+    git(repoDir, "add", unicodePath);
+    git(repoDir, "commit", "-m", "feat: add unicode-named file");
+
+    // Dirty the unicode-named file
+    writeFileSync(join(repoDir, unicodePath), "export const v = 2;\n");
+
+    const headBefore = git(repoDir, "rev-parse", "HEAD");
+    const result = createCheckpointCommit(repoDir, 42, false, "main");
+    const headAfter = git(repoDir, "rev-parse", "HEAD");
+
+    expect(result).toBe(true);
+    expect(headAfter).not.toBe(headBefore);
+
+    // The unicode path appears verbatim in the checkpoint commit.
+    // Use -c core.quotePath=false so git doesn't escape non-ASCII in its output.
+    const changed = git(
+      repoDir,
+      "-c",
+      "core.quotePath=false",
+      "show",
+      "--name-only",
+      "--pretty=format:",
+      "HEAD",
+    ).trim();
+    expect(changed).toContain(unicodePath);
+  });
 });

--- a/src/lib/workflow/checkpoint.integration.test.ts
+++ b/src/lib/workflow/checkpoint.integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration tests for createCheckpointCommit (#528 AC-4)
+ *
+ * These tests exercise real git against a temp worktree — no mocks.
+ * They guard the regression mode described in the issue: chain-mode
+ * checkpoints sweeping unrelated dirty files (`.claude/*`, `.sequant-manifest.json`)
+ * into the PR base when the worktree is dirty outside the feature scope.
+ *
+ * Pair with the mocked unit tests in src/commands/run.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createCheckpointCommit } from "./worktree-manager.js";
+
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed (${result.status}): ${result.stderr}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+// Porcelain output must preserve the leading XY columns — do not trim.
+function gitRaw(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed (${result.status}): ${result.stderr}`,
+    );
+  }
+  return result.stdout;
+}
+
+describe("createCheckpointCommit (integration)", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "sequant-checkpoint-"));
+
+    // Initialize repo with main branch + user config scoped to this repo only
+    git(repoDir, "init", "--initial-branch=main");
+    git(repoDir, "config", "user.email", "test@sequant.test");
+    git(repoDir, "config", "user.name", "Test");
+    git(repoDir, "config", "commit.gpgsign", "false");
+
+    // Baseline commit on main — includes a tracked infra file to reproduce the
+    // real regression (dirty tracked file outside the feature's commit scope)
+    writeFileSync(join(repoDir, "README.md"), "# repo\n");
+    mkdirSync(join(repoDir, ".claude"), { recursive: true });
+    writeFileSync(join(repoDir, ".claude/memory.md"), "initial\n");
+    git(repoDir, "add", "README.md", ".claude/memory.md");
+    git(repoDir, "commit", "-m", "initial commit");
+
+    // Feature branch with a committed change to src/feature.ts
+    git(repoDir, "checkout", "-b", "feature/test");
+    mkdirSync(join(repoDir, "src"), { recursive: true });
+    writeFileSync(join(repoDir, "src/feature.ts"), "export const v = 1;\n");
+    git(repoDir, "add", "src/feature.ts");
+    git(repoDir, "commit", "-m", "feat: add feature");
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("skips checkpoint and warns when a dirty non-feature file exists (AC-4)", () => {
+    // Reproduce the regression: dirty a tracked infra file outside feature scope
+    writeFileSync(join(repoDir, ".claude/memory.md"), "dirty infra\n");
+    // Also dirty the feature file so there is in-scope work available
+    writeFileSync(join(repoDir, "src/feature.ts"), "export const v = 2;\n");
+
+    const headBefore = git(repoDir, "rev-parse", "HEAD");
+    const result = createCheckpointCommit(repoDir, 42, false, "main");
+    const headAfter = git(repoDir, "rev-parse", "HEAD");
+
+    expect(result).toBe(false);
+    // No new commit — the checkpoint was correctly skipped
+    expect(headAfter).toBe(headBefore);
+
+    // Both files remain dirty (modified, not staged, not committed)
+    const status = gitRaw(repoDir, "status", "--porcelain");
+    expect(status).toMatch(/^ M \.claude\/memory\.md$/m);
+    expect(status).toMatch(/^ M src\/feature\.ts$/m);
+  });
+
+  it("commits only in-scope feature files when the tree is clean outside scope", () => {
+    writeFileSync(join(repoDir, "src/feature.ts"), "export const v = 3;\n");
+
+    const headBefore = git(repoDir, "rev-parse", "HEAD");
+    const result = createCheckpointCommit(repoDir, 42, false, "main");
+    const headAfter = git(repoDir, "rev-parse", "HEAD");
+
+    expect(result).toBe(true);
+    expect(headAfter).not.toBe(headBefore);
+
+    // Commit message shape
+    const msg = git(repoDir, "log", "-1", "--pretty=%s");
+    expect(msg).toBe("checkpoint(#42): QA passed");
+
+    // Only the feature file is in the checkpoint commit
+    const changed = git(
+      repoDir,
+      "show",
+      "--name-only",
+      "--pretty=format:",
+      "HEAD",
+    ).trim();
+    expect(changed).toBe("src/feature.ts");
+  });
+
+  it("returns true with no new commit when the tree is clean (AC-5)", () => {
+    const headBefore = git(repoDir, "rev-parse", "HEAD");
+    const result = createCheckpointCommit(repoDir, 42, false, "main");
+    const headAfter = git(repoDir, "rev-parse", "HEAD");
+
+    expect(result).toBe(true);
+    expect(headAfter).toBe(headBefore);
+  });
+});

--- a/src/lib/workflow/worktree-manager.ts
+++ b/src/lib/workflow/worktree-manager.ts
@@ -970,14 +970,16 @@ export async function ensureWorktreesChain(
 }
 
 /**
- * Create a checkpoint commit in the worktree after QA passes
- * This allows recovery in case later issues in the chain fail
+ * Create a checkpoint commit in the worktree after QA passes.
+ * Only stages files that were touched by the issue's commits (diff vs baseBranch).
+ * If unrelated dirty files exist, emits a warning and skips the checkpoint.
  * @internal Exported for testing
  */
 export function createCheckpointCommit(
   worktreePath: string,
   issueNumber: number,
   verbose: boolean,
+  baseBranch?: string,
 ): boolean {
   // Check if there are uncommitted changes
   const statusResult = spawnSync(
@@ -995,8 +997,11 @@ export function createCheckpointCommit(
     return false;
   }
 
-  const hasChanges = statusResult.stdout.toString().trim().length > 0;
-  if (!hasChanges) {
+  const statusLines = statusResult.stdout
+    .toString()
+    .split("\n")
+    .filter((line) => line.length > 0);
+  if (statusLines.length === 0) {
     if (verbose) {
       console.log(
         chalk.gray(`    📌 No changes to checkpoint (already committed)`),
@@ -1005,10 +1010,66 @@ export function createCheckpointCommit(
     return true;
   }
 
-  // Stage all changes
-  const addResult = spawnSync("git", ["-C", worktreePath, "add", "-A"], {
-    stdio: "pipe",
-  });
+  // Parse dirty file paths from porcelain output (format: "XY path" or "XY path -> newpath")
+  // Porcelain columns: index 0 = index status, index 1 = worktree status, index 2 = space
+  // Preserve raw lines to avoid corrupting the fixed-width column layout
+  const dirtyFiles = statusLines
+    .map((line) => line.slice(3).split(" -> ").pop()!.trim())
+    .filter(Boolean);
+
+  // Determine which files to stage.
+  // When baseBranch is provided (chain mode), scope to feature paths only.
+  // When baseBranch is absent (non-chain), treat all dirty files as in-scope.
+  let inScope: string[];
+  if (baseBranch) {
+    const diffResult = spawnSync(
+      "git",
+      ["-C", worktreePath, "diff", "--name-only", `${baseBranch}...HEAD`],
+      { stdio: "pipe" },
+    );
+
+    const featurePaths = new Set<string>();
+    if (diffResult.status === 0) {
+      diffResult.stdout
+        .toString()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .forEach((p) => featurePaths.add(p));
+    }
+
+    inScope = dirtyFiles.filter((f) => featurePaths.has(f));
+    const outOfScope = dirtyFiles.filter((f) => !featurePaths.has(f));
+
+    // AC-2: If unrelated dirty files exist, warn and skip checkpoint
+    if (outOfScope.length > 0) {
+      console.log(
+        chalk.yellow(
+          `    ⚠  Skipping checkpoint for #${issueNumber}: ${outOfScope.length} unrelated dirty file(s) in worktree:`,
+        ),
+      );
+      for (const f of outOfScope) {
+        console.log(chalk.yellow(`       - ${f}`));
+      }
+      return false;
+    }
+  } else {
+    // Non-chain mode: all dirty files are in-scope
+    inScope = dirtyFiles;
+  }
+
+  if (inScope.length === 0) {
+    if (verbose) {
+      console.log(chalk.gray(`    📌 No in-scope changes to checkpoint`));
+    }
+    return true;
+  }
+
+  // AC-1: Stage only in-scope feature paths
+  const addResult = spawnSync(
+    "git",
+    ["-C", worktreePath, "add", "--", ...inScope],
+    { stdio: "pipe" },
+  );
 
   if (addResult.status !== 0) {
     if (verbose) {

--- a/src/lib/workflow/worktree-manager.ts
+++ b/src/lib/workflow/worktree-manager.ts
@@ -981,10 +981,11 @@ export function createCheckpointCommit(
   verbose: boolean,
   baseBranch?: string,
 ): boolean {
-  // Check if there are uncommitted changes
+  // Check if there are uncommitted changes.
+  // Use -z (NUL-terminated) so paths with unicode or special chars aren't quoted/escaped.
   const statusResult = spawnSync(
     "git",
-    ["-C", worktreePath, "status", "--porcelain"],
+    ["-C", worktreePath, "status", "--porcelain", "-z"],
     { stdio: "pipe" },
   );
 
@@ -997,11 +998,8 @@ export function createCheckpointCommit(
     return false;
   }
 
-  const statusLines = statusResult.stdout
-    .toString()
-    .split("\n")
-    .filter((line) => line.length > 0);
-  if (statusLines.length === 0) {
+  const statusRaw = statusResult.stdout.toString();
+  if (statusRaw.length === 0) {
     if (verbose) {
       console.log(
         chalk.gray(`    📌 No changes to checkpoint (already committed)`),
@@ -1010,13 +1008,20 @@ export function createCheckpointCommit(
     return true;
   }
 
-  // Parse dirty file paths from porcelain output (format: "XY path" or "XY path -> newpath")
-  // Porcelain columns: index 0 = index status, index 1 = worktree status, index 2 = space
-  // Preserve raw lines to avoid corrupting the fixed-width column layout.
-  // The trailing .trim() strips whitespace around rename targets — not column fixing.
-  const dirtyFiles = statusLines
-    .map((line) => line.slice(3).split(" -> ").pop()!.trim())
-    .filter(Boolean);
+  // Parse NUL-separated porcelain entries. Each entry is "XY path".
+  // For renames/copies, the next entry is the old path and must be consumed.
+  const entries = statusRaw.split("\0").filter((e) => e.length > 0);
+  const dirtyFiles: string[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const xy = entry.slice(0, 2);
+    const path = entry.slice(3);
+    if (path) dirtyFiles.push(path);
+    // Rename (R) and copy (C) entries are followed by the original path — skip it
+    if (xy[0] === "R" || xy[0] === "C") {
+      i++;
+    }
+  }
 
   // Determine which files to stage.
   // When baseBranch is provided (chain mode), scope to feature paths only.
@@ -1025,7 +1030,7 @@ export function createCheckpointCommit(
   if (baseBranch) {
     const diffResult = spawnSync(
       "git",
-      ["-C", worktreePath, "diff", "--name-only", `${baseBranch}...HEAD`],
+      ["-C", worktreePath, "diff", "--name-only", "-z", `${baseBranch}...HEAD`],
       { stdio: "pipe" },
     );
 
@@ -1033,8 +1038,8 @@ export function createCheckpointCommit(
     if (diffResult.status === 0) {
       diffResult.stdout
         .toString()
-        .split("\n")
-        .filter((line) => line.length > 0)
+        .split("\0")
+        .filter((p) => p.length > 0)
         .forEach((p) => featurePaths.add(p));
     }
 

--- a/src/lib/workflow/worktree-manager.ts
+++ b/src/lib/workflow/worktree-manager.ts
@@ -1012,7 +1012,8 @@ export function createCheckpointCommit(
 
   // Parse dirty file paths from porcelain output (format: "XY path" or "XY path -> newpath")
   // Porcelain columns: index 0 = index status, index 1 = worktree status, index 2 = space
-  // Preserve raw lines to avoid corrupting the fixed-width column layout
+  // Preserve raw lines to avoid corrupting the fixed-width column layout.
+  // The trailing .trim() strips whitespace around rename targets — not column fixing.
   const dirtyFiles = statusLines
     .map((line) => line.slice(3).split(" -> ").pop()!.trim())
     .filter(Boolean);


### PR DESCRIPTION
## Summary

- Replaces hardcoded `git add -A` in `createCheckpointCommit` with a scoped `git add -- <inScope>`. In chain mode, staging is limited to paths touched by the issue's commits (`git diff --name-only -z baseBranch...HEAD`).
- If unrelated dirty files exist (e.g. `.claude/*`, `.sequant-manifest.json` dirtied by `sequant sync` or Claude Code memory writes), the checkpoint is **skipped with a warning** rather than sweeping them into the PR base. This eliminates the regression documented in #528 (PR #37 shipped +5600 lines of contamination).
- Uses `-z` (NUL-terminated) output on both `git status --porcelain` and `git diff --name-only`, so paths with unicode or special characters aren't misclassified by git's default quoting.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean (0 warnings)
- [x] 139 unit tests pass — `src/commands/run.test.ts` (12 new `createCheckpointCommit` tests covering scoped staging, warn+skip, rename pairs, unicode paths, untracked files, non-chain fallback, clean tree, and failure paths)
- [x] 4 integration tests pass — `src/lib/workflow/checkpoint.integration.test.ts` spawns real `git` against a temp worktree; covers: dirty non-feature file → warn+skip, clean-out-of-scope → scoped commit, clean tree → no-op, unicode path round-trip
- [ ] CI green on both Node versions

## AC coverage

- [x] AC-1: Checkpoint stages only paths in `baseBranch...HEAD`, not `git add -A`
- [x] AC-2: Unrelated dirty files → warning + skip
- [x] AC-3: Tests rewritten (no `["add","-A"]` assertion), scoped + abort paths covered
- [x] AC-4: Integration test against real `git` in temp worktree
- [x] AC-5: Clean tree still logs "No changes to checkpoint" and returns true
- [x] AC-6: `CHANGELOG.md` entry under `[Unreleased] → Fixed`