### PR TITLE
fix(#534): treat null QA verdict and zero-diff exec as phase failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Orchestrator no longer reports empty-worktree runs as successful (#534)
+  - QA phase with null/unparseable verdict now returns `success: false` with `"QA completed without a parseable verdict"` instead of silently passing
+  - Exec phase now fails with `"exec produced no changes (no commits, no uncommitted work)"` when the agent session returns success but the worktree has no commits ahead of `origin/main` and no uncommitted work
+
 ### Changed
 
 - Restore `/solve` feature parity in `/assess` output (#522)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Orchestrator no longer reports empty-worktree runs as successful (#534)
   - QA phase with null/unparseable verdict now returns `success: false` with `"QA completed without a parseable verdict"` instead of silently passing
-  - Exec phase now fails with `"exec produced no changes (no commits, no uncommitted work)"` when the agent session returns success but the worktree has no commits ahead of `origin/main` and no uncommitted work
+  - Exec phase now fails with `"exec produced no changes (no commits, no uncommitted work)"` when the agent session returns success but HEAD has no commits unique to it relative to `origin/main` and no uncommitted work (counted via `git rev-list --count origin/main..HEAD` so stale branches where main has advanced still report correctly)
 
 ### Changed
 

--- a/src/lib/workflow/phase-executor.test.ts
+++ b/src/lib/workflow/phase-executor.test.ts
@@ -1029,24 +1029,16 @@ describe("hasExecChanges", () => {
     mockExecSync.mockReset();
   });
 
-  function gitDiffExitStatus(status: number): Error {
-    const err = new Error("git diff exited") as Error & { status: number };
-    err.status = status;
-    return err;
-  }
-
   it("returns true when there are commits ahead of origin/main", () => {
-    // git diff --quiet exits 1 → commits ahead
-    mockExecSync.mockImplementationOnce(() => {
-      throw gitDiffExitStatus(1);
-    });
+    // git rev-list --count origin/main..HEAD returns "3\n"
+    mockExecSync.mockReturnValueOnce(Buffer.from("3\n"));
     expect(hasExecChanges("/tmp/wt")).toBe(true);
     expect(mockExecSync).toHaveBeenCalledTimes(1);
   });
 
   it("returns true when there are uncommitted changes but no commits", () => {
-    // git diff --quiet exits 0 → no commits
-    mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    // git rev-list --count → "0"
+    mockExecSync.mockReturnValueOnce(Buffer.from("0\n"));
     // git status --porcelain returns dirty output
     mockExecSync.mockReturnValueOnce(Buffer.from(" M src/foo.ts\n"));
     expect(hasExecChanges("/tmp/wt")).toBe(true);
@@ -1054,25 +1046,40 @@ describe("hasExecChanges", () => {
   });
 
   it("returns false when there are no commits and no uncommitted work", () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from("0\n"));
     mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    expect(hasExecChanges("/tmp/wt")).toBe(false);
+  });
+
+  it("returns false on a stale base branch when HEAD has no unique commits even though origin/main has advanced", () => {
+    // Regression guard: `git diff --quiet origin/main..HEAD` would exit 1
+    // here (main has advanced past HEAD), falsely reporting "has commits".
+    // `git rev-list --count origin/main..HEAD` correctly returns 0.
+    mockExecSync.mockReturnValueOnce(Buffer.from("0\n"));
     mockExecSync.mockReturnValueOnce(Buffer.from(""));
     expect(hasExecChanges("/tmp/wt")).toBe(false);
   });
 
   it("fails open (returns true) on git errors (e.g. missing origin)", () => {
-    // git diff --quiet exits 128 → unknown revision
+    // rev-list throws when origin/main is not a valid ref
     mockExecSync.mockImplementationOnce(() => {
-      throw gitDiffExitStatus(128);
+      throw new Error("fatal: bad revision 'origin/main..HEAD'");
     });
     expect(hasExecChanges("/tmp/wt")).toBe(true);
   });
 
   it("fails open when git status itself throws", () => {
-    mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    mockExecSync.mockReturnValueOnce(Buffer.from("0\n"));
     mockExecSync.mockImplementationOnce(() => {
       throw new Error("git status unavailable");
     });
     expect(hasExecChanges("/tmp/wt")).toBe(true);
+  });
+
+  it("treats non-numeric rev-list output as zero (fail closed on parse)", () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from("not-a-number\n"));
+    mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    expect(hasExecChanges("/tmp/wt")).toBe(false);
   });
 });
 
