### PR TITLE
docs(#532): document force-push handoff pattern when pre-tool hook blocks

### DIFF
--- a/.claude/skills/_shared/references/force-push.md
+++ b/.claude/skills/_shared/references/force-push.md
@@ -1,0 +1,34 @@
+# Force-push handoff pattern
+
+When you encounter `HOOK_BLOCKED: Force push` from `.claude/hooks/pre-tool.sh:106-111`, **do not attempt to bypass the hook**. The block is intentional — force-pushing rewrites history and can destroy work for others sharing the branch.
+
+## The pattern: hand the command to the user
+
+When a force push is genuinely required (e.g., cleaning contamination off a feature branch after a clean rebase), present the exact command to the user prefixed with `!` so they execute it in-session:
+
+```
+! git push --force-with-lease origin feature/<branch>
+```
+
+The user pastes that into the prompt; the `!` runs it in their shell, output streams back into the conversation, and you continue from there.
+
+**Always prefer `--force-with-lease` over raw `--force`.** `--force-with-lease` refuses to overwrite the remote ref if someone else pushed in the meantime, turning a silent stomp into a clean error.
+
+## Why bypass attempts fail
+
+`CLAUDE_HOOKS_DISABLED=true git push --force ...` does **not** work. The hook reads `CLAUDE_HOOKS_DISABLED` at the harness level *before* Bash executes the command, so prefixing the env var inside the command line has no effect. Setting it via `export` in a prior tool call doesn't help either — each Bash tool call is a fresh subprocess.
+
+## When force push is legitimate vs. not
+
+| Legitimate | Not legitimate |
+|------------|----------------|
+| Cleaning rebase contamination off your own feature branch before PR | Rewriting history on `main`/`master` |
+| Removing accidentally-committed secrets after rotation | "Squashing for cleanliness" on a shared branch |
+| Recovering from a mistakenly-pushed merge commit | Force-pushing over someone else's work |
+
+For shared branches, prefer `git revert` over force push.
+
+## Reference
+
+- Block definition: `.claude/hooks/pre-tool.sh:106-111`
+- Regex: `git push.*(--force| -f($| ))` — note this can also match the literal strings inside quoted `gh issue/pr` bodies (workaround: write the body to a file first)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 ## Commit Rules
 
 - Do NOT add `Co-Authored-By` lines to any commits in this repository.
+
+## Hooks
+
+- **`HOOK_BLOCKED: Force push`** — see [.claude/skills/_shared/references/force-push.md](.claude/skills/_shared/references/force-push.md) for the user-handoff pattern. Do not attempt `CLAUDE_HOOKS_DISABLED=true` bypasses; they don't work.


### PR DESCRIPTION
## Summary

Adds `.claude/skills/_shared/references/force-push.md` documenting the user-handoff pattern when `pre-tool.sh:106-111` blocks a force push. Adds a one-line pointer in `CLAUDE.md` so agents see the link.

## What's covered

- The `!`-prefix handoff pattern (present the command for the user to execute in-session)
- Why bypass attempts fail (env-var read happens at harness level, before Bash subprocess)
- Reference to `pre-tool.sh:106-111`
- `--force-with-lease` over raw forced push, with rationale
- Legitimate vs not-legitimate forced-push scenarios
- The self-referential regex caveat — including a live demo: this commit's own message was initially blocked by the same regex when it contained the literal command strings

## AC Coverage

| AC | Status |
|----|--------|
| AC-1: Document the handoff pattern | ✅ Met |
| AC-2: State that bypass is intentional / won't work | ✅ Met |
| AC-3: Reference `pre-tool.sh:106-111` | ✅ Met |
| AC-4: Use `--force-with-lease` | ✅ Met |
| AC-5: (Optional) Hook regex anchoring fix | 🔄 Deferred to follow-up |

AC-5 deferred per spec — that's a hook behavior change requiring regression tests for the four push variants. This PR is docs-only.

## Test plan

- [x] Read both files end-to-end
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Verify `CLAUDE.md` link path resolves (relative path correct)

## Verification of the documented pattern

This PR's commit + creation flow exercised the documented pattern itself:

1. The commit message contained the literal strings that trip the regex → blocked by hook.
2. Workaround applied per the new doc: write message to file, commit with `git commit -F`.
3. Same applied to this PR body.

Self-referential evidence the pattern works.

Closes #532
