### PR TITLE
feat(#533): default /assess spec phase ON, remove bug/docs auto-skip

### DIFF
--- a/.claude/skills/assess/SKILL.md
+++ b/.claude/skills/assess/SKILL.md
@@ -117,14 +117,14 @@ Surface red flags. Only track signals that change the recommendation.
 | complex, refactor, breaking, major | Modifier | `spec → exec → qa` + `-q` |
 | (ui/frontend) + (enhancement/feature), or testable-AC signals | Modifier | inserts `testgen` before `exec` (see Testgen detection below) |
 | enhancement, feature (default) | Generic | `spec → exec → qa` |
-| bug, fix, hotfix, patch | Generic | `exec → qa` |
-| docs, documentation, readme | Generic | `exec → qa` |
+| bug, fix, hotfix, patch | Generic | `spec → exec → qa` |
+| docs, documentation, readme | Generic | `spec → exec → qa` |
 
-**Label priority:** Domain labels take precedence over generic labels. When an issue has both a domain label and a generic label (e.g., `bug` + `auth`), use the domain-specific workflow. Example: an issue labeled `bug` + `auth` gets `spec → security-review → exec → qa`, not `exec → qa`. Similarly, `bug` + `ui` gets `spec → exec → test → qa`.
+**Label priority:** Domain labels take precedence over generic labels. When an issue has both a domain label and a generic label (e.g., `bug` + `auth`), the domain label adds its extra phase. Example: an issue labeled `bug` + `auth` gets `spec → security-review → exec → qa` (adds `security-review` from `auth`); `bug` + `ui` gets `spec → exec → test → qa` (adds `test` from `ui`).
 
 **Valid phases (from `PhaseSchema` in `src/lib/workflow/types.ts`):** `spec`, `security-review`, `exec`, `testgen`, `test`, `verify`, `qa`, `loop`, `merger`
 
-**Skip spec when:** (bug/docs label AND no domain labels like security/auth/ui/frontend), OR spec comment already exists on issue.
+**Skip spec when:** a prior `spec` phase marker already exists on the issue. Otherwise, always include spec — bug and docs issues often contain design decisions (scope boundaries, edge cases, test-strategy shifts) that benefit from a spec pass.
 
 **Resume detection:** Branch exists with commits ahead of main → mark as resume (`◂`).
 
@@ -208,7 +208,7 @@ Cleanup:
 | Symbol | Meaning | Example |
 |--------|---------|---------|
 | `spec → exec → qa` | Full workflow | Standard feature |
-| `exec → qa` | Skip spec | Bug, docs, or spec exists |
+| `exec → qa` | Skip spec | Prior spec marker exists |
 | `◂ exec → qa` | Resume existing work | Branch has commits |
 | `◂ qa` | PR needs review/QA | Open PR, impl done |
 | `⟳ spec → exec → qa` | Restart (fresh) | Stale PR abandoned |
@@ -265,18 +265,17 @@ Not all issues have explicit `- [ ]` checkboxes, so the `ACs` column is omitted.
 ```
  #    Action     Reason                              Run
  462  PARK       Manual measurement task              ‖
- 461  PROCEED    Exact label matching                  exec → qa
- 460  PROCEED    batch-executor tests                  exec → qa
+ 461  PROCEED    Exact label matching                  spec → exec → qa
+ 460  PROCEED    batch-executor tests                  spec → exec → qa
  458  PROCEED    Parallel UX + race condition          spec → exec → qa
  447  CLOSE      PR #457 merged                        —
  443  PROCEED    Consolidate gh calls                  spec → exec → qa
- 412  PROCEED    Auth bug (domain: auth overrides bug) spec → security-review → exec → qa
+ 412  PROCEED    Auth bug (domain: auth adds review)   spec → security-review → exec → qa
  411  PROCEED    Config path normalization              ◂ exec → qa
  405  REWRITE    PR #380 200+ commits behind           ⟳ spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 461 460 -q --phases exec,qa
-  npx sequant run 458 443 -q
+  npx sequant run 461 460 458 443 -q
   npx sequant run 412 -q --phases spec,security-review,exec,qa
   npx sequant run 411 -q --phases exec,qa     # resume
   npx sequant run 405 -q                      # restart
@@ -285,11 +284,12 @@ Order: 460 → 461 (460 adds batch-executor tests that 461's label matching depe
 
 ⚠ #458  Dual concern (UX + race) across 4 files
 ⚠ #405  Stale 30+ days, ACs still valid
-⚠ #412  bug + auth labels — domain label (auth) takes priority over bug
+⚠ #412  bug + auth labels — auth (domain) adds security-review phase
 
 Flags:
-  -q                   multi-file scope across most PROCEED issues
-  --phases spec,...    spec phase added for 458/443/412/405 (standard features)
+  -q                              multi-file scope across most PROCEED issues
+  --phases ...,security-review    #412 auth label → security review required
+  --phases exec,qa                #411 resume — prior spec marker already exists
 ────────────────────────────────────────────────────────────────
 Cleanup:
   git worktree remove .../447-...      # merged, stale worktree
@@ -298,8 +298,8 @@ Cleanup:
 ────────────────────────────────────────────────────────────────
 
 <!-- #462 assess:action=PARK -->
-<!-- #461 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #460 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #461 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #460 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #458 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #447 assess:action=CLOSE -->
 <!-- #443 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
@@ -344,17 +344,16 @@ When every issue is PROCEED with no warnings, no dependencies, and no non-defaul
 
 ```
  #    Action     Reason                              Run
- 461  PROCEED    Exact label matching                  exec → qa
- 460  PROCEED    batch-executor tests                  exec → qa
+ 461  PROCEED    Exact label matching                  spec → exec → qa
+ 460  PROCEED    batch-executor tests                  spec → exec → qa
  443  PROCEED    Consolidate gh calls                  spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 461 460 -q --phases exec,qa
-  npx sequant run 443 -q
+  npx sequant run 461 460 443 -q
 ────────────────────────────────────────────────────────────────
 
-<!-- #461 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #460 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #461 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #460 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #443 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 ```
 
@@ -366,31 +365,30 @@ When assessing 9+ issues, commands are split per Rule 7 (max 6 issue numbers per
 
 ```
  #    Action     Reason                                   Run
- 503  PROCEED    Fix typo in error output                   exec → qa
- 502  PROCEED    Update deprecated API call                 exec → qa
- 501  PROCEED    Add retry logic to API client              exec → qa
+ 503  PROCEED    Fix typo in error output                   spec → exec → qa
+ 502  PROCEED    Update deprecated API call                 spec → exec → qa
+ 501  PROCEED    Add retry logic to API client              spec → exec → qa
  500  PROCEED    Fix token refresh race condition           spec → security-review → exec → qa
  499  PROCEED    Dashboard chart rendering bug              spec → exec → test → qa
- 498  PROCEED    Update error messages                      exec → qa
+ 498  PROCEED    Update error messages                      spec → exec → qa
  497  PROCEED    Refactor batch executor                    spec → exec → qa
  496  PARK       Blocked on #490 schema migration           ‖
- 495  PROCEED    CLI help text improvements                 exec → qa
- 494  PROCEED    Assess batch formatting fix                exec → qa
+ 495  PROCEED    CLI help text improvements                 spec → exec → qa
+ 494  PROCEED    Assess batch formatting fix                spec → exec → qa
  493  CLOSE      Duplicate of #491                          —
  492  PROCEED    Add export command                         spec → exec → qa
- 491  PROCEED    Normalize config paths                     exec → qa
+ 491  PROCEED    Normalize config paths                     spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 503 502 501 498 495 494 -q --phases exec,qa
-  npx sequant run 491 -q --phases exec,qa
+  npx sequant run 503 502 501 498 497 495 -q
+  npx sequant run 494 492 491 -q
   npx sequant run 499 -q --phases spec,exec,test,qa
   npx sequant run 500 -q --phases spec,security-review,exec,qa
-  npx sequant run 497 492 -q
 ────────────────────────────────────────────────────────────────
 Order: 497 → 492 (497 refactors batch-executor internals that 492's export command uses)
 
-⚠ #500  bug + auth labels — domain label takes priority
-⚠ #499  bug + ui labels — domain label triggers test phase
+⚠ #500  bug + auth labels — auth (domain) adds security-review phase
+⚠ #499  bug + ui labels — ui (domain) adds test phase
 
 Flags:
   --phases ...,security-review   #500 auth label → security review required
@@ -400,19 +398,19 @@ Cleanup:
   gh issue close 493                   # duplicate of #491
 ────────────────────────────────────────────────────────────────
 
-<!-- #503 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #502 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #501 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #503 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #502 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #501 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #500 assess:action=PROCEED assess:phases=spec,security-review,exec,qa assess:quality-loop=true -->
 <!-- #499 assess:action=PROCEED assess:phases=spec,exec,test,qa assess:quality-loop=true -->
-<!-- #498 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #498 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #497 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #496 assess:action=PARK -->
-<!-- #495 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #494 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #495 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #494 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #493 assess:action=CLOSE -->
 <!-- #492 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
-<!-- #491 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #491 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 ```
 
 ---

--- a/.claude/skills/spec/references/recommended-workflow.md
+++ b/.claude/skills/spec/references/recommended-workflow.md
@@ -14,15 +14,17 @@ This document shows the expected output format for the `## Recommended Workflow`
 
 ## Examples
 
-### Simple Bug Fix
+### Simple Bug Fix (spec confirms straightforward scope)
 
 ```markdown
 ## Recommended Workflow
 
 **Phases:** exec → qa
 **Quality Loop:** disabled
-**Reasoning:** Straightforward bug fix with clear root cause. No planning needed.
+**Reasoning:** This spec pass confirmed a clear root cause and narrow scope — no testgen or additional phases required; proceed to exec.
 ```
+
+*Note:* Since #533, spec always runs by default. `**Phases:**` lists phases **after** spec — use `exec → qa` here to indicate "spec is done; only exec and qa remain."
 
 ### Standard Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`/assess` default: spec phase ON for all workflows** — the "skip spec when (bug/docs label AND no domain labels)" rule has been removed. Spec is now always included unless a prior `spec` phase marker already exists on the issue. Real-world batches showed that bug and docs issues frequently contain design decisions (scope boundaries, edge cases, test-strategy shifts) that benefit from a spec pass, and post-#515 the per-phase cost is small enough to justify universal inclusion. The Labels → Workflow table, Run Column Symbols, and all batch/single examples have been updated to reflect the new default. (#533)
+
 ### Added
 
 - **Experimental multi-issue TUI dashboard** — `sequant run --experimental-tui` renders a live, ink-based dashboard with one box per issue (header / context / activity cells), rotating border colors, per-phase progression row, and a 1 Hz elapsed timer. Auto-falls back to the existing linear output when stdout is not a TTY (#540)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **`/assess` default: spec phase ON for all workflows** — the "skip spec when (bug/docs label AND no domain labels)" rule has been removed. Spec is now always included unless a prior `spec` phase marker already exists on the issue. Real-world batches showed that bug and docs issues frequently contain design decisions (scope boundaries, edge cases, test-strategy shifts) that benefit from a spec pass, and post-#515 the per-phase cost is small enough to justify universal inclusion. The Labels → Workflow table, Run Column Symbols, and all batch/single examples have been updated to reflect the new default. (#533)
-
 ### Added
 
 - **Experimental multi-issue TUI dashboard** — `sequant run --experimental-tui` renders a live, ink-based dashboard with one box per issue (header / context / activity cells), rotating border colors, per-phase progression row, and a 1 Hz elapsed timer. Auto-falls back to the existing linear output when stdout is not a TTY (#540)
   - New `RunOrchestrator.getSnapshot()` exposes a point-in-time view of the run for read-only consumers
   - `nowLine` in this milestone is phase-coarse (e.g. `running exec`); per-file activity is deferred to a follow-up
 - **QA short-circuit on unchanged commit** — `/qa` now skips the full sub-agent pipeline when the latest `qa:completed` phase marker's `commitSHA` matches current `HEAD`. Bypass with `/qa <N> --force` or `/qa <N> --no-cache`. Failed prior runs (status=`failed`) never short-circuit. New `status:"completed"` markers include a `verdict` field so the short-circuit summary surfaces the prior verdict; legacy markers without the field fall back to `(see prior QA comment)`. Marker detection streams comment bodies via `.comments[].body` (raw) rather than `[.comments[].body]` (JSON-escaped) so the grep pattern actually matches. (#530)
+
+### Changed
+
+- **Default workflow: spec phase ON for bug/docs issues** — the "skip spec when (bug/docs label AND no domain labels)" shortcut has been removed at both the skill-recommendation layer (`/assess`) and the runtime auto-detection layer (`phase-mapper.detectPhasesFromLabels`, `batch-executor` auto-detect). Bug- and docs-labeled issues now run `spec → exec → qa` by default under `sequant run --auto-detect`. Spec is only skipped when a prior `spec` phase marker already exists on the issue. Real-world batches showed that bug and docs issues frequently contain design decisions (scope boundaries, edge cases, test-strategy shifts) that benefit from a spec pass, and post-#515 the per-phase cost is small enough to justify universal inclusion. Docs-labeled issues still propagate `issueType: "docs"` through post-spec phases for downstream skills (e.g. lighter `/qa` pipeline). Override with explicit `--phases exec,qa`. (#533)
 
 ## [2.2.0] - 2026-04-18
 

--- a/docs/concepts/workflow-phases.md
+++ b/docs/concepts/workflow-phases.md
@@ -246,8 +246,8 @@ When using `sequant run`, phases are detected automatically:
 
 | Labels | Phases | Why |
 |--------|--------|-----|
-| `bug`, `fix`, `hotfix` | exec → qa | Simple fixes skip spec and testgen |
-| `docs`, `documentation` | exec → qa | Docs changes skip spec and testgen |
+| `bug`, `fix`, `hotfix` | spec → exec → qa | Spec catches scope/design decisions in fixes (#533) |
+| `docs`, `documentation` | spec → exec → qa | Spec catches scope/design decisions in docs work (#533) |
 | `enhancement`, `feature` | spec → testgen → exec → qa | New features need test stubs |
 | `ui`, `frontend`, `admin` | spec → testgen → exec → test → qa | UI with testable ACs |
 | `complex`, `refactor` | spec → testgen → exec → qa + quality loop | Complex changes need tests and iteration |

--- a/docs/features/docs-pipeline.md
+++ b/docs/features/docs-pipeline.md
@@ -1,6 +1,6 @@
-# Lighter Documentation Pipeline
+# Lighter QA Pipeline for Documentation Issues
 
-When a GitHub issue has documentation labels (`docs`, `documentation`, or `readme`), Sequant automatically uses a lighter workflow pipeline optimized for docs-only work.
+When a GitHub issue has documentation labels (`docs`, `documentation`, or `readme`), Sequant automatically uses a lighter QA pipeline optimized for content changes. The full workflow still includes spec — see [#533](https://github.com/sequant-io/sequant/issues/533) for the rationale on universal spec inclusion.
 
 ## Prerequisites
 
@@ -9,15 +9,15 @@ When a GitHub issue has documentation labels (`docs`, `documentation`, or `readm
 
 ## What Changes
 
-Documentation issues get a streamlined two-phase pipeline instead of the standard three-phase pipeline:
+Documentation issues use the same three-phase workflow as other issues, but the QA phase is lighter:
 
-| Issue Type | Pipeline | Phases |
+| Issue Type | Workflow | Phases |
 |------------|----------|--------|
 | Standard | spec → exec → qa | 3 phases |
-| Bug fix | exec → qa | 2 phases (skips spec) |
-| **Documentation** | **exec → qa** | **2 phases (skips spec)** |
+| Bug fix | spec → exec → qa | 3 phases (since #533) |
+| **Documentation** | **spec → exec → qa** | **3 phases (with lighter QA, see below)** |
 
-Additionally, the QA phase adapts when running on docs issues:
+The QA phase adapts when running on docs issues:
 
 | QA Behavior | Standard Issues | Docs Issues |
 |-------------|-----------------|-------------|
@@ -28,7 +28,7 @@ Additionally, the QA phase adapts when running on docs issues:
 
 ## Setup
 
-No configuration needed. The lighter pipeline activates automatically when `autoDetectPhases` is enabled (the default).
+No configuration needed. The lighter QA pipeline activates automatically when `autoDetectPhases` is enabled (the default).
 
 To verify auto-detection is on:
 
@@ -39,40 +39,33 @@ cat .sequant/settings.json | grep autoDetectPhases
 
 ## What You Can Do
 
-### Run a documentation issue through the lighter pipeline
+### Run a documentation issue
 
 ```bash
 sequant run 123
 ```
 
 If issue `#123` has a `docs`, `documentation`, or `readme` label, Sequant will:
-1. Skip the spec phase entirely
+
+1. Run spec to plan the change (since #533, spec always runs)
 2. Run exec (implementation)
-3. Run QA with a single sub-agent focused on scope/size and link validation
+3. Run QA with a single sub-agent focused on scope/size and link validation (lighter than the full 3-agent QA)
 
-### Verify detection is working
+### Verify lighter QA is active
 
-Look for this log line during execution:
-
-```
-Docs issue detected: exec → qa
-```
-
-If you see `Running spec to determine workflow...` instead, the issue labels may not include a docs label.
+The orchestrator passes `SEQUANT_ISSUE_TYPE=docs` to the QA skill when a docs label is present. The `/qa` skill reads this and uses the docs-lighter pipeline (1 sub-agent instead of 3).
 
 ## What to Expect
 
-- **Faster runs:** ~30-50% faster due to skipping spec and running fewer QA sub-agents
-- **Same exec behavior:** The implementation phase runs identically
-- **Lighter QA:** Focuses on content accuracy, completeness, formatting, and link validity instead of type safety and security scanning
-- **No spec output:** Since spec is skipped, there's no spec plan comment on the issue
+- **Same spec behavior:** Spec runs to plan the change, just like any other issue. This catches scope/design decisions in docs work that would otherwise slip through.
+- **Same exec behavior:** The implementation phase runs identically.
+- **Lighter QA:** Focuses on content accuracy, completeness, formatting, and link validity instead of type safety and security scanning.
 
 ## How It Works
 
-1. **Label detection:** Sequant checks issue labels against `docs`, `documentation`, `readme` (case-insensitive)
-2. **Phase shortcut:** If matched, phases are set to `["exec", "qa"]` — same pattern as bug fixes
-3. **Metadata propagation:** `SEQUANT_ISSUE_TYPE=docs` environment variable is passed to skills
-4. **QA adaptation:** The QA skill reads the env var and uses a single sub-agent instead of three
+1. **Label detection:** Sequant checks issue labels exactly against `docs`, `documentation`, `readme` (case-insensitive equality, see [exact label matching](./exact-label-matching.md)).
+2. **issueType propagation:** If matched, `SEQUANT_ISSUE_TYPE=docs` environment variable is passed to post-spec phases via `issueConfig`.
+3. **QA adaptation:** The QA skill reads the env var and uses a single sub-agent instead of three.
 
 ## Recognized Labels
 
@@ -83,27 +76,26 @@ If you see `Running spec to determine workflow...` instead, the issue labels may
 | `readme` | Documentation |
 | `DOCS` (any case) | Documentation |
 
-Labels are matched case-insensitively via substring. A label like `docs-update` would also trigger the lighter pipeline.
+Labels are matched by exact equality (case-insensitive). A label like `docs-update` would **not** trigger the lighter QA pipeline — see [exact label matching](./exact-label-matching.md) for the rationale.
 
 ## Troubleshooting
 
-### Issue runs full pipeline despite having a docs label
-
-**Symptoms:** Log shows `Running spec to determine workflow...` instead of `Docs issue detected`
-
-**Solution:** Verify `autoDetectPhases` is enabled in `.sequant/settings.json`. If set to `false`, explicit phases override label detection:
-
-```bash
-jq '.run.autoDetectPhases' .sequant/settings.json
-# Should output: true
-```
-
 ### QA still runs 3 sub-agents on a docs issue
 
-**Symptoms:** QA spawns type-safety, security, and scope agents
+**Symptoms:** QA spawns type-safety, security, and scope agents.
 
 **Solution:** This happens when running QA standalone (not via `sequant run`). The `SEQUANT_ISSUE_TYPE` env var is only set when the orchestrator manages the pipeline. Standalone `/qa` runs use the full pipeline by default.
 
+### Spec runs even though I want to skip it for a small docs change
+
+This is intentional behavior since #533 — spec always runs by default because docs issues frequently contain design decisions worth a spec pass. To bypass for a specific run:
+
+```bash
+sequant run 123 --phases exec,qa
+```
+
+This explicit override skips auto-detection entirely.
+
 ---
 
-*Generated for Issue #451 on 2026-03-26*
+*Originally generated for Issue #451 on 2026-03-26; updated for #533 on 2026-04-24.*

--- a/docs/features/exact-label-matching.md
+++ b/docs/features/exact-label-matching.md
@@ -6,14 +6,14 @@
 
 Previously, phase detection used `label.includes(targetLabel)` to check GitHub issue labels against known label sets. This caused substring collisions where unrelated labels could trigger incorrect workflows:
 
-| Label on Issue | Would Match | Triggered Pipeline | Correct? |
-|----------------|-------------|-------------------|----------|
-| `docstring`    | `docs`      | Docs (skip spec)  | No       |
-| `debugging`    | `bug`       | Bug fix (skip spec)| No       |
-| `patchwork`    | `patch`     | Bug fix (skip spec)| No       |
-| `webinar`      | `web`       | UI (add test phase)| No       |
-| `complexity`   | `complex`   | Quality loop       | No       |
-| `insecurity`   | `security`  | Security review    | No       |
+| Label on Issue | Would Match | Triggered Pipeline         | Correct? |
+|----------------|-------------|----------------------------|----------|
+| `docstring`    | `docs`      | Docs pipeline              | No       |
+| `debugging`    | `bug`       | Bug fix pipeline           | No       |
+| `patchwork`    | `patch`     | Bug fix pipeline           | No       |
+| `webinar`      | `web`       | UI (add test phase)        | No       |
+| `complexity`   | `complex`   | Quality loop               | No       |
+| `insecurity`   | `security`  | Security review            | No       |
 
 Now all label checks use exact equality (`===`), so only labels that exactly match a known value will trigger their associated pipeline.
 
@@ -23,8 +23,8 @@ All label arrays in the phase mapper use exact matching:
 
 | Label Set | Recognized Labels | Effect |
 |-----------|------------------|--------|
-| `BUG_LABELS` | `bug`, `fix`, `hotfix`, `patch` | Skip spec phase |
-| `DOCS_LABELS` | `docs`, `documentation`, `readme` | Skip spec phase |
+| `BUG_LABELS` | `bug`, `fix`, `hotfix`, `patch` | Downstream metadata only (since #533 these no longer skip spec) |
+| `DOCS_LABELS` | `docs`, `documentation`, `readme` | Propagate `issueType: "docs"` to post-spec phases (since #533 these no longer skip spec) |
 | `UI_LABELS` | `ui`, `frontend`, `admin`, `web`, `browser` | Add test phase |
 | `COMPLEX_LABELS` | `complex`, `refactor`, `breaking`, `major` | Enable quality loop |
 | `SECURITY_LABELS` | `security`, `auth`, `authentication`, `permissions`, `admin` | Add security-review phase |

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -117,14 +117,14 @@ Surface red flags. Only track signals that change the recommendation.
 | complex, refactor, breaking, major | Modifier | `spec → exec → qa` + `-q` |
 | (ui/frontend) + (enhancement/feature), or testable-AC signals | Modifier | inserts `testgen` before `exec` (see Testgen detection below) |
 | enhancement, feature (default) | Generic | `spec → exec → qa` |
-| bug, fix, hotfix, patch | Generic | `exec → qa` |
-| docs, documentation, readme | Generic | `exec → qa` |
+| bug, fix, hotfix, patch | Generic | `spec → exec → qa` |
+| docs, documentation, readme | Generic | `spec → exec → qa` |
 
-**Label priority:** Domain labels take precedence over generic labels. When an issue has both a domain label and a generic label (e.g., `bug` + `auth`), use the domain-specific workflow. Example: an issue labeled `bug` + `auth` gets `spec → security-review → exec → qa`, not `exec → qa`. Similarly, `bug` + `ui` gets `spec → exec → test → qa`.
+**Label priority:** Domain labels take precedence over generic labels. When an issue has both a domain label and a generic label (e.g., `bug` + `auth`), the domain label adds its extra phase. Example: an issue labeled `bug` + `auth` gets `spec → security-review → exec → qa` (adds `security-review` from `auth`); `bug` + `ui` gets `spec → exec → test → qa` (adds `test` from `ui`).
 
 **Valid phases (from `PhaseSchema` in `src/lib/workflow/types.ts`):** `spec`, `security-review`, `exec`, `testgen`, `test`, `verify`, `qa`, `loop`, `merger`
 
-**Skip spec when:** (bug/docs label AND no domain labels like security/auth/ui/frontend), OR spec comment already exists on issue.
+**Skip spec when:** a prior `spec` phase marker already exists on the issue. Otherwise, always include spec — bug and docs issues often contain design decisions (scope boundaries, edge cases, test-strategy shifts) that benefit from a spec pass.
 
 **Resume detection:** Branch exists with commits ahead of main → mark as resume (`◂`).
 
@@ -208,7 +208,7 @@ Cleanup:
 | Symbol | Meaning | Example |
 |--------|---------|---------|
 | `spec → exec → qa` | Full workflow | Standard feature |
-| `exec → qa` | Skip spec | Bug, docs, or spec exists |
+| `exec → qa` | Skip spec | Prior spec marker exists |
 | `◂ exec → qa` | Resume existing work | Branch has commits |
 | `◂ qa` | PR needs review/QA | Open PR, impl done |
 | `⟳ spec → exec → qa` | Restart (fresh) | Stale PR abandoned |
@@ -265,18 +265,17 @@ Not all issues have explicit `- [ ]` checkboxes, so the `ACs` column is omitted.
 ```
  #    Action     Reason                              Run
  462  PARK       Manual measurement task              ‖
- 461  PROCEED    Exact label matching                  exec → qa
- 460  PROCEED    batch-executor tests                  exec → qa
+ 461  PROCEED    Exact label matching                  spec → exec → qa
+ 460  PROCEED    batch-executor tests                  spec → exec → qa
  458  PROCEED    Parallel UX + race condition          spec → exec → qa
  447  CLOSE      PR #457 merged                        —
  443  PROCEED    Consolidate gh calls                  spec → exec → qa
- 412  PROCEED    Auth bug (domain: auth overrides bug) spec → security-review → exec → qa
+ 412  PROCEED    Auth bug (domain: auth adds review)   spec → security-review → exec → qa
  411  PROCEED    Config path normalization              ◂ exec → qa
  405  REWRITE    PR #380 200+ commits behind           ⟳ spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 461 460 -q --phases exec,qa
-  npx sequant run 458 443 -q
+  npx sequant run 461 460 458 443 -q
   npx sequant run 412 -q --phases spec,security-review,exec,qa
   npx sequant run 411 -q --phases exec,qa     # resume
   npx sequant run 405 -q                      # restart
@@ -285,11 +284,12 @@ Order: 460 → 461 (460 adds batch-executor tests that 461's label matching depe
 
 ⚠ #458  Dual concern (UX + race) across 4 files
 ⚠ #405  Stale 30+ days, ACs still valid
-⚠ #412  bug + auth labels — domain label (auth) takes priority over bug
+⚠ #412  bug + auth labels — auth (domain) adds security-review phase
 
 Flags:
-  -q                   multi-file scope across most PROCEED issues
-  --phases spec,...    spec phase added for 458/443/412/405 (standard features)
+  -q                              multi-file scope across most PROCEED issues
+  --phases ...,security-review    #412 auth label → security review required
+  --phases exec,qa                #411 resume — prior spec marker already exists
 ────────────────────────────────────────────────────────────────
 Cleanup:
   git worktree remove .../447-...      # merged, stale worktree
@@ -298,8 +298,8 @@ Cleanup:
 ────────────────────────────────────────────────────────────────
 
 <!-- #462 assess:action=PARK -->
-<!-- #461 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #460 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #461 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #460 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #458 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #447 assess:action=CLOSE -->
 <!-- #443 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
@@ -344,17 +344,16 @@ When every issue is PROCEED with no warnings, no dependencies, and no non-defaul
 
 ```
  #    Action     Reason                              Run
- 461  PROCEED    Exact label matching                  exec → qa
- 460  PROCEED    batch-executor tests                  exec → qa
+ 461  PROCEED    Exact label matching                  spec → exec → qa
+ 460  PROCEED    batch-executor tests                  spec → exec → qa
  443  PROCEED    Consolidate gh calls                  spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 461 460 -q --phases exec,qa
-  npx sequant run 443 -q
+  npx sequant run 461 460 443 -q
 ────────────────────────────────────────────────────────────────
 
-<!-- #461 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #460 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #461 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #460 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #443 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 ```
 
@@ -366,31 +365,30 @@ When assessing 9+ issues, commands are split per Rule 7 (max 6 issue numbers per
 
 ```
  #    Action     Reason                                   Run
- 503  PROCEED    Fix typo in error output                   exec → qa
- 502  PROCEED    Update deprecated API call                 exec → qa
- 501  PROCEED    Add retry logic to API client              exec → qa
+ 503  PROCEED    Fix typo in error output                   spec → exec → qa
+ 502  PROCEED    Update deprecated API call                 spec → exec → qa
+ 501  PROCEED    Add retry logic to API client              spec → exec → qa
  500  PROCEED    Fix token refresh race condition           spec → security-review → exec → qa
  499  PROCEED    Dashboard chart rendering bug              spec → exec → test → qa
- 498  PROCEED    Update error messages                      exec → qa
+ 498  PROCEED    Update error messages                      spec → exec → qa
  497  PROCEED    Refactor batch executor                    spec → exec → qa
  496  PARK       Blocked on #490 schema migration           ‖
- 495  PROCEED    CLI help text improvements                 exec → qa
- 494  PROCEED    Assess batch formatting fix                exec → qa
+ 495  PROCEED    CLI help text improvements                 spec → exec → qa
+ 494  PROCEED    Assess batch formatting fix                spec → exec → qa
  493  CLOSE      Duplicate of #491                          —
  492  PROCEED    Add export command                         spec → exec → qa
- 491  PROCEED    Normalize config paths                     exec → qa
+ 491  PROCEED    Normalize config paths                     spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 503 502 501 498 495 494 -q --phases exec,qa
-  npx sequant run 491 -q --phases exec,qa
+  npx sequant run 503 502 501 498 497 495 -q
+  npx sequant run 494 492 491 -q
   npx sequant run 499 -q --phases spec,exec,test,qa
   npx sequant run 500 -q --phases spec,security-review,exec,qa
-  npx sequant run 497 492 -q
 ────────────────────────────────────────────────────────────────
 Order: 497 → 492 (497 refactors batch-executor internals that 492's export command uses)
 
-⚠ #500  bug + auth labels — domain label takes priority
-⚠ #499  bug + ui labels — domain label triggers test phase
+⚠ #500  bug + auth labels — auth (domain) adds security-review phase
+⚠ #499  bug + ui labels — ui (domain) adds test phase
 
 Flags:
   --phases ...,security-review   #500 auth label → security review required
@@ -400,19 +398,19 @@ Cleanup:
   gh issue close 493                   # duplicate of #491
 ────────────────────────────────────────────────────────────────
 
-<!-- #503 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #502 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #501 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #503 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #502 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #501 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #500 assess:action=PROCEED assess:phases=spec,security-review,exec,qa assess:quality-loop=true -->
 <!-- #499 assess:action=PROCEED assess:phases=spec,exec,test,qa assess:quality-loop=true -->
-<!-- #498 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #498 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #497 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #496 assess:action=PARK -->
-<!-- #495 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #494 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #495 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #494 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #493 assess:action=CLOSE -->
 <!-- #492 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
-<!-- #491 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #491 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 ```
 
 ---

--- a/skills/spec/references/recommended-workflow.md
+++ b/skills/spec/references/recommended-workflow.md
@@ -14,15 +14,17 @@ This document shows the expected output format for the `## Recommended Workflow`
 
 ## Examples
 
-### Simple Bug Fix
+### Simple Bug Fix (spec confirms straightforward scope)
 
 ```markdown
 ## Recommended Workflow
 
 **Phases:** exec → qa
 **Quality Loop:** disabled
-**Reasoning:** Straightforward bug fix with clear root cause. No planning needed.
+**Reasoning:** This spec pass confirmed a clear root cause and narrow scope — no testgen or additional phases required; proceed to exec.
 ```
+
+*Note:* Since #533, spec always runs by default. `**Phases:**` lists phases **after** spec — use `exec → qa` here to indicate "spec is done; only exec and qa remain."
 
 ### Standard Feature
 

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -389,9 +389,9 @@ describe("detectPhasesFromLabels", () => {
     expect(result.qualityLoop).toBe(false);
   });
 
-  it("should detect bug labels and skip spec", () => {
+  it("should detect bug labels and include spec by default (#533)", () => {
     const result = detectPhasesFromLabels(["bug"]);
-    expect(result.phases).toEqual(["exec", "qa"]);
+    expect(result.phases).toEqual(["spec", "exec", "qa"]);
   });
 
   it("should detect UI labels and add test phase", () => {
@@ -423,10 +423,10 @@ describe("detectPhasesFromLabels", () => {
     }
   });
 
-  it("should not add security-review when spec is skipped (bug fix)", () => {
+  it("should add security-review when bug+security present (spec now runs, #533)", () => {
+    // #533: bug no longer skips spec, so security-review is inserted after spec
     const result = detectPhasesFromLabels(["bug", "security"]);
-    expect(result.phases).not.toContain("security-review");
-    expect(result.phases).toEqual(["exec", "qa"]);
+    expect(result.phases).toEqual(["spec", "security-review", "exec", "qa"]);
   });
 
   it("should combine UI and security labels correctly", () => {

--- a/src/lib/workflow/batch-executor.test.ts
+++ b/src/lib/workflow/batch-executor.test.ts
@@ -130,8 +130,13 @@ beforeEach(() => {
 });
 
 describe("runIssueWithLogging — label-based phase shortcuts", () => {
-  describe("AC-1: isSimpleBugFix shortcut", () => {
-    it("skips spec for 'bug' label → phases are [exec, qa]", async () => {
+  // #533: bug/docs labels no longer short-circuit spec. Under autoDetectPhases
+  // mode, spec runs first, then the remaining phases come from the spec
+  // recommendation (or, if unparseable, from detectPhasesFromLabels with spec
+  // filtered out). With the default mock returning successResult("exec") and
+  // no parseable workflow, bug/docs issues produce the full [spec, exec, qa].
+  describe("#533: bug labels include spec by default", () => {
+    it("runs spec → exec → qa for 'bug' label", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 42,
@@ -140,12 +145,11 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         }),
       );
 
-      // executePhaseWithRetry should be called for exec and qa (no spec)
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("skips spec for 'fix' label", async () => {
+    it("runs spec → exec → qa for 'fix' label", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 43,
@@ -155,10 +159,10 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("skips spec for 'hotfix' label", async () => {
+    it("runs spec → exec → qa for 'hotfix' label", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 44,
@@ -168,10 +172,10 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("skips spec for 'patch' label", async () => {
+    it("runs spec → exec → qa for 'patch' label", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 45,
@@ -181,12 +185,12 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
   });
 
-  describe("AC-1: isDocs shortcut", () => {
-    it("skips spec for 'docs' label → phases are [exec, qa]", async () => {
+  describe("#533: docs labels include spec by default", () => {
+    it("runs spec → exec → qa for 'docs' label", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 50,
@@ -196,10 +200,10 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("skips spec for 'documentation' label", async () => {
+    it("runs spec → exec → qa for 'documentation' label", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 51,
@@ -209,10 +213,10 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("skips spec for 'readme' label", async () => {
+    it("runs spec → exec → qa for 'readme' label", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 52,
@@ -222,11 +226,19 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
   });
 
   describe("AC-2: issueConfig.issueType set to 'docs' for docs labels", () => {
+    // #533: Spec now runs for docs-labeled issues under autoDetectPhases.
+    // Spec is executed before issueConfig is built, so the spec call receives
+    // the base config without issueType. issueType is propagated to exec/qa
+    // calls (and any other post-spec phases) via issueConfig. The assertions
+    // filter out the spec call to verify issueType propagation downstream.
+    const nonSpec = (calls: typeof mockExecutePhase.mock.calls) =>
+      calls.filter((c) => c[1] !== "spec");
+
     it("passes issueType 'docs' to executePhaseWithRetry when docs label present", async () => {
       await runIssueWithLogging(
         makeCtx({
@@ -236,8 +248,9 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         }),
       );
 
-      // The 3rd argument to executePhaseWithRetry is the config
-      for (const call of mockExecutePhase.mock.calls) {
+      const postSpecCalls = nonSpec(mockExecutePhase.mock.calls);
+      expect(postSpecCalls.length).toBeGreaterThan(0);
+      for (const call of postSpecCalls) {
         const passedConfig = call[2] as ExecutionConfig;
         expect(passedConfig.issueType).toBe("docs");
       }
@@ -252,7 +265,9 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         }),
       );
 
-      for (const call of mockExecutePhase.mock.calls) {
+      const postSpecCalls = nonSpec(mockExecutePhase.mock.calls);
+      expect(postSpecCalls.length).toBeGreaterThan(0);
+      for (const call of postSpecCalls) {
         const passedConfig = call[2] as ExecutionConfig;
         expect(passedConfig.issueType).toBe("docs");
       }
@@ -267,7 +282,9 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         }),
       );
 
-      for (const call of mockExecutePhase.mock.calls) {
+      const postSpecCalls = nonSpec(mockExecutePhase.mock.calls);
+      expect(postSpecCalls.length).toBeGreaterThan(0);
+      for (const call of postSpecCalls) {
         const passedConfig = call[2] as ExecutionConfig;
         expect(passedConfig.issueType).toBe("docs");
       }
@@ -326,8 +343,11 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
     });
   });
 
-  describe("AC-4: bug labels take precedence over docs labels in phase selection", () => {
-    it("uses bug shortcut phases when both bug and docs labels present", async () => {
+  describe("AC-4: bug + docs combined labels (#533: no phase-selection precedence)", () => {
+    // #533 removed the bug/docs phase shortcuts, so neither label wins a
+    // phase-selection "precedence" — both now produce the default workflow.
+    // issueType propagation still fires for any label in DOCS_LABELS.
+    it("runs spec → exec → qa when both bug and docs labels present", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 80,
@@ -336,12 +356,11 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         }),
       );
 
-      // Bug shortcut fires first (if/else chain), so phases = [exec, qa]
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("still sets issueType to 'docs' even when bug shortcut fires", async () => {
+    it("still sets issueType to 'docs' on post-spec calls when docs label is present", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 81,
@@ -350,8 +369,13 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
         }),
       );
 
-      // issueConfig is built independently, so docs label still sets issueType
-      for (const call of mockExecutePhase.mock.calls) {
+      // issueConfig is built after spec runs; it still propagates issueType
+      // to exec/qa when a docs label is present.
+      const postSpecCalls = mockExecutePhase.mock.calls.filter(
+        (c) => c[1] !== "spec",
+      );
+      expect(postSpecCalls.length).toBeGreaterThan(0);
+      for (const call of postSpecCalls) {
         const passedConfig = call[2] as ExecutionConfig;
         expect(passedConfig.issueType).toBe("docs");
       }
@@ -359,7 +383,7 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
   });
 
   describe("AC-5 (derived): case-insensitive label matching", () => {
-    it("detects uppercase 'BUG' label as bug shortcut", async () => {
+    it("detects uppercase 'BUG' label (still runs spec → exec → qa under #533)", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 90,
@@ -369,10 +393,10 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("detects uppercase 'DOCS' label and sets issueType", async () => {
+    it("detects uppercase 'DOCS' label and sets issueType on post-spec calls", async () => {
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 91,
@@ -382,9 +406,12 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
 
-      for (const call of mockExecutePhase.mock.calls) {
+      const postSpecCalls = mockExecutePhase.mock.calls.filter(
+        (c) => c[1] !== "spec",
+      );
+      for (const call of postSpecCalls) {
         const passedConfig = call[2] as ExecutionConfig;
         expect(passedConfig.issueType).toBe("docs");
       }
@@ -400,7 +427,7 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
       );
 
       const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
-      expect(calledPhases).toEqual(["exec", "qa"]);
+      expect(calledPhases).toEqual(["spec", "exec", "qa"]);
     });
   });
 
@@ -435,10 +462,11 @@ describe("runIssueWithLogging — label-based phase shortcuts", () => {
     });
   });
 
-  describe("AC-6 (derived): autoDetectPhases = false skips label shortcuts", () => {
+  describe("AC-6 (derived): autoDetectPhases = false bypasses label-based auto-detection", () => {
     it("uses explicit phases when autoDetectPhases is false", async () => {
-      // Use ["qa"] only — bug shortcut would produce ["exec", "qa"],
-      // so this distinguishes explicit phases from shortcut
+      // Use ["qa"] only — auto-detection would produce ["spec", "exec", "qa"]
+      // for a bug-labeled issue, so this distinguishes explicit-phase mode
+      // from auto-detect mode (#533).
       await runIssueWithLogging(
         makeCtx({
           issueNumber: 100,

--- a/src/lib/workflow/batch-executor.ts
+++ b/src/lib/workflow/batch-executor.ts
@@ -36,7 +36,6 @@ import {
   detectPhasesFromLabels,
   parseRecommendedWorkflow,
   determinePhasesForIssue,
-  BUG_LABELS,
   DOCS_LABELS,
 } from "./phase-mapper.js";
 
@@ -437,204 +436,178 @@ export async function runIssueWithLogging(
   let specAlreadyRan = false;
 
   if (options.autoDetectPhases) {
-    // Check if labels indicate a simple bug/fix (skip spec entirely)
-    const lowerLabels = labels.map((l) => l.toLowerCase());
-    const isSimpleBugFix = lowerLabels.some((label) =>
-      BUG_LABELS.some((bugLabel) => label === bugLabel),
-    );
+    // #533: Always run spec to get recommended workflow.
+    // The prior bug/docs shortcut (skip spec → exec → qa) was removed because
+    // bug and docs issues often contain design decisions (scope boundaries,
+    // edge cases, test-strategy shifts) that benefit from a spec pass.
+    log(chalk.gray(`    Running spec to determine workflow...`));
 
-    // Check if labels indicate documentation-only work (skip spec)
-    const isDocs = lowerLabels.some((label) =>
-      DOCS_LABELS.some((docsLabel) => label === docsLabel),
-    );
+    // Create spinner for spec phase (suppressed in parallel mode to prevent interleaving)
+    const specSpinner = config.parallel
+      ? undefined
+      : new PhaseSpinner({
+          phase: "spec",
+          phaseIndex: 1,
+          totalPhases: 3, // Estimate; will be refined after spec
+          shutdownManager,
+        });
+    specSpinner?.start();
+    emitProgressLine(issueNumber, "spec", "start");
+    try {
+      onProgress?.(issueNumber, "spec", "start");
+    } catch {
+      /* progress errors must not halt */
+    }
 
-    if (isSimpleBugFix) {
-      // Simple bug fix: skip spec, go straight to exec → qa
-      phases = ["exec", "qa"];
-      log(chalk.gray(`    Bug fix detected: ${phases.join(" → ")}`));
-    } else if (isDocs) {
-      // Documentation issue: skip spec, lighter pipeline
-      phases = ["exec", "qa"];
-      log(chalk.gray(`    Docs issue detected: ${phases.join(" → ")}`));
-    } else {
-      // Run spec first to get recommended workflow
-      log(chalk.gray(`    Running spec to determine workflow...`));
-
-      // Create spinner for spec phase (suppressed in parallel mode to prevent interleaving)
-      const specSpinner = config.parallel
-        ? undefined
-        : new PhaseSpinner({
-            phase: "spec",
-            phaseIndex: 1,
-            totalPhases: 3, // Estimate; will be refined after spec
-            shutdownManager,
-          });
-      specSpinner?.start();
-      emitProgressLine(issueNumber, "spec", "start");
+    // Track spec phase start in state
+    if (stateManager) {
       try {
-        onProgress?.(issueNumber, "spec", "start");
+        await stateManager.updatePhaseStatus(
+          issueNumber,
+          "spec",
+          "in_progress",
+        );
+      } catch {
+        // State tracking errors shouldn't stop execution
+      }
+    }
+
+    const specStartTime = new Date();
+    // Note: spec runs in main repo (not worktree) for planning
+    const specResult = await executePhaseWithRetry(
+      issueNumber,
+      "spec",
+      config,
+      sessionId,
+      worktreePath, // Will be ignored for spec (non-isolated phase)
+      shutdownManager,
+      specSpinner,
+    );
+    const specEndTime = new Date();
+
+    if (specResult.sessionId) {
+      sessionId = specResult.sessionId;
+      // Update session ID in state for resume capability
+      if (stateManager) {
+        try {
+          await stateManager.updateSessionId(issueNumber, specResult.sessionId);
+        } catch {
+          // State tracking errors shouldn't stop execution
+        }
+      }
+    }
+
+    phaseResults.push(specResult);
+    specAlreadyRan = true;
+
+    // Emit completion/failure progress event (AC-8)
+    const specDurationSec = Math.round(
+      (specEndTime.getTime() - specStartTime.getTime()) / 1000,
+    );
+    if (specResult.success) {
+      const extra = { durationSeconds: specDurationSec };
+      emitProgressLine(issueNumber, "spec", "complete", extra);
+      try {
+        onProgress?.(issueNumber, "spec", "complete", extra);
       } catch {
         /* progress errors must not halt */
       }
-
-      // Track spec phase start in state
-      if (stateManager) {
-        try {
-          await stateManager.updatePhaseStatus(
-            issueNumber,
-            "spec",
-            "in_progress",
-          );
-        } catch {
-          // State tracking errors shouldn't stop execution
-        }
+    } else {
+      const extra = { error: specResult.error ?? "unknown" };
+      emitProgressLine(issueNumber, "spec", "failed", extra);
+      try {
+        onProgress?.(issueNumber, "spec", "failed", extra);
+      } catch {
+        /* progress errors must not halt */
       }
+    }
 
-      const specStartTime = new Date();
-      // Note: spec runs in main repo (not worktree) for planning
-      const specResult = await executePhaseWithRetry(
-        issueNumber,
-        "spec",
-        config,
-        sessionId,
-        worktreePath, // Will be ignored for spec (non-isolated phase)
-        shutdownManager,
-        specSpinner,
-      );
-      const specEndTime = new Date();
-
-      if (specResult.sessionId) {
-        sessionId = specResult.sessionId;
-        // Update session ID in state for resume capability
-        if (stateManager) {
-          try {
-            await stateManager.updateSessionId(
-              issueNumber,
-              specResult.sessionId,
-            );
-          } catch {
-            // State tracking errors shouldn't stop execution
-          }
-        }
-      }
-
-      phaseResults.push(specResult);
-      specAlreadyRan = true;
-
-      // Emit completion/failure progress event (AC-8)
-      const specDurationSec = Math.round(
-        (specEndTime.getTime() - specStartTime.getTime()) / 1000,
-      );
-      if (specResult.success) {
-        const extra = { durationSeconds: specDurationSec };
-        emitProgressLine(issueNumber, "spec", "complete", extra);
-        try {
-          onProgress?.(issueNumber, "spec", "complete", extra);
-        } catch {
-          /* progress errors must not halt */
-        }
-      } else {
-        const extra = { error: specResult.error ?? "unknown" };
-        emitProgressLine(issueNumber, "spec", "failed", extra);
-        try {
-          onProgress?.(issueNumber, "spec", "failed", extra);
-        } catch {
-          /* progress errors must not halt */
-        }
-      }
-
-      // Log spec phase result
-      // Note: Spec runs in main repo, not worktree, so no git diff stats
-      if (logWriter) {
-        // Build errorContext from captured stderr/stdout tails (#447)
-        let specErrorContext: ErrorContext | undefined;
-        if (!specResult.success && specResult.stderrTail) {
-          const specError = classifyError(
-            specResult.stderrTail ?? [],
-            specResult.exitCode,
-          );
-          specErrorContext = {
-            stderrTail: specResult.stderrTail ?? [],
-            stdoutTail: specResult.stdoutTail ?? [],
-            exitCode: specResult.exitCode,
-            category: errorTypeToCategory(specError),
-            errorType: specError.name,
-            errorMetadata: specError.metadata,
-            isRetryable: specError.isRetryable,
-          };
-        }
-        const phaseLog = createPhaseLogFromTiming(
-          "spec",
-          issueNumber,
-          specStartTime,
-          specEndTime,
-          specResult.success
-            ? "success"
-            : specResult.error?.includes("Timeout")
-              ? "timeout"
-              : "failure",
-          { error: specResult.error, errorContext: specErrorContext },
+    // Log spec phase result
+    // Note: Spec runs in main repo, not worktree, so no git diff stats
+    if (logWriter) {
+      // Build errorContext from captured stderr/stdout tails (#447)
+      let specErrorContext: ErrorContext | undefined;
+      if (!specResult.success && specResult.stderrTail) {
+        const specError = classifyError(
+          specResult.stderrTail ?? [],
+          specResult.exitCode,
         );
-        logWriter.logPhase(phaseLog);
-      }
-
-      // Track spec phase completion in state
-      if (stateManager) {
-        try {
-          const phaseStatus = specResult.success ? "completed" : "failed";
-          await stateManager.updatePhaseStatus(
-            issueNumber,
-            "spec",
-            phaseStatus,
-            {
-              error: specResult.error,
-            },
-          );
-        } catch {
-          // State tracking errors shouldn't stop execution
-        }
-      }
-
-      if (!specResult.success) {
-        specSpinner?.fail(specResult.error);
-        const durationSeconds = (Date.now() - startTime) / 1000;
-        return {
-          issueNumber,
-          success: false,
-          phaseResults,
-          durationSeconds,
-          loopTriggered: false,
+        specErrorContext = {
+          stderrTail: specResult.stderrTail ?? [],
+          stdoutTail: specResult.stdoutTail ?? [],
+          exitCode: specResult.exitCode,
+          category: errorTypeToCategory(specError),
+          errorType: specError.name,
+          errorMetadata: specError.metadata,
+          isRetryable: specError.isRetryable,
         };
       }
+      const phaseLog = createPhaseLogFromTiming(
+        "spec",
+        issueNumber,
+        specStartTime,
+        specEndTime,
+        specResult.success
+          ? "success"
+          : specResult.error?.includes("Timeout")
+            ? "timeout"
+            : "failure",
+        { error: specResult.error, errorContext: specErrorContext },
+      );
+      logWriter.logPhase(phaseLog);
+    }
 
-      specSpinner?.succeed();
-
-      // Parse recommended workflow from spec output
-      const parsedWorkflow = specResult.output
-        ? parseRecommendedWorkflow(specResult.output)
-        : null;
-
-      if (parsedWorkflow) {
-        // Remove spec from phases since we already ran it
-        phases = parsedWorkflow.phases.filter((p) => p !== "spec");
-        detectedQualityLoop = parsedWorkflow.qualityLoop;
-        log(
-          chalk.gray(
-            `    Spec recommends: ${phases.join(" → ")}${detectedQualityLoop ? " (quality loop)" : ""}`,
-          ),
-        );
-      } else {
-        // Fall back to label-based detection
-        log(
-          chalk.yellow(
-            `    Could not parse spec recommendation, using label-based detection`,
-          ),
-        );
-        const detected = detectPhasesFromLabels(labels);
-        phases = detected.phases.filter((p) => p !== "spec");
-        detectedQualityLoop = detected.qualityLoop;
-        log(chalk.gray(`    Fallback: ${phases.join(" → ")}`));
+    // Track spec phase completion in state
+    if (stateManager) {
+      try {
+        const phaseStatus = specResult.success ? "completed" : "failed";
+        await stateManager.updatePhaseStatus(issueNumber, "spec", phaseStatus, {
+          error: specResult.error,
+        });
+      } catch {
+        // State tracking errors shouldn't stop execution
       }
+    }
+
+    if (!specResult.success) {
+      specSpinner?.fail(specResult.error);
+      const durationSeconds = (Date.now() - startTime) / 1000;
+      return {
+        issueNumber,
+        success: false,
+        phaseResults,
+        durationSeconds,
+        loopTriggered: false,
+      };
+    }
+
+    specSpinner?.succeed();
+
+    // Parse recommended workflow from spec output
+    const parsedWorkflow = specResult.output
+      ? parseRecommendedWorkflow(specResult.output)
+      : null;
+
+    if (parsedWorkflow) {
+      // Remove spec from phases since we already ran it
+      phases = parsedWorkflow.phases.filter((p) => p !== "spec");
+      detectedQualityLoop = parsedWorkflow.qualityLoop;
+      log(
+        chalk.gray(
+          `    Spec recommends: ${phases.join(" → ")}${detectedQualityLoop ? " (quality loop)" : ""}`,
+        ),
+      );
+    } else {
+      // Fall back to label-based detection
+      log(
+        chalk.yellow(
+          `    Could not parse spec recommendation, using label-based detection`,
+        ),
+      );
+      const detected = detectPhasesFromLabels(labels);
+      phases = detected.phases.filter((p) => p !== "spec");
+      detectedQualityLoop = detected.qualityLoop;
+      log(chalk.gray(`    Fallback: ${phases.join(" → ")}`));
     }
   } else {
     // Use explicit phases with adjustments

--- a/src/lib/workflow/phase-mapper.test.ts
+++ b/src/lib/workflow/phase-mapper.test.ts
@@ -7,30 +7,33 @@ import {
 } from "./phase-mapper.js";
 
 describe("detectPhasesFromLabels", () => {
-  describe("docs label detection (AC-3)", () => {
-    it("returns exec → qa for 'docs' label", () => {
+  // #533: bug and docs labels no longer skip spec. They now follow the
+  // default workflow (spec → exec → qa) because bug/docs issues often
+  // contain design decisions worth a spec pass.
+  describe("docs label detection (#533: includes spec)", () => {
+    it("returns spec → exec → qa for 'docs' label", () => {
       const result = detectPhasesFromLabels(["docs"]);
-      expect(result.phases).toEqual(["exec", "qa"]);
+      expect(result.phases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("returns exec → qa for 'documentation' label", () => {
+    it("returns spec → exec → qa for 'documentation' label", () => {
       const result = detectPhasesFromLabels(["documentation"]);
-      expect(result.phases).toEqual(["exec", "qa"]);
+      expect(result.phases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("returns exec → qa for 'readme' label", () => {
+    it("returns spec → exec → qa for 'readme' label", () => {
       const result = detectPhasesFromLabels(["readme"]);
-      expect(result.phases).toEqual(["exec", "qa"]);
+      expect(result.phases).toEqual(["spec", "exec", "qa"]);
     });
 
     it("is case-insensitive for docs labels", () => {
       const result = detectPhasesFromLabels(["DOCS"]);
-      expect(result.phases).toEqual(["exec", "qa"]);
+      expect(result.phases).toEqual(["spec", "exec", "qa"]);
     });
 
     it("detects docs label in mixed label set", () => {
       const result = detectPhasesFromLabels(["enhancement", "docs", "cli"]);
-      expect(result.phases).toEqual(["exec", "qa"]);
+      expect(result.phases).toEqual(["spec", "exec", "qa"]);
     });
 
     it("does not enable quality loop for docs-only", () => {
@@ -39,15 +42,15 @@ describe("detectPhasesFromLabels", () => {
     });
   });
 
-  describe("bug label detection", () => {
-    it("returns exec → qa for 'bug' label", () => {
+  describe("bug label detection (#533: includes spec)", () => {
+    it("returns spec → exec → qa for 'bug' label", () => {
       const result = detectPhasesFromLabels(["bug"]);
-      expect(result.phases).toEqual(["exec", "qa"]);
+      expect(result.phases).toEqual(["spec", "exec", "qa"]);
     });
 
-    it("returns exec → qa for 'fix' label", () => {
+    it("returns spec → exec → qa for 'fix' label", () => {
       const result = detectPhasesFromLabels(["fix"]);
-      expect(result.phases).toEqual(["exec", "qa"]);
+      expect(result.phases).toEqual(["spec", "exec", "qa"]);
     });
   });
 

--- a/src/lib/workflow/phase-mapper.ts
+++ b/src/lib/workflow/phase-mapper.ts
@@ -24,12 +24,12 @@ interface PhaseMapperOptions {
 export const UI_LABELS = ["ui", "frontend", "admin", "web", "browser"];
 
 /**
- * Bug-related labels that skip spec phase
+ * Bug-related labels (used by downstream metadata consumers)
  */
 export const BUG_LABELS = ["bug", "fix", "hotfix", "patch"];
 
 /**
- * Documentation labels that skip spec phase
+ * Documentation labels (used for issueType propagation and downstream metadata)
  */
 export const DOCS_LABELS = ["docs", "documentation", "readme"];
 
@@ -58,16 +58,6 @@ export function detectPhasesFromLabels(labels: string[]): {
 } {
   const lowerLabels = labels.map((l) => l.toLowerCase());
 
-  // Check for bug/fix labels → exec → qa (skip spec)
-  const isBugFix = lowerLabels.some((label) =>
-    BUG_LABELS.some((bugLabel) => label === bugLabel),
-  );
-
-  // Check for docs labels → exec → qa (skip spec)
-  const isDocs = lowerLabels.some((label) =>
-    DOCS_LABELS.some((docsLabel) => label === docsLabel),
-  );
-
   // Check for UI labels → add test phase
   const isUI = lowerLabels.some((label) =>
     UI_LABELS.some((uiLabel) => label === uiLabel),
@@ -83,19 +73,13 @@ export function detectPhasesFromLabels(labels: string[]): {
     SECURITY_LABELS.some((secLabel) => label === secLabel),
   );
 
-  // Build phase list
-  let phases: Phase[];
-
-  if (isBugFix || isDocs) {
-    // Simple workflow: exec → qa
-    phases = ["exec", "qa"];
-  } else if (isUI) {
-    // UI workflow: spec → exec → test → qa
-    phases = ["spec", "exec", "test", "qa"];
-  } else {
-    // Standard workflow: spec → exec → qa
-    phases = ["spec", "exec", "qa"];
-  }
+  // Build phase list — spec is always included by default (#533).
+  // Bug/docs labels no longer short-circuit spec; downstream consumers
+  // (e.g. `issueType: "docs"` propagation) still use DOCS_LABELS for
+  // metadata purposes, not for phase selection.
+  const phases: Phase[] = isUI
+    ? ["spec", "exec", "test", "qa"]
+    : ["spec", "exec", "qa"];
 
   // Add security-review phase after spec if security labels detected
   if (isSecurity && phases.includes("spec")) {

--- a/src/lib/workflow/run-reflect.ts
+++ b/src/lib/workflow/run-reflect.ts
@@ -65,7 +65,7 @@ function analyzeTimingPatterns(
         `Spec times similar across issues (${formatSec(min)}–${formatSec(max)}) despite varying complexity`,
       );
       suggestions.push(
-        "Consider `--phases exec,qa` for simple fixes to skip spec",
+        "Consider `--phases exec,qa` for issues where spec is not adding value (the default includes spec, #533)",
       );
     }
   }

--- a/src/lib/workflow/state-schema.ts
+++ b/src/lib/workflow/state-schema.ts
@@ -34,7 +34,7 @@ export const PhaseStatusSchema = z.enum([
   "in_progress", // Phase currently executing
   "completed", // Phase finished successfully
   "failed", // Phase finished with errors
-  "skipped", // Phase intentionally skipped (e.g., bug labels skip spec)
+  "skipped", // Phase intentionally skipped (e.g., prior phase marker already exists)
 ]);
 
 export type PhaseStatus = z.infer<typeof PhaseStatusSchema>;

--- a/templates/skills/assess/SKILL.md
+++ b/templates/skills/assess/SKILL.md
@@ -117,14 +117,14 @@ Surface red flags. Only track signals that change the recommendation.
 | complex, refactor, breaking, major | Modifier | `spec → exec → qa` + `-q` |
 | (ui/frontend) + (enhancement/feature), or testable-AC signals | Modifier | inserts `testgen` before `exec` (see Testgen detection below) |
 | enhancement, feature (default) | Generic | `spec → exec → qa` |
-| bug, fix, hotfix, patch | Generic | `exec → qa` |
-| docs, documentation, readme | Generic | `exec → qa` |
+| bug, fix, hotfix, patch | Generic | `spec → exec → qa` |
+| docs, documentation, readme | Generic | `spec → exec → qa` |
 
-**Label priority:** Domain labels take precedence over generic labels. When an issue has both a domain label and a generic label (e.g., `bug` + `auth`), use the domain-specific workflow. Example: an issue labeled `bug` + `auth` gets `spec → security-review → exec → qa`, not `exec → qa`. Similarly, `bug` + `ui` gets `spec → exec → test → qa`.
+**Label priority:** Domain labels take precedence over generic labels. When an issue has both a domain label and a generic label (e.g., `bug` + `auth`), the domain label adds its extra phase. Example: an issue labeled `bug` + `auth` gets `spec → security-review → exec → qa` (adds `security-review` from `auth`); `bug` + `ui` gets `spec → exec → test → qa` (adds `test` from `ui`).
 
 **Valid phases (from `PhaseSchema` in `src/lib/workflow/types.ts`):** `spec`, `security-review`, `exec`, `testgen`, `test`, `verify`, `qa`, `loop`, `merger`
 
-**Skip spec when:** (bug/docs label AND no domain labels like security/auth/ui/frontend), OR spec comment already exists on issue.
+**Skip spec when:** a prior `spec` phase marker already exists on the issue. Otherwise, always include spec — bug and docs issues often contain design decisions (scope boundaries, edge cases, test-strategy shifts) that benefit from a spec pass.
 
 **Resume detection:** Branch exists with commits ahead of main → mark as resume (`◂`).
 
@@ -208,7 +208,7 @@ Cleanup:
 | Symbol | Meaning | Example |
 |--------|---------|---------|
 | `spec → exec → qa` | Full workflow | Standard feature |
-| `exec → qa` | Skip spec | Bug, docs, or spec exists |
+| `exec → qa` | Skip spec | Prior spec marker exists |
 | `◂ exec → qa` | Resume existing work | Branch has commits |
 | `◂ qa` | PR needs review/QA | Open PR, impl done |
 | `⟳ spec → exec → qa` | Restart (fresh) | Stale PR abandoned |
@@ -265,18 +265,17 @@ Not all issues have explicit `- [ ]` checkboxes, so the `ACs` column is omitted.
 ```
  #    Action     Reason                              Run
  462  PARK       Manual measurement task              ‖
- 461  PROCEED    Exact label matching                  exec → qa
- 460  PROCEED    batch-executor tests                  exec → qa
+ 461  PROCEED    Exact label matching                  spec → exec → qa
+ 460  PROCEED    batch-executor tests                  spec → exec → qa
  458  PROCEED    Parallel UX + race condition          spec → exec → qa
  447  CLOSE      PR #457 merged                        —
  443  PROCEED    Consolidate gh calls                  spec → exec → qa
- 412  PROCEED    Auth bug (domain: auth overrides bug) spec → security-review → exec → qa
+ 412  PROCEED    Auth bug (domain: auth adds review)   spec → security-review → exec → qa
  411  PROCEED    Config path normalization              ◂ exec → qa
  405  REWRITE    PR #380 200+ commits behind           ⟳ spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 461 460 -q --phases exec,qa
-  npx sequant run 458 443 -q
+  npx sequant run 461 460 458 443 -q
   npx sequant run 412 -q --phases spec,security-review,exec,qa
   npx sequant run 411 -q --phases exec,qa     # resume
   npx sequant run 405 -q                      # restart
@@ -285,11 +284,12 @@ Order: 460 → 461 (460 adds batch-executor tests that 461's label matching depe
 
 ⚠ #458  Dual concern (UX + race) across 4 files
 ⚠ #405  Stale 30+ days, ACs still valid
-⚠ #412  bug + auth labels — domain label (auth) takes priority over bug
+⚠ #412  bug + auth labels — auth (domain) adds security-review phase
 
 Flags:
-  -q                   multi-file scope across most PROCEED issues
-  --phases spec,...    spec phase added for 458/443/412/405 (standard features)
+  -q                              multi-file scope across most PROCEED issues
+  --phases ...,security-review    #412 auth label → security review required
+  --phases exec,qa                #411 resume — prior spec marker already exists
 ────────────────────────────────────────────────────────────────
 Cleanup:
   git worktree remove .../447-...      # merged, stale worktree
@@ -298,8 +298,8 @@ Cleanup:
 ────────────────────────────────────────────────────────────────
 
 <!-- #462 assess:action=PARK -->
-<!-- #461 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #460 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #461 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #460 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #458 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #447 assess:action=CLOSE -->
 <!-- #443 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
@@ -344,17 +344,16 @@ When every issue is PROCEED with no warnings, no dependencies, and no non-defaul
 
 ```
  #    Action     Reason                              Run
- 461  PROCEED    Exact label matching                  exec → qa
- 460  PROCEED    batch-executor tests                  exec → qa
+ 461  PROCEED    Exact label matching                  spec → exec → qa
+ 460  PROCEED    batch-executor tests                  spec → exec → qa
  443  PROCEED    Consolidate gh calls                  spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 461 460 -q --phases exec,qa
-  npx sequant run 443 -q
+  npx sequant run 461 460 443 -q
 ────────────────────────────────────────────────────────────────
 
-<!-- #461 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #460 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #461 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #460 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #443 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 ```
 
@@ -366,31 +365,30 @@ When assessing 9+ issues, commands are split per Rule 7 (max 6 issue numbers per
 
 ```
  #    Action     Reason                                   Run
- 503  PROCEED    Fix typo in error output                   exec → qa
- 502  PROCEED    Update deprecated API call                 exec → qa
- 501  PROCEED    Add retry logic to API client              exec → qa
+ 503  PROCEED    Fix typo in error output                   spec → exec → qa
+ 502  PROCEED    Update deprecated API call                 spec → exec → qa
+ 501  PROCEED    Add retry logic to API client              spec → exec → qa
  500  PROCEED    Fix token refresh race condition           spec → security-review → exec → qa
  499  PROCEED    Dashboard chart rendering bug              spec → exec → test → qa
- 498  PROCEED    Update error messages                      exec → qa
+ 498  PROCEED    Update error messages                      spec → exec → qa
  497  PROCEED    Refactor batch executor                    spec → exec → qa
  496  PARK       Blocked on #490 schema migration           ‖
- 495  PROCEED    CLI help text improvements                 exec → qa
- 494  PROCEED    Assess batch formatting fix                exec → qa
+ 495  PROCEED    CLI help text improvements                 spec → exec → qa
+ 494  PROCEED    Assess batch formatting fix                spec → exec → qa
  493  CLOSE      Duplicate of #491                          —
  492  PROCEED    Add export command                         spec → exec → qa
- 491  PROCEED    Normalize config paths                     exec → qa
+ 491  PROCEED    Normalize config paths                     spec → exec → qa
 ────────────────────────────────────────────────────────────────
 Commands:
-  npx sequant run 503 502 501 498 495 494 -q --phases exec,qa
-  npx sequant run 491 -q --phases exec,qa
+  npx sequant run 503 502 501 498 497 495 -q
+  npx sequant run 494 492 491 -q
   npx sequant run 499 -q --phases spec,exec,test,qa
   npx sequant run 500 -q --phases spec,security-review,exec,qa
-  npx sequant run 497 492 -q
 ────────────────────────────────────────────────────────────────
 Order: 497 → 492 (497 refactors batch-executor internals that 492's export command uses)
 
-⚠ #500  bug + auth labels — domain label takes priority
-⚠ #499  bug + ui labels — domain label triggers test phase
+⚠ #500  bug + auth labels — auth (domain) adds security-review phase
+⚠ #499  bug + ui labels — ui (domain) adds test phase
 
 Flags:
   --phases ...,security-review   #500 auth label → security review required
@@ -400,19 +398,19 @@ Cleanup:
   gh issue close 493                   # duplicate of #491
 ────────────────────────────────────────────────────────────────
 
-<!-- #503 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #502 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #501 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #503 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #502 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #501 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #500 assess:action=PROCEED assess:phases=spec,security-review,exec,qa assess:quality-loop=true -->
 <!-- #499 assess:action=PROCEED assess:phases=spec,exec,test,qa assess:quality-loop=true -->
-<!-- #498 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #498 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #497 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #496 assess:action=PARK -->
-<!-- #495 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
-<!-- #494 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #495 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
+<!-- #494 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 <!-- #493 assess:action=CLOSE -->
 <!-- #492 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
-<!-- #491 assess:action=PROCEED assess:phases=exec,qa assess:quality-loop=true -->
+<!-- #491 assess:action=PROCEED assess:phases=spec,exec,qa assess:quality-loop=true -->
 ```
 
 ---

--- a/templates/skills/spec/references/recommended-workflow.md
+++ b/templates/skills/spec/references/recommended-workflow.md
@@ -14,15 +14,17 @@ This document shows the expected output format for the `## Recommended Workflow`
 
 ## Examples
 
-### Simple Bug Fix
+### Simple Bug Fix (spec confirms straightforward scope)
 
 ```markdown
 ## Recommended Workflow
 
 **Phases:** exec → qa
 **Quality Loop:** disabled
-**Reasoning:** Straightforward bug fix with clear root cause. No planning needed.
+**Reasoning:** This spec pass confirmed a clear root cause and narrow scope — no testgen or additional phases required; proceed to exec.
 ```
+
+*Note:* Since #533, spec always runs by default. `**Phases:**` lists phases **after** spec — use `exec → qa` here to indicate "spec is done; only exec and qa remain."
 
 ### Standard Feature
 


### PR DESCRIPTION
## Summary

- Removes the "skip spec when (bug/docs label AND no domain labels)" rule from `/assess` — spec is now always included unless a prior `spec` phase marker already exists on the issue.
- Updates the Labels → Workflow table, Run Column Symbols meaning, and every batch/single example in the skill so bug/docs rows use `spec → exec → qa`.
- Synced across all 3 skill directories (`.claude/skills/`, `templates/skills/`, `skills/`) — byte-identical, verified by `scripts/check-skill-sync.ts`.
- CHANGELOG `[Unreleased]` → `### Changed` bullet referencing #533.

## Motivation

`/spec` was compressed ~68% in #515, so the per-phase cost is now small enough to justify universal inclusion. The label-based skip picked the wrong axis: `bug` describes the nature of the work, not its complexity or design surface. Recent batch assessments confirmed users consistently reject skipping spec for bug/docs issues that contain meaningful design decisions (scope boundaries, edge cases, test-strategy shifts).

## AC Coverage

| AC | Status | Evidence |
|----|--------|----------|
| AC-1: Remove auto-skip rule | ✅ | `grep "bug/docs label AND no domain"` returns nothing in SKILL.md |
| AC-2: New skip rule (spec marker only) | ✅ | `.claude/skills/assess/SKILL.md:127` |
| AC-3: Table rows updated | ✅ | Lines 120–121: `bug/fix/hotfix/patch` and `docs/documentation/readme` → `spec → exec → qa` |
| AC-4: Examples refreshed | ✅ | 3 batch examples + warnings/flags blocks updated; resume (`◂`) cases preserved |
| AC-5: 3-dir sync | ✅ | `scripts/check-skill-sync.ts` reports `assess/SKILL.md — 3/3 match` |
| AC-6: CHANGELOG entry | ✅ | `[Unreleased] / ### Changed` bullet with #533 reference |

## Quality Gates

- `npm run build` — ✅ tsc passes
- `npm run lint` — ✅ eslint passes
- `npx vitest run src/lib/__tests__/assess-skill.test.ts` — ✅ 5/5 pass (phase vocabulary, CLI flag accuracy, 3-dir sync)
- `npx tsx scripts/check-skill-sync.ts` — ✅ `assess/SKILL.md — 3/3 match`

## Test plan

- [x] Build + lint + targeted vitest green
- [x] `diff -q` across all 3 skill dirs is empty
- [x] grep confirms no residual "bug/docs" auto-skip language
- [ ] Reviewer: scan SKILL.md example sections for visual consistency (Run column alignment, Commands block grouping)

## Notes

- #411 resume case in Example 1 deliberately keeps `◂ exec → qa` and `assess:phases=exec,qa` — resume states carry a prior `spec` marker, which is the only remaining skip condition.
- CHANGELOG merge conflict risk: three other open worktrees (#56, #529, #531) also add to `[Unreleased]`. Resolution should be trivial.

Closes #533