@@ -1201,12 +1208,8 @@ describe("mapAgentSuccessToPhaseResult", () => {
 
   describe("exec phase", () => {
     it("passes when exec produced commits", () => {
-      // git diff --quiet exits 1 → commits ahead
-      mockExecSync.mockImplementationOnce(() => {
-        const err = new Error("diff") as Error & { status: number };
-        err.status = 1;
-        throw err;
-      });
+      // git rev-list --count origin/main..HEAD → 2
+      mockExecSync.mockReturnValueOnce(Buffer.from("2\n"));
       const result = mapAgentSuccessToPhaseResult(
         "exec",
         makeAgentResult({ output: "done" }),
@@ -1218,8 +1221,8 @@ describe("mapAgentSuccessToPhaseResult", () => {
     });
 
     it("passes when exec left uncommitted work", () => {
-      // git diff --quiet exits 0 → no commits
-      mockExecSync.mockReturnValueOnce(Buffer.from(""));
+      // git rev-list --count → 0
+      mockExecSync.mockReturnValueOnce(Buffer.from("0\n"));
       // git status --porcelain shows dirty tree
       mockExecSync.mockReturnValueOnce(Buffer.from("?? src/new.ts\n"));
       const result = mapAgentSuccessToPhaseResult(
@@ -1232,7 +1235,26 @@ describe("mapAgentSuccessToPhaseResult", () => {
     });
 
     it("fails when exec produced no commits and no uncommitted work (#534)", () => {
+      mockExecSync.mockReturnValueOnce(Buffer.from("0\n"));
       mockExecSync.mockReturnValueOnce(Buffer.from(""));
+      const result = mapAgentSuccessToPhaseResult(
+        "exec",
+        makeAgentResult({ output: "done" }),
+        120,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        "exec produced no changes (no commits, no uncommitted work)",
+      );
+    });
+
+    it("fails on a stale base branch when HEAD has no unique commits (regression for #534 follow-up)", () => {
+      // Even if origin/main has advanced, HEAD's commit count relative to
+      // origin/main is still 0 — exec did nothing and must be reported as a
+      // failure. Previously `git diff --quiet origin/main..HEAD` would have
+      // exited 1 (inverse diff non-empty) and falsely passed.
+      mockExecSync.mockReturnValueOnce(Buffer.from("0\n"));
       mockExecSync.mockReturnValueOnce(Buffer.from(""));
       const result = mapAgentSuccessToPhaseResult(
         "exec",

--- a/src/lib/workflow/phase-executor.test.ts
+++ b/src/lib/workflow/phase-executor.test.ts
@@ -1,14 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from "child_process";
 import {
   parseQaVerdict,
   parseQaSummary,
   formatDuration,
   getPhasePrompt,
   executePhaseWithRetry,
+  hasExecChanges,
+  mapAgentSuccessToPhaseResult,
   SPEC_EXTRA_RETRIES,
   SPEC_RETRY_BACKOFF_MS,
 } from "./phase-executor.js";
 import type { ExecutionConfig, PhaseResult } from "./types.js";
+import type { AgentPhaseResult } from "./drivers/index.js";
 import { ShutdownManager } from "../shutdown.js";
 
 // Mock agents-md module
@@ -18,6 +27,7 @@ vi.mock("../agents-md.js", () => ({
 
 import { readAgentsMd } from "../agents-md.js";
 const mockReadAgentsMd = vi.mocked(readAgentsMd);
+const mockExecSync = vi.mocked(execSync);
 
 describe("parseQaVerdict", () => {
   const verdicts = [
@@ -1011,5 +1021,243 @@ describe("executePhaseWithRetry", () => {
 
     expect(executePhaseFn).toHaveBeenCalledTimes(1);
     expect(result.success).toBe(true);
+  });
+});
+
+describe("hasExecChanges", () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+  });
+
+  function gitDiffExitStatus(status: number): Error {
+    const err = new Error("git diff exited") as Error & { status: number };
+    err.status = status;
+    return err;
+  }
+
+  it("returns true when there are commits ahead of origin/main", () => {
+    // git diff --quiet exits 1 → commits ahead
+    mockExecSync.mockImplementationOnce(() => {
+      throw gitDiffExitStatus(1);
+    });
+    expect(hasExecChanges("/tmp/wt")).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns true when there are uncommitted changes but no commits", () => {
+    // git diff --quiet exits 0 → no commits
+    mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    // git status --porcelain returns dirty output
+    mockExecSync.mockReturnValueOnce(Buffer.from(" M src/foo.ts\n"));
+    expect(hasExecChanges("/tmp/wt")).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns false when there are no commits and no uncommitted work", () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    expect(hasExecChanges("/tmp/wt")).toBe(false);
+  });
+
+  it("fails open (returns true) on git errors (e.g. missing origin)", () => {
+    // git diff --quiet exits 128 → unknown revision
+    mockExecSync.mockImplementationOnce(() => {
+      throw gitDiffExitStatus(128);
+    });
+    expect(hasExecChanges("/tmp/wt")).toBe(true);
+  });
+
+  it("fails open when git status itself throws", () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from(""));
+    mockExecSync.mockImplementationOnce(() => {
+      throw new Error("git status unavailable");
+    });
+    expect(hasExecChanges("/tmp/wt")).toBe(true);
+  });
+});
+
+describe("mapAgentSuccessToPhaseResult", () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+  });
+
+  function makeAgentResult(
+    overrides: Partial<AgentPhaseResult> = {},
+  ): AgentPhaseResult {
+    return {
+      success: true,
+      output: "",
+      ...overrides,
+    };
+  }
+
+  describe("qa phase", () => {
+    it("passes through READY_FOR_MERGE verdict as success", () => {
+      const agentResult = makeAgentResult({
+        output: "### Verdict: READY_FOR_MERGE",
+      });
+      const result = mapAgentSuccessToPhaseResult(
+        "qa",
+        agentResult,
+        60,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(true);
+      expect(result.verdict).toBe("READY_FOR_MERGE");
+      expect(result.error).toBeUndefined();
+    });
+
+    it("passes through NEEDS_VERIFICATION verdict as success", () => {
+      const agentResult = makeAgentResult({
+        output: "### Verdict: NEEDS_VERIFICATION",
+      });
+      const result = mapAgentSuccessToPhaseResult(
+        "qa",
+        agentResult,
+        60,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(true);
+      expect(result.verdict).toBe("NEEDS_VERIFICATION");
+    });
+
+    it("fails on AC_NOT_MET verdict (existing behavior preserved)", () => {
+      const agentResult = makeAgentResult({
+        output: "### Verdict: AC_NOT_MET",
+      });
+      const result = mapAgentSuccessToPhaseResult(
+        "qa",
+        agentResult,
+        60,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("QA verdict: AC_NOT_MET");
+      expect(result.verdict).toBe("AC_NOT_MET");
+    });
+
+    it("fails on AC_MET_BUT_NOT_A_PLUS verdict (existing behavior preserved)", () => {
+      const agentResult = makeAgentResult({
+        output: "### Verdict: AC_MET_BUT_NOT_A_PLUS",
+      });
+      const result = mapAgentSuccessToPhaseResult(
+        "qa",
+        agentResult,
+        60,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("QA verdict: AC_MET_BUT_NOT_A_PLUS");
+    });
+
+    it("fails when output is present but no verdict is parseable (#534)", () => {
+      const agentResult = makeAgentResult({
+        output: "Some review text but no verdict line",
+      });
+      const result = mapAgentSuccessToPhaseResult(
+        "qa",
+        agentResult,
+        60,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("QA completed without a parseable verdict");
+      expect(result.verdict).toBeUndefined();
+    });
+
+    it("fails when output is empty (#534)", () => {
+      const agentResult = makeAgentResult({ output: "" });
+      const result = mapAgentSuccessToPhaseResult(
+        "qa",
+        agentResult,
+        60,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("QA completed without a parseable verdict");
+    });
+
+    it("preserves sessionId and tails on null-verdict failure", () => {
+      const agentResult = makeAgentResult({
+        output: "",
+        sessionId: "sess-123",
+        stderrTail: ["boom"],
+        stdoutTail: ["hello"],
+        exitCode: 0,
+      });
+      const result = mapAgentSuccessToPhaseResult(
+        "qa",
+        agentResult,
+        60,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(false);
+      expect(result.sessionId).toBe("sess-123");
+      expect(result.stderrTail).toEqual(["boom"]);
+      expect(result.stdoutTail).toEqual(["hello"]);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("exec phase", () => {
+    it("passes when exec produced commits", () => {
+      // git diff --quiet exits 1 → commits ahead
+      mockExecSync.mockImplementationOnce(() => {
+        const err = new Error("diff") as Error & { status: number };
+        err.status = 1;
+        throw err;
+      });
+      const result = mapAgentSuccessToPhaseResult(
+        "exec",
+        makeAgentResult({ output: "done" }),
+        120,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("passes when exec left uncommitted work", () => {
+      // git diff --quiet exits 0 → no commits
+      mockExecSync.mockReturnValueOnce(Buffer.from(""));
+      // git status --porcelain shows dirty tree
+      mockExecSync.mockReturnValueOnce(Buffer.from("?? src/new.ts\n"));
+      const result = mapAgentSuccessToPhaseResult(
+        "exec",
+        makeAgentResult({ output: "done" }),
+        120,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("fails when exec produced no commits and no uncommitted work (#534)", () => {
+      mockExecSync.mockReturnValueOnce(Buffer.from(""));
+      mockExecSync.mockReturnValueOnce(Buffer.from(""));
+      const result = mapAgentSuccessToPhaseResult(
+        "exec",
+        makeAgentResult({ output: "done" }),
+        120,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        "exec produced no changes (no commits, no uncommitted work)",
+      );
+    });
+  });
+
+  describe("other phases", () => {
+    it("does not apply guards to non-qa, non-exec phases", () => {
+      // No execSync calls expected
+      const result = mapAgentSuccessToPhaseResult(
+        "spec",
+        makeAgentResult({ output: "plan" }),
+        30,
+        "/tmp/wt",
+      );
+      expect(result.success).toBe(true);
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -16,7 +16,11 @@ import { Phase, ExecutionConfig, PhaseResult, QaVerdict } from "./types.js";
 import type { QaSummary } from "./run-log-schema.js";
 import { readAgentsMd } from "../agents-md.js";
 import { getDriver } from "./drivers/index.js";
-import type { AgentDriver, AgentExecutionConfig } from "./drivers/index.js";
+import type {
+  AgentDriver,
+  AgentExecutionConfig,
+  AgentPhaseResult,
+} from "./drivers/index.js";
 import { classifyError } from "./error-classifier.js";
 import { ApiError } from "../errors.js";
 
@@ -249,6 +253,133 @@ export function formatDuration(seconds: number): string {
 }
 
 /**
+ * Check whether the exec phase produced any changes in the worktree.
+ * Returns true if there are commits ahead of origin/main OR uncommitted work.
+ * Fails open (returns true) on git errors — a missing origin ref is worse
+ * diagnosed as a real zero-diff run than as a false phase failure.
+ *
+ * @internal Exported for testing only.
+ */
+export function hasExecChanges(cwd: string): boolean {
+  // git diff --quiet exits 0 when identical, 1 when differing, other on error.
+  let commitsAhead: boolean;
+  try {
+    execSync("git diff --quiet origin/main..HEAD", { cwd, stdio: "pipe" });
+    commitsAhead = false;
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 1) {
+      commitsAhead = true;
+    } else {
+      return true;
+    }
+  }
+  if (commitsAhead) return true;
+  try {
+    const porcelain = execSync("git status --porcelain", { cwd, stdio: "pipe" })
+      .toString()
+      .trim();
+    return porcelain.length > 0;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Map a successful AgentPhaseResult to a PhaseResult, applying phase-specific
+ * guards that catch agent sessions which returned success without producing
+ * usable work (#534):
+ *
+ * - `qa`: fails when no parseable verdict is found (empty or malformed output).
+ * - `exec`: fails when no commits and no uncommitted changes exist.
+ *
+ * @internal Exported for testing only.
+ */
+export function mapAgentSuccessToPhaseResult(
+  phase: Phase,
+  agentResult: AgentPhaseResult,
+  durationSeconds: number,
+  cwd: string,
+): PhaseResult & { sessionId?: string } {
+  const tails = {
+    stderrTail: agentResult.stderrTail,
+    stdoutTail: agentResult.stdoutTail,
+    exitCode: agentResult.exitCode,
+  };
+
+  if (phase === "qa") {
+    const verdict = agentResult.output
+      ? parseQaVerdict(agentResult.output)
+      : null;
+    const summary = agentResult.output
+      ? (parseQaSummary(agentResult.output) ?? undefined)
+      : undefined;
+    if (
+      verdict &&
+      verdict !== "READY_FOR_MERGE" &&
+      verdict !== "NEEDS_VERIFICATION"
+    ) {
+      return {
+        phase,
+        success: false,
+        durationSeconds,
+        error: `QA verdict: ${verdict}`,
+        sessionId: agentResult.sessionId,
+        output: agentResult.output,
+        verdict,
+        summary,
+        ...tails,
+      };
+    }
+    if (!verdict) {
+      // #534: a null verdict (empty or unparseable output) is not success.
+      return {
+        phase,
+        success: false,
+        durationSeconds,
+        error: "QA completed without a parseable verdict",
+        sessionId: agentResult.sessionId,
+        output: agentResult.output,
+        summary,
+        ...tails,
+      };
+    }
+    return {
+      phase,
+      success: true,
+      durationSeconds,
+      sessionId: agentResult.sessionId,
+      output: agentResult.output,
+      verdict,
+      summary,
+      ...tails,
+    };
+  }
+
+  if (phase === "exec" && !hasExecChanges(cwd)) {
+    // #534: an exec phase that produced nothing is not success.
+    return {
+      phase,
+      success: false,
+      durationSeconds,
+      error: "exec produced no changes (no commits, no uncommitted work)",
+      sessionId: agentResult.sessionId,
+      output: agentResult.output,
+      ...tails,
+    };
+  }
+
+  return {
+    phase,
+    success: true,
+    durationSeconds,
+    sessionId: agentResult.sessionId,
+    output: agentResult.output,
+    ...tails,
+  };
+}
+
+/**
  * Get the prompt for a phase with the issue number substituted.
  * Selects self-contained prompts for non-Claude agents.
  * Includes AGENTS.md content as context so non-Claude agents
@@ -466,56 +597,13 @@ async function executePhase(
 
   const durationSeconds = (Date.now() - startTime) / 1000;
 
-  // Map AgentPhaseResult to PhaseResult
-  const tails = {
-    stderrTail: agentResult.stderrTail,
-    stdoutTail: agentResult.stdoutTail,
-    exitCode: agentResult.exitCode,
-  };
-
   if (agentResult.success) {
-    // For QA phase, check the verdict to determine actual success
-    // Agent "success" just means the execution completed — we need to parse the verdict
-    if (phase === "qa" && agentResult.output) {
-      const verdict = parseQaVerdict(agentResult.output);
-      const summary = parseQaSummary(agentResult.output) ?? undefined;
-      if (
-        verdict &&
-        verdict !== "READY_FOR_MERGE" &&
-        verdict !== "NEEDS_VERIFICATION"
-      ) {
-        return {
-          phase,
-          success: false,
-          durationSeconds,
-          error: `QA verdict: ${verdict}`,
-          sessionId: agentResult.sessionId,
-          output: agentResult.output,
-          verdict,
-          summary,
-          ...tails,
-        };
-      }
-      return {
-        phase,
-        success: true,
-        durationSeconds,
-        sessionId: agentResult.sessionId,
-        output: agentResult.output,
-        verdict: verdict ?? undefined,
-        summary,
-        ...tails,
-      };
-    }
-
-    return {
+    return mapAgentSuccessToPhaseResult(
       phase,
-      success: true,
+      agentResult,
       durationSeconds,
-      sessionId: agentResult.sessionId,
-      output: agentResult.output,
-      ...tails,
-    };
+      cwd,
+    );
   }
 
   return {
@@ -524,7 +612,9 @@ async function executePhase(
     durationSeconds,
     error: agentResult.error,
     sessionId: agentResult.sessionId,
-    ...tails,
+    stderrTail: agentResult.stderrTail,
+    stdoutTail: agentResult.stdoutTail,
+    exitCode: agentResult.exitCode,
   };
 }
 

--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -254,25 +254,32 @@ export function formatDuration(seconds: number): string {
 
 /**
  * Check whether the exec phase produced any changes in the worktree.
- * Returns true if there are commits ahead of origin/main OR uncommitted work.
- * Fails open (returns true) on git errors — a missing origin ref is worse
+ * Returns true if HEAD has commits unique to it relative to origin/main
+ * OR uncommitted work is present.
+ *
+ * Uses `git rev-list --count origin/main..HEAD` (commits reachable from HEAD
+ * but not origin/main) instead of `git diff origin/main..HEAD`, because the
+ * two-dot diff also fires in reverse when origin/main has advanced past HEAD
+ * — on stale branches that would falsely report "has commits" even when the
+ * exec phase produced nothing, reintroducing the bug #534 is fixing.
+ *
+ * Fails open (returns true) on git errors — a missing origin ref is better
  * diagnosed as a real zero-diff run than as a false phase failure.
  *
  * @internal Exported for testing only.
  */
 export function hasExecChanges(cwd: string): boolean {
-  // git diff --quiet exits 0 when identical, 1 when differing, other on error.
   let commitsAhead: boolean;
   try {
-    execSync("git diff --quiet origin/main..HEAD", { cwd, stdio: "pipe" });
-    commitsAhead = false;
-  } catch (err) {
-    const status = (err as { status?: number }).status;
-    if (status === 1) {
-      commitsAhead = true;
-    } else {
-      return true;
-    }
+    const count = execSync("git rev-list --count origin/main..HEAD", {
+      cwd,
+      stdio: "pipe",
+    })
+      .toString()
+      .trim();
+    commitsAhead = Number.parseInt(count, 10) > 0;
+  } catch {
+    return true;
   }
   if (commitsAhead) return true;
   try {


### PR DESCRIPTION
## Summary

- Harden the run orchestrator's post-success mapping so it no longer treats two clear failure modes as success:
  - **QA phase with null/unparseable verdict** → returns `success: false` with `"QA completed without a parseable verdict"` (sessionId and stderr/stdout tails preserved).
  - **Exec phase with zero file changes** → returns `success: false` with `"exec produced no changes (no commits, no uncommitted work)"` after checking `git diff --quiet origin/main..HEAD` AND `git status --porcelain` in the worktree.
- Extract `mapAgentSuccessToPhaseResult` (pure, `@internal`-exported) so the post-success logic is directly unit-testable without the full `executePhase` machinery.
- Add `hasExecChanges(cwd)` helper that fails open on git errors to avoid false phase failures when `origin/main` isn't fetched.

## Test plan

- [x] `npm run build` — tsc clean
- [x] `npm run lint` — 0 warnings
- [x] `npm test src/lib/workflow/phase-executor.test.ts` — 88/88 pass (16 new)
- [x] `npx vitest run src/lib/workflow/` — 713/713 pass across 27 files
- [x] Synthetic reproducer via `tsx -e` confirmed both guards fire against an empty `mktemp` repo and a null-verdict QA result
- [ ] CI passes on push

Closes #534
