### PR TITLE
feat(#529): enforce manual-test AC gate in QA skill

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1830,7 +1830,7 @@ Before finalizing the verdict, check if any ACs require manual (runtime) verific
 ```bash
 # 1. Extract spec plan comment from issue
 spec_comment=$(gh issue view <issue-number> --json comments --jq \
-  '[.comments[].body | select(contains("SEQUANT_PHASE") and contains("spec"))] | last' || true)
+  '[.comments[].body | select(contains("\"phase\":\"spec\""))] | last' || true)
 
 # 2. Detect ACs with manual-test verification methods
 # Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
@@ -1840,7 +1840,7 @@ manual_test_acs=$(echo "$spec_comment" | \
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk '/^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1840,7 +1840,7 @@ manual_test_acs=$(echo "$spec_comment" | \
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk 'BEGIN{IGNORECASE=1} /^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1760,6 +1760,15 @@ Provide an overall verdict:
    - IF .tsx files changed AND /test did NOT run AND no 'no-browser-test' label:
        → Set browser_test_missing = true
 
+3a. Manual test AC enforcement check:
+   - Scan spec plan comment for ACs with **Verification:** Manual Test (or freeform: try X confirm Y, verify by, test that)
+   - For each detected manual-test AC:
+     - IF runtime test was executed → AC status from test result (MET/NOT_MET)
+     - IF approved override documented → AC status = MET
+     - ELSE → AC status = PENDING (this increments pending_count)
+   - NOTE: No new verdict branch needed — PENDING manual-test ACs flow through
+     the existing pending_count > 0 → NEEDS_VERIFICATION path in step 4
+
 4. Determine verdict (in order):
    - IF not_met_count > 0 OR partial_count > 0:
        → AC_NOT_MET (block merge)
@@ -1813,6 +1822,105 @@ fi
 | `.tsx` changed + `no-browser-test` label | Normal verdict (explicit opt-out) |
 | `.tsx` changed + no `/test` + no opt-out | Force `AC_MET_BUT_NOT_A_PLUS` |
 | No `.tsx` changed | Normal verdict |
+
+**Manual Test AC Enforcement:**
+
+Before finalizing the verdict, check if any ACs require manual (runtime) verification that was specified in the `/spec` plan:
+
+```bash
+# 1. Extract spec plan comment from issue
+spec_comment=$(gh issue view <issue-number> --json comments --jq \
+  '[.comments[].body | select(contains("SEQUANT_PHASE") and contains("spec"))] | last' || true)
+
+# 2. Detect ACs with manual-test verification methods
+# Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
+manual_test_acs=$(echo "$spec_comment" | \
+  grep -iE '(\*\*Verification:\*\*\s*Manual Test|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
+
+# 3. Extract AC IDs associated with manual-test lines
+# Scan backwards from each match to find the nearest ### AC-N header
+manual_ac_ids=$(echo "$spec_comment" | \
+  awk '/^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  grep -oE 'AC-[0-9]+' | sort -u || true)
+```
+
+**If manual-test ACs are detected**, include this section in QA output:
+
+```markdown
+### Manual Test ACs Detected
+
+| AC | Verification Method | Runtime Test Status |
+|----|--------------------|--------------------|
+| AC-N | Manual Test | ✅ Executed / ⚠️ PENDING / 🔄 Overridden |
+```
+
+**Enforcement Rules:**
+
+For each detected manual-test AC, QA must do ONE of:
+
+1. **Execute the test** using available tools (chrome-devtools MCP, dev server, CLI invocation) and record pass/fail evidence → mark AC `MET` or `NOT_MET` based on result
+2. **Mark AC `PENDING`** with note: `⚠️ Manual verification required — runtime test not executed` → flows through `pending_count > 0 → NEEDS_VERIFICATION` verdict path
+3. **Override** with approved justification (see Manual Test Override below) → mark AC `MET`
+
+**Key Rule:** A manual-test AC CANNOT be marked `MET` from static code review alone. QA must either execute the runtime test, provide an approved override, or mark `PENDING`.
+
+| Scenario | AC Status | Verdict Impact |
+|----------|-----------|----------------|
+| Runtime test executed and passed | `MET` | Normal verdict |
+| Runtime test executed and failed | `NOT_MET` | → `AC_NOT_MET` |
+| Runtime test not executed, no override | `PENDING` | → `NEEDS_VERIFICATION` |
+| Override with approved justification | `MET` | Normal verdict |
+| Override with unapproved justification | `PENDING` | → `NEEDS_VERIFICATION` |
+
+### Manual Test Override
+
+In some cases, runtime verification can be safely skipped for manual-test ACs when the verification target has no runtime surface or is covered by equivalent automated tests. **Overrides require explicit justification and risk assessment.**
+
+**Override Format (REQUIRED when skipping manual-test execution):**
+
+```markdown
+### Manual Test Override
+
+**AC:** AC-N
+**Requirement:** Runtime verification for manual-test AC
+**Override:** Yes
+**Justification:** [One of the approved categories below]
+**Risk Assessment:** [None/Low]
+```
+
+**Approved Override Categories:**
+
+| Category | Example | Risk |
+|----------|---------|------|
+| No runtime surface | Pure type definitions, config schema validation | None |
+| Equivalent unit test coverage | Automated test covers the exact same code path the manual test would exercise | Low |
+| Tested in sibling issue | Cross-reference to another issue where the same runtime behavior was verified | Low |
+
+**NOT Approved for Override (always require runtime test):**
+
+| Category | Example | Why |
+|----------|---------|-----|
+| Logic changes with UI surface | Modified form validation, new user flows | Runtime behavior may diverge from code review expectations |
+| New user-facing features | Added pages, new interactions | Must verify actual user experience |
+| Integration points | API calls, database writes, auth flows | Runtime dependencies may behave differently |
+| Error handling with user feedback | Toast messages, error pages, redirects | Presentation layer needs runtime check |
+
+**Risk Assessment Definitions:**
+
+| Level | Meaning | Criteria |
+|-------|---------|----------|
+| **None** | Zero runtime impact | Change has no executable runtime surface (types, config) |
+| **Low** | Negligible runtime impact | Automated tests cover the same path; manual test would be redundant |
+| **Medium** | Possible runtime impact | **Should NOT be overridden** — run the manual test |
+
+**Override Decision Flow:**
+
+1. Check if change matches an approved category → If no, runtime test is required
+2. Assess risk level → If Medium or higher, runtime test is required
+3. Document override using the format above in the QA output
+4. Include override in the GitHub issue comment for audit trail
+
+**CRITICAL:** When in doubt, execute the manual test. Overrides are for clear-cut cases only. The motivation for this gate (issue #529) was a real bug that passed QA because `minRows: 1` appeared correct in code review but did not work at runtime.
 
 **CRITICAL:** `PARTIALLY_MET` is NOT sufficient for merge. It MUST be treated as `NOT_MET` for verdict purposes.
 
@@ -2094,6 +2202,7 @@ When the size gate determined `SMALL_DIFF=true`, use the **simplified output tem
 - [ ] **Skill Command Verification** - Included if `.claude/skills/**/*.md` modified (or marked N/A)
 - [ ] **Skill Change Review** - Skill-specific verification prompts included if skills changed
 - [ ] **Smoke Test** - Included if workflow-affecting changes (skills, scripts, CLI), or marked "Not Required"
+- [ ] **Manual Test AC Enforcement** - Included if spec plan has Manual Test ACs (or marked N/A if no manual-test ACs detected)
 - [ ] **CHANGELOG Verification** - User-facing changes have `[Unreleased]` entry (or marked N/A)
 - [ ] **Documentation Check** - README/docs updated if feature adds new functionality
 - [ ] **Next Steps** - Clear, actionable recommendations
@@ -2466,6 +2575,20 @@ You MUST include these sections:
 | Error handling | `[command]` | ✅/❌ | [observation] |
 
 **Smoke Test Status:** Complete / Partial (document gaps) / Not Required
+
+---
+
+### Manual Test ACs
+
+[Include if spec plan has ACs with **Verification:** Manual Test, otherwise: "N/A - No manual-test ACs detected"]
+
+| AC | Verification Method | Runtime Test Status | Evidence |
+|----|--------------------|--------------------|----------|
+| AC-N | Manual Test | ✅ Executed / ⚠️ PENDING / 🔄 Overridden | [result or override justification] |
+
+**Manual Test Enforcement:** X/Y manual-test ACs verified at runtime
+
+[If any overrides applied, include Manual Test Override block per Section 7]
 
 ---
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1833,14 +1833,14 @@ spec_comment=$(gh issue view <issue-number> --json comments --jq \
   '[.comments[].body | select(contains("\"phase\":\"spec\""))] | last' || true)
 
 # 2. Detect ACs with manual-test verification methods
-# Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
+# Matches: "**Verification:** Manual Test", "**Verify:** ...", "try X, confirm Y", "verify by", "test that"
 manual_test_acs=$(echo "$spec_comment" | \
-  grep -iE '(\*\*Verification:\*\*\s*Manual Test|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
+  grep -iE '(\*\*Verification:\*\*\s*Manual Test|\*\*Verify:\*\*\s*|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
 
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|\*\*Verify:\*\*|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Manual Test AC enforcement gate** — `/qa` now detects ACs with `**Verification:** Manual Test` (and freeform patterns like `try X, confirm Y`) from `/spec` comments and requires runtime execution or an approved override before marking them `MET`. Unexecuted manual-test ACs are marked `PENDING`, forcing `NEEDS_VERIFICATION` verdict. Override mechanism mirrors Section 11a with approved categories: `no runtime surface`, `equivalent unit test coverage`, `tested in sibling issue` (#529)
 - **Experimental multi-issue TUI dashboard** — `sequant run --experimental-tui` renders a live, ink-based dashboard with one box per issue (header / context / activity cells), rotating border colors, per-phase progression row, and a 1 Hz elapsed timer. Auto-falls back to the existing linear output when stdout is not a TTY (#540)
   - New `RunOrchestrator.getSnapshot()` exposes a point-in-time view of the run for read-only consumers
   - `nowLine` in this milestone is phase-coarse (e.g. `running exec`); per-file activity is deferred to a follow-up

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -1830,7 +1830,7 @@ Before finalizing the verdict, check if any ACs require manual (runtime) verific
 ```bash
 # 1. Extract spec plan comment from issue
 spec_comment=$(gh issue view <issue-number> --json comments --jq \
-  '[.comments[].body | select(contains("SEQUANT_PHASE") and contains("spec"))] | last' || true)
+  '[.comments[].body | select(contains("\"phase\":\"spec\""))] | last' || true)
 
 # 2. Detect ACs with manual-test verification methods
 # Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
@@ -1840,7 +1840,7 @@ manual_test_acs=$(echo "$spec_comment" | \
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk '/^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -1840,7 +1840,7 @@ manual_test_acs=$(echo "$spec_comment" | \
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk 'BEGIN{IGNORECASE=1} /^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -1760,6 +1760,15 @@ Provide an overall verdict:
    - IF .tsx files changed AND /test did NOT run AND no 'no-browser-test' label:
        → Set browser_test_missing = true
 
+3a. Manual test AC enforcement check:
+   - Scan spec plan comment for ACs with **Verification:** Manual Test (or freeform: try X confirm Y, verify by, test that)
+   - For each detected manual-test AC:
+     - IF runtime test was executed → AC status from test result (MET/NOT_MET)
+     - IF approved override documented → AC status = MET
+     - ELSE → AC status = PENDING (this increments pending_count)
+   - NOTE: No new verdict branch needed — PENDING manual-test ACs flow through
+     the existing pending_count > 0 → NEEDS_VERIFICATION path in step 4
+
 4. Determine verdict (in order):
    - IF not_met_count > 0 OR partial_count > 0:
        → AC_NOT_MET (block merge)
@@ -1813,6 +1822,105 @@ fi
 | `.tsx` changed + `no-browser-test` label | Normal verdict (explicit opt-out) |
 | `.tsx` changed + no `/test` + no opt-out | Force `AC_MET_BUT_NOT_A_PLUS` |
 | No `.tsx` changed | Normal verdict |
+
+**Manual Test AC Enforcement:**
+
+Before finalizing the verdict, check if any ACs require manual (runtime) verification that was specified in the `/spec` plan:
+
+```bash
+# 1. Extract spec plan comment from issue
+spec_comment=$(gh issue view <issue-number> --json comments --jq \
+  '[.comments[].body | select(contains("SEQUANT_PHASE") and contains("spec"))] | last' || true)
+
+# 2. Detect ACs with manual-test verification methods
+# Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
+manual_test_acs=$(echo "$spec_comment" | \
+  grep -iE '(\*\*Verification:\*\*\s*Manual Test|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
+
+# 3. Extract AC IDs associated with manual-test lines
+# Scan backwards from each match to find the nearest ### AC-N header
+manual_ac_ids=$(echo "$spec_comment" | \
+  awk '/^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  grep -oE 'AC-[0-9]+' | sort -u || true)
+```
+
+**If manual-test ACs are detected**, include this section in QA output:
+
+```markdown
+### Manual Test ACs Detected
+
+| AC | Verification Method | Runtime Test Status |
+|----|--------------------|--------------------|
+| AC-N | Manual Test | ✅ Executed / ⚠️ PENDING / 🔄 Overridden |
+```
+
+**Enforcement Rules:**
+
+For each detected manual-test AC, QA must do ONE of:
+
+1. **Execute the test** using available tools (chrome-devtools MCP, dev server, CLI invocation) and record pass/fail evidence → mark AC `MET` or `NOT_MET` based on result
+2. **Mark AC `PENDING`** with note: `⚠️ Manual verification required — runtime test not executed` → flows through `pending_count > 0 → NEEDS_VERIFICATION` verdict path
+3. **Override** with approved justification (see Manual Test Override below) → mark AC `MET`
+
+**Key Rule:** A manual-test AC CANNOT be marked `MET` from static code review alone. QA must either execute the runtime test, provide an approved override, or mark `PENDING`.
+
+| Scenario | AC Status | Verdict Impact |
+|----------|-----------|----------------|
+| Runtime test executed and passed | `MET` | Normal verdict |
+| Runtime test executed and failed | `NOT_MET` | → `AC_NOT_MET` |
+| Runtime test not executed, no override | `PENDING` | → `NEEDS_VERIFICATION` |
+| Override with approved justification | `MET` | Normal verdict |
+| Override with unapproved justification | `PENDING` | → `NEEDS_VERIFICATION` |
+
+### Manual Test Override
+
+In some cases, runtime verification can be safely skipped for manual-test ACs when the verification target has no runtime surface or is covered by equivalent automated tests. **Overrides require explicit justification and risk assessment.**
+
+**Override Format (REQUIRED when skipping manual-test execution):**
+
+```markdown
+### Manual Test Override
+
+**AC:** AC-N
+**Requirement:** Runtime verification for manual-test AC
+**Override:** Yes
+**Justification:** [One of the approved categories below]
+**Risk Assessment:** [None/Low]
+```
+
+**Approved Override Categories:**
+
+| Category | Example | Risk |
+|----------|---------|------|
+| No runtime surface | Pure type definitions, config schema validation | None |
+| Equivalent unit test coverage | Automated test covers the exact same code path the manual test would exercise | Low |
+| Tested in sibling issue | Cross-reference to another issue where the same runtime behavior was verified | Low |
+
+**NOT Approved for Override (always require runtime test):**
+
+| Category | Example | Why |
+|----------|---------|-----|
+| Logic changes with UI surface | Modified form validation, new user flows | Runtime behavior may diverge from code review expectations |
+| New user-facing features | Added pages, new interactions | Must verify actual user experience |
+| Integration points | API calls, database writes, auth flows | Runtime dependencies may behave differently |
+| Error handling with user feedback | Toast messages, error pages, redirects | Presentation layer needs runtime check |
+
+**Risk Assessment Definitions:**
+
+| Level | Meaning | Criteria |
+|-------|---------|----------|
+| **None** | Zero runtime impact | Change has no executable runtime surface (types, config) |
+| **Low** | Negligible runtime impact | Automated tests cover the same path; manual test would be redundant |
+| **Medium** | Possible runtime impact | **Should NOT be overridden** — run the manual test |
+
+**Override Decision Flow:**
+
+1. Check if change matches an approved category → If no, runtime test is required
+2. Assess risk level → If Medium or higher, runtime test is required
+3. Document override using the format above in the QA output
+4. Include override in the GitHub issue comment for audit trail
+
+**CRITICAL:** When in doubt, execute the manual test. Overrides are for clear-cut cases only. The motivation for this gate (issue #529) was a real bug that passed QA because `minRows: 1` appeared correct in code review but did not work at runtime.
 
 **CRITICAL:** `PARTIALLY_MET` is NOT sufficient for merge. It MUST be treated as `NOT_MET` for verdict purposes.
 
@@ -2094,6 +2202,7 @@ When the size gate determined `SMALL_DIFF=true`, use the **simplified output tem
 - [ ] **Skill Command Verification** - Included if `.claude/skills/**/*.md` modified (or marked N/A)
 - [ ] **Skill Change Review** - Skill-specific verification prompts included if skills changed
 - [ ] **Smoke Test** - Included if workflow-affecting changes (skills, scripts, CLI), or marked "Not Required"
+- [ ] **Manual Test AC Enforcement** - Included if spec plan has Manual Test ACs (or marked N/A if no manual-test ACs detected)
 - [ ] **CHANGELOG Verification** - User-facing changes have `[Unreleased]` entry (or marked N/A)
 - [ ] **Documentation Check** - README/docs updated if feature adds new functionality
 - [ ] **Next Steps** - Clear, actionable recommendations
@@ -2466,6 +2575,20 @@ You MUST include these sections:
 | Error handling | `[command]` | ✅/❌ | [observation] |
 
 **Smoke Test Status:** Complete / Partial (document gaps) / Not Required
+
+---
+
+### Manual Test ACs
+
+[Include if spec plan has ACs with **Verification:** Manual Test, otherwise: "N/A - No manual-test ACs detected"]
+
+| AC | Verification Method | Runtime Test Status | Evidence |
+|----|--------------------|--------------------|----------|
+| AC-N | Manual Test | ✅ Executed / ⚠️ PENDING / 🔄 Overridden | [result or override justification] |
+
+**Manual Test Enforcement:** X/Y manual-test ACs verified at runtime
+
+[If any overrides applied, include Manual Test Override block per Section 7]
 
 ---
 

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -1833,14 +1833,14 @@ spec_comment=$(gh issue view <issue-number> --json comments --jq \
   '[.comments[].body | select(contains("\"phase\":\"spec\""))] | last' || true)
 
 # 2. Detect ACs with manual-test verification methods
-# Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
+# Matches: "**Verification:** Manual Test", "**Verify:** ...", "try X, confirm Y", "verify by", "test that"
 manual_test_acs=$(echo "$spec_comment" | \
-  grep -iE '(\*\*Verification:\*\*\s*Manual Test|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
+  grep -iE '(\*\*Verification:\*\*\s*Manual Test|\*\*Verify:\*\*\s*|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
 
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|\*\*Verify:\*\*|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -1830,7 +1830,7 @@ Before finalizing the verdict, check if any ACs require manual (runtime) verific
 ```bash
 # 1. Extract spec plan comment from issue
 spec_comment=$(gh issue view <issue-number> --json comments --jq \
-  '[.comments[].body | select(contains("SEQUANT_PHASE") and contains("spec"))] | last' || true)
+  '[.comments[].body | select(contains("\"phase\":\"spec\""))] | last' || true)
 
 # 2. Detect ACs with manual-test verification methods
 # Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
@@ -1840,7 +1840,7 @@ manual_test_acs=$(echo "$spec_comment" | \
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk '/^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -1840,7 +1840,7 @@ manual_test_acs=$(echo "$spec_comment" | \
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk 'BEGIN{IGNORECASE=1} /^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -1760,6 +1760,15 @@ Provide an overall verdict:
    - IF .tsx files changed AND /test did NOT run AND no 'no-browser-test' label:
        → Set browser_test_missing = true
 
+3a. Manual test AC enforcement check:
+   - Scan spec plan comment for ACs with **Verification:** Manual Test (or freeform: try X confirm Y, verify by, test that)
+   - For each detected manual-test AC:
+     - IF runtime test was executed → AC status from test result (MET/NOT_MET)
+     - IF approved override documented → AC status = MET
+     - ELSE → AC status = PENDING (this increments pending_count)
+   - NOTE: No new verdict branch needed — PENDING manual-test ACs flow through
+     the existing pending_count > 0 → NEEDS_VERIFICATION path in step 4
+
 4. Determine verdict (in order):
    - IF not_met_count > 0 OR partial_count > 0:
        → AC_NOT_MET (block merge)
@@ -1813,6 +1822,105 @@ fi
 | `.tsx` changed + `no-browser-test` label | Normal verdict (explicit opt-out) |
 | `.tsx` changed + no `/test` + no opt-out | Force `AC_MET_BUT_NOT_A_PLUS` |
 | No `.tsx` changed | Normal verdict |
+
+**Manual Test AC Enforcement:**
+
+Before finalizing the verdict, check if any ACs require manual (runtime) verification that was specified in the `/spec` plan:
+
+```bash
+# 1. Extract spec plan comment from issue
+spec_comment=$(gh issue view <issue-number> --json comments --jq \
+  '[.comments[].body | select(contains("SEQUANT_PHASE") and contains("spec"))] | last' || true)
+
+# 2. Detect ACs with manual-test verification methods
+# Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
+manual_test_acs=$(echo "$spec_comment" | \
+  grep -iE '(\*\*Verification:\*\*\s*Manual Test|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
+
+# 3. Extract AC IDs associated with manual-test lines
+# Scan backwards from each match to find the nearest ### AC-N header
+manual_ac_ids=$(echo "$spec_comment" | \
+  awk '/^### AC-[0-9]+/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  grep -oE 'AC-[0-9]+' | sort -u || true)
+```
+
+**If manual-test ACs are detected**, include this section in QA output:
+
+```markdown
+### Manual Test ACs Detected
+
+| AC | Verification Method | Runtime Test Status |
+|----|--------------------|--------------------|
+| AC-N | Manual Test | ✅ Executed / ⚠️ PENDING / 🔄 Overridden |
+```
+
+**Enforcement Rules:**
+
+For each detected manual-test AC, QA must do ONE of:
+
+1. **Execute the test** using available tools (chrome-devtools MCP, dev server, CLI invocation) and record pass/fail evidence → mark AC `MET` or `NOT_MET` based on result
+2. **Mark AC `PENDING`** with note: `⚠️ Manual verification required — runtime test not executed` → flows through `pending_count > 0 → NEEDS_VERIFICATION` verdict path
+3. **Override** with approved justification (see Manual Test Override below) → mark AC `MET`
+
+**Key Rule:** A manual-test AC CANNOT be marked `MET` from static code review alone. QA must either execute the runtime test, provide an approved override, or mark `PENDING`.
+
+| Scenario | AC Status | Verdict Impact |
+|----------|-----------|----------------|
+| Runtime test executed and passed | `MET` | Normal verdict |
+| Runtime test executed and failed | `NOT_MET` | → `AC_NOT_MET` |
+| Runtime test not executed, no override | `PENDING` | → `NEEDS_VERIFICATION` |
+| Override with approved justification | `MET` | Normal verdict |
+| Override with unapproved justification | `PENDING` | → `NEEDS_VERIFICATION` |
+
+### Manual Test Override
+
+In some cases, runtime verification can be safely skipped for manual-test ACs when the verification target has no runtime surface or is covered by equivalent automated tests. **Overrides require explicit justification and risk assessment.**
+
+**Override Format (REQUIRED when skipping manual-test execution):**
+
+```markdown
+### Manual Test Override
+
+**AC:** AC-N
+**Requirement:** Runtime verification for manual-test AC
+**Override:** Yes
+**Justification:** [One of the approved categories below]
+**Risk Assessment:** [None/Low]
+```
+
+**Approved Override Categories:**
+
+| Category | Example | Risk |
+|----------|---------|------|
+| No runtime surface | Pure type definitions, config schema validation | None |
+| Equivalent unit test coverage | Automated test covers the exact same code path the manual test would exercise | Low |
+| Tested in sibling issue | Cross-reference to another issue where the same runtime behavior was verified | Low |
+
+**NOT Approved for Override (always require runtime test):**
+
+| Category | Example | Why |
+|----------|---------|-----|
+| Logic changes with UI surface | Modified form validation, new user flows | Runtime behavior may diverge from code review expectations |
+| New user-facing features | Added pages, new interactions | Must verify actual user experience |
+| Integration points | API calls, database writes, auth flows | Runtime dependencies may behave differently |
+| Error handling with user feedback | Toast messages, error pages, redirects | Presentation layer needs runtime check |
+
+**Risk Assessment Definitions:**
+
+| Level | Meaning | Criteria |
+|-------|---------|----------|
+| **None** | Zero runtime impact | Change has no executable runtime surface (types, config) |
+| **Low** | Negligible runtime impact | Automated tests cover the same path; manual test would be redundant |
+| **Medium** | Possible runtime impact | **Should NOT be overridden** — run the manual test |
+
+**Override Decision Flow:**
+
+1. Check if change matches an approved category → If no, runtime test is required
+2. Assess risk level → If Medium or higher, runtime test is required
+3. Document override using the format above in the QA output
+4. Include override in the GitHub issue comment for audit trail
+
+**CRITICAL:** When in doubt, execute the manual test. Overrides are for clear-cut cases only. The motivation for this gate (issue #529) was a real bug that passed QA because `minRows: 1` appeared correct in code review but did not work at runtime.
 
 **CRITICAL:** `PARTIALLY_MET` is NOT sufficient for merge. It MUST be treated as `NOT_MET` for verdict purposes.
 
@@ -2094,6 +2202,7 @@ When the size gate determined `SMALL_DIFF=true`, use the **simplified output tem
 - [ ] **Skill Command Verification** - Included if `.claude/skills/**/*.md` modified (or marked N/A)
 - [ ] **Skill Change Review** - Skill-specific verification prompts included if skills changed
 - [ ] **Smoke Test** - Included if workflow-affecting changes (skills, scripts, CLI), or marked "Not Required"
+- [ ] **Manual Test AC Enforcement** - Included if spec plan has Manual Test ACs (or marked N/A if no manual-test ACs detected)
 - [ ] **CHANGELOG Verification** - User-facing changes have `[Unreleased]` entry (or marked N/A)
 - [ ] **Documentation Check** - README/docs updated if feature adds new functionality
 - [ ] **Next Steps** - Clear, actionable recommendations
@@ -2466,6 +2575,20 @@ You MUST include these sections:
 | Error handling | `[command]` | ✅/❌ | [observation] |
 
 **Smoke Test Status:** Complete / Partial (document gaps) / Not Required
+
+---
+
+### Manual Test ACs
+
+[Include if spec plan has ACs with **Verification:** Manual Test, otherwise: "N/A - No manual-test ACs detected"]
+
+| AC | Verification Method | Runtime Test Status | Evidence |
+|----|--------------------|--------------------|----------|
+| AC-N | Manual Test | ✅ Executed / ⚠️ PENDING / 🔄 Overridden | [result or override justification] |
+
+**Manual Test Enforcement:** X/Y manual-test ACs verified at runtime
+
+[If any overrides applied, include Manual Test Override block per Section 7]
 
 ---
 

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -1833,14 +1833,14 @@ spec_comment=$(gh issue view <issue-number> --json comments --jq \
   '[.comments[].body | select(contains("\"phase\":\"spec\""))] | last' || true)
 
 # 2. Detect ACs with manual-test verification methods
-# Matches: "**Verification:** Manual Test", "try X, confirm Y", "verify by", "test that"
+# Matches: "**Verification:** Manual Test", "**Verify:** ...", "try X, confirm Y", "verify by", "test that"
 manual_test_acs=$(echo "$spec_comment" | \
-  grep -iE '(\*\*Verification:\*\*\s*Manual Test|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
+  grep -iE '(\*\*Verification:\*\*\s*Manual Test|\*\*Verify:\*\*\s*|try .*, confirm|verify by|test that|verify:?\s*manual)' || true)
 
 # 3. Extract AC IDs associated with manual-test lines
 # Scan backwards from each match to find the nearest ### AC-N header
 manual_ac_ids=$(echo "$spec_comment" | \
-  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|try .*, confirm|verify by|test that/{print ac}' | \
+  awk 'BEGIN{IGNORECASE=1} /^(#+ AC-[0-9]+|\*\*AC-[0-9]+)/{ac=$0} /Manual Test|\*\*Verify:\*\*|try .*, confirm|verify by|test that/{print ac}' | \
   grep -oE 'AC-[0-9]+' | sort -u || true)
 ```
 


### PR DESCRIPTION
## Summary

- Adds a **Manual Test AC Enforcement** gate to the QA skill that detects ACs with `**Verification:** Manual Test` (and freeform patterns like `try X, confirm Y`) from `/spec` comments
- Requires QA to either execute runtime tests, provide an approved override, or mark ACs `PENDING` (forcing `NEEDS_VERIFICATION` verdict)
- Override mechanism mirrors Section 11a with 3 approved categories: `no runtime surface`, `equivalent unit test coverage`, `tested in sibling issue`

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | QA scans spec comments for verification keywords | ✅ Implemented | SKILL.md:1826-1846 — detection logic with grep patterns |
| AC-2 | QA executes or marks PENDING for each manual-test AC | ✅ Implemented | SKILL.md:1856-1870 — enforcement rules with 3 options |
| AC-3 | PENDING forces NEEDS_VERIFICATION verdict | ✅ Implemented | SKILL.md:1763-1772 — step 3a wires into existing pending_count path |
| AC-4 | Override mechanism mirroring Section 11a | ✅ Implemented | SKILL.md:1875-1925 — full override with approved/not-approved categories |
| AC-5 | Update SKILL.md across all 3 directories | ✅ Implemented | diff confirms identical content in .claude/skills/, skills/, templates/skills/ |
| AC-6 | Update CHANGELOG.md under [Unreleased] | ✅ Implemented | CHANGELOG.md — entry under Added section |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npm test` passes (2673 tests, 114 test files)
- [x] All 3 SKILL.md copies verified identical via `diff`

Closes #529