### PR TITLE
fix(#562): qualify Skill("loop") in fullsolve as sequant:loop

### DIFF
--- a/.claude/skills/fullsolve/SKILL.md
+++ b/.claude/skills/fullsolve/SKILL.md
@@ -446,7 +446,7 @@ while test_iteration < MAX_TEST_ITERATIONS:
         break
 
     # Use /loop to fix failures
-    Skill(skill: "loop", args: "<issue-number> --phase test")
+    Skill(skill: "sequant:loop", args: "<issue-number> --phase test")
     test_iteration += 1
 ```
 
@@ -524,7 +524,7 @@ while qa_iteration < MAX_QA_ITERATIONS:
         break
 
     # Use /loop to fix issues (AC_NOT_MET)
-    Skill(skill: "loop", args: "<issue-number> --phase qa")
+    Skill(skill: "sequant:loop", args: "<issue-number> --phase qa")
     qa_iteration += 1
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/fullsolve` quality-loop misroute** — fixed unqualified `Skill("loop")` calls in fullsolve SKILL.md resolving to Anthropic's top-level recurring-prompt `loop` skill instead of sequant's quality-loop skill, causing the workflow to silently prompt the user to schedule a recurring task instead of running the test/QA fix iteration. All 6 occurrences across the 3 mirrored fullsolve SKILL.md files (`.claude/skills/`, `skills/`, `templates/skills/`) now use the qualified form `Skill("sequant:loop", ...)`. (#562)
+
 ### Added
 
 - **Prior assessment detection in `/assess`** — `/assess` now scans existing issue comments for prior `<!-- assess:action=... -->` markers before posting. New comments prepend a supersession header (`Supersedes prior assess from <date> (<action>)` for one prior, `Supersedes N prior assessments (most recent: <date>)` for multiple). When ≥3 priors exist with no intervening exec phase marker, the dashboard emits a re-assessment churn warning. When the new recommendation conflicts with a prior `PROCEED` or `REWRITE`, the user is prompted to confirm via `AskUserQuestion` before posting (skipped for prior `CLOSE`/`PARK`/`CLARIFY`/`MERGE`). New parser exports in `src/lib/assess-comment-parser.ts`: `findAllAssessComments()`, `buildSupersessionHeader()`, `detectChurn()`, `shouldPromptOnConflict()`. Detection matches the durable HTML action marker — works on production dashboard-format comments that lack the legacy `## Assess Analysis` prose header. (#555)

--- a/skills/fullsolve/SKILL.md
+++ b/skills/fullsolve/SKILL.md
@@ -446,7 +446,7 @@ while test_iteration < MAX_TEST_ITERATIONS:
         break
 
     # Use /loop to fix failures
-    Skill(skill: "loop", args: "<issue-number> --phase test")
+    Skill(skill: "sequant:loop", args: "<issue-number> --phase test")
     test_iteration += 1
 ```
 
@@ -524,7 +524,7 @@ while qa_iteration < MAX_QA_ITERATIONS:
         break
 
     # Use /loop to fix issues (AC_NOT_MET)
-    Skill(skill: "loop", args: "<issue-number> --phase qa")
+    Skill(skill: "sequant:loop", args: "<issue-number> --phase qa")
     qa_iteration += 1
 ```
 

--- a/templates/skills/fullsolve/SKILL.md
+++ b/templates/skills/fullsolve/SKILL.md
@@ -446,7 +446,7 @@ while test_iteration < MAX_TEST_ITERATIONS:
         break
 
     # Use /loop to fix failures
-    Skill(skill: "loop", args: "<issue-number> --phase test")
+    Skill(skill: "sequant:loop", args: "<issue-number> --phase test")
     test_iteration += 1
 ```
 
@@ -524,7 +524,7 @@ while qa_iteration < MAX_QA_ITERATIONS:
         break
 
     # Use /loop to fix issues (AC_NOT_MET)
-    Skill(skill: "loop", args: "<issue-number> --phase qa")
+    Skill(skill: "sequant:loop", args: "<issue-number> --phase qa")
     qa_iteration += 1
 ```
 


### PR DESCRIPTION
## Summary

Fixes the silent misroute of `/fullsolve`'s quality loop. Unqualified `Skill(skill: "loop", ...)` was resolving to Anthropic's top-level recurring-prompt skill instead of sequant's quality-loop skill, so when fullsolve hit the test/QA fix branch the user got a "schedule a recurring task?" prompt instead of automated fix iteration.

- 6 occurrences (lines 449 and 527 of each of 3 mirrored fullsolve `SKILL.md` files) changed from `"loop"` → `"sequant:loop"`
- Other unqualified `Skill()` calls (`spec`/`exec`/`qa`/`test`) intentionally left untouched per AC-3 — no name collisions exist for those today
- CHANGELOG entry under `[Unreleased] / ### Fixed`

Closes #562

## Acceptance Criteria

- [x] **AC-1:** All 6 occurrences of `Skill(skill: "loop", ...)` in fullsolve SKILL.md mirrors changed to `Skill(skill: "sequant:loop", ...)`. Verified: `grep -c 'Skill(skill: "loop"'` returns 0 in all 3 files; `grep -c 'Skill(skill: "sequant:loop"'` returns 2 per file.
- [x] **AC-2:** 3-dir sync preserved. Verified: pairwise `diff` clean across `.claude/skills/fullsolve/SKILL.md`, `skills/fullsolve/SKILL.md`, `templates/skills/fullsolve/SKILL.md`.
- [x] **AC-3:** Other unqualified `Skill()` calls untouched. Verified: `git diff origin/main` on `.claude/skills/fullsolve/SKILL.md` shows only the 4 loop-related lines changed (2 removed, 2 added) — no `spec`/`exec`/`qa`/`test` references modified.
- [x] **AC-4:** CHANGELOG entry under `[Unreleased] / ### Fixed` referencing #562 and naming the symptom (silent loop misroute).
- [x] **AC-5:** Smoke test note (this section).

## Smoke Test Plan (AC-5)

The bug only surfaces when `/fullsolve` enters the quality-loop branch (i.e., a `/test` or `/qa` phase fails and triggers fix iteration). Triggering this in a controlled fashion requires an issue whose AC will fail QA. Recommended smoke test:

1. Pick (or create) an issue with a deliberately-incomplete AC such that `/qa` returns `AC_NOT_MET` on first pass.
2. Run `/fullsolve <N>`.
3. When the QA loop fires, expect the first line of output from the loop branch to be:
   > `Quality loop - Parse test/QA findings and iterate until quality gates pass`

   …**not** the recurring-prompt skill's prompt:
   > `Parse the input below into [interval] <prompt…> and schedule it.`
4. Capture the first line as evidence and append to this PR / linked issue.

**Verification timing:** This run of `/fullsolve 562` itself did *not* enter the quality-loop branch (QA passes on first pass for a mechanical fix), so the smoke test must be run against a separately-failing issue. Documented here per AC-5; will execute on the next loop-triggering issue and link evidence.

## Test plan

- [x] `npm run build` — passes (no TS surface; markdown-only changes)
- [x] `grep` verifications above
- [x] pairwise `diff` of the 3 mirrored SKILL.md files
- [ ] Manual smoke test on a loop-triggering issue (per AC-5)

## Non-Goals

- Not requalifying `spec`/`exec`/`qa`/`test` references — no collision exists for those names, and gratuitous churn risks introducing typos.
- Not changing the harness skill-name resolution logic.
- Not auditing other sequant skills for similar unqualified calls.