### PR TITLE
fix(#564): pre-tool.sh regexes skip gh issue/pr body content

### DIFF
--- a/.claude/hooks/pre-tool.sh
+++ b/.claude/hooks/pre-tool.sh
@@ -214,6 +214,7 @@ check_sensitive_files() {
 
 if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
     # Security checks for git commit
+    # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
     if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
         # Skip security checks if --no-verify is used
         if ! echo "$TOOL_INPUT" | grep -qE -- '--no-verify'; then
@@ -246,6 +247,7 @@ fi
 # --- No-Changes Guard (AC-7) ---
 # Block commits when there are no staged or unstaged changes (prevents empty commits)
 # Skips for --amend since amending doesn't require new changes
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     if ! echo "$TOOL_INPUT" | grep -qE -- '--amend|--allow-empty'; then
         # Extract target directory from cd command if present (for worktree commits)
@@ -273,6 +275,7 @@ fi
 # Warn (but don't block) when committing outside a feature worktree
 # This catches accidental commits to main repo during feature work
 QUALITY_LOG="/tmp/claude-quality.log"
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     CWD=$(pwd)
     if ! echo "$CWD" | grep -qE 'worktrees/feature/'; then
@@ -284,6 +287,7 @@ fi
 # --- Commit Message Validation (AC-3) ---
 # Enforce conventional commits format: type(scope): description
 # Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     # Extract message from -m flag
     MSG=""

--- a/.claude/hooks/pre-tool.sh
+++ b/.claude/hooks/pre-tool.sh
@@ -105,7 +105,8 @@ fi
 
 # Force push
 # Pattern requires -f to be a standalone flag (not part of branch name like -fix)
-if echo "$TOOL_INPUT" | grep -qE 'git push.*(--force| -f($| ))'; then
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
+if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git push.*(--force| -f($| ))'; then
     echo "HOOK_BLOCKED: Force push" | tee -a /tmp/claude-hook.log >&2
     exit 2
 fi
@@ -213,7 +214,7 @@ check_sensitive_files() {
 
 if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
     # Security checks for git commit
-    if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+    if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
         # Skip security checks if --no-verify is used
         if ! echo "$TOOL_INPUT" | grep -qE -- '--no-verify'; then
             # Check staged files for secrets
@@ -245,7 +246,7 @@ fi
 # --- No-Changes Guard (AC-7) ---
 # Block commits when there are no staged or unstaged changes (prevents empty commits)
 # Skips for --amend since amending doesn't require new changes
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     if ! echo "$TOOL_INPUT" | grep -qE -- '--amend|--allow-empty'; then
         # Extract target directory from cd command if present (for worktree commits)
         # Handles: "cd /path && git commit" or "cd /path; git commit"
@@ -272,7 +273,7 @@ fi
 # Warn (but don't block) when committing outside a feature worktree
 # This catches accidental commits to main repo during feature work
 QUALITY_LOG="/tmp/claude-quality.log"
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     CWD=$(pwd)
     if ! echo "$CWD" | grep -qE 'worktrees/feature/'; then
         echo "$(date +%H:%M:%S) WORKTREE_WARNING: Committing outside feature worktree ($CWD)" >> "$QUALITY_LOG"
@@ -283,7 +284,7 @@ fi
 # --- Commit Message Validation (AC-3) ---
 # Enforce conventional commits format: type(scope): description
 # Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     # Extract message from -m flag
     MSG=""
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Default workflow: spec phase ON for bug/docs issues** — the "skip spec when (bug/docs label AND no domain labels)" shortcut has been removed at both the skill-recommendation layer (`/assess`) and the runtime auto-detection layer (`phase-mapper.detectPhasesFromLabels`, `batch-executor` auto-detect). Bug- and docs-labeled issues now run `spec → exec → qa` by default under `sequant run --auto-detect`. Spec is only skipped when a prior `spec` phase marker already exists on the issue. Real-world batches showed that bug and docs issues frequently contain design decisions (scope boundaries, edge cases, test-strategy shifts) that benefit from a spec pass, and post-#515 the per-phase cost is small enough to justify universal inclusion. Docs-labeled issues still propagate `issueType: "docs"` through post-spec phases for downstream skills (e.g. lighter `/qa` pipeline). Override with explicit `--phases exec,qa`. (#533)
 
+### Fixed
+
+- **Pre-tool hook regexes now skip `gh issue|pr` body content** — the force-push regex and all four `git commit` regex sites in `pre-tool.sh` (security-checks, no-changes guard, worktree warning, conventional-commits validator) are now gated behind the same `^gh (issue|pr) ` exclusion that already guarded the secrets/credentials checks. Previously, `gh issue create` / `gh pr create` / `gh issue comment` / `gh pr comment` calls whose body text merely *referenced* these tokens (e.g. a doc explaining the hook itself, or a release note) were blocked at the tool-call level. Mirrored across all three hook copies (`templates/hooks/pre-tool.sh`, `hooks/pre-tool.sh`, `.claude/hooks/pre-tool.sh`). Follow-up to #532. (#564)
+
 ## [2.2.0] - 2026-04-18
 
 ### Added

--- a/__tests__/pre-tool-hook.integration.test.ts
+++ b/__tests__/pre-tool-hook.integration.test.ts
@@ -1,0 +1,146 @@
+// Tests for Issue #564 — pre-tool.sh regexes must skip gh issue/pr body content
+// Spawns the canonical hook script (templates/hooks/pre-tool.sh) with real
+// stdin and asserts on exit codes. AC-4 uses an isolated tmp git repo so the
+// "no staged changes" assertion is independent of the developer's working tree.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const HOOK = join(REPO_ROOT, "templates", "hooks", "pre-tool.sh");
+
+// Strip env vars that the hook treats as worktree/parallel context — those
+// would change behavior for unrelated reasons.
+function cleanEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.SEQUANT_WORKTREE;
+  delete env.SEQUANT_ISSUE;
+  delete env.CLAUDE_HOOKS_DISABLED;
+  return env;
+}
+
+function runHook(
+  toolInput: string,
+  cwd: string,
+): { code: number; stderr: string } {
+  const payload = JSON.stringify({
+    tool_name: "Bash",
+    tool_input: { command: toolInput },
+  });
+  const result = spawnSync("bash", [HOOK], {
+    input: payload,
+    cwd,
+    env: cleanEnv(),
+    encoding: "utf8",
+  });
+  return {
+    code: result.status ?? -1,
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("pre-tool.sh regex exclusions for gh issue/pr (#564)", () => {
+  let cleanRepo: string;
+
+  beforeAll(() => {
+    // AC-4 needs an isolated git repo with no staged or unstaged changes.
+    cleanRepo = mkdtempSync(join(tmpdir(), "pre-tool-test-"));
+    spawnSync("git", ["init", "-q"], { cwd: cleanRepo });
+    spawnSync("git", ["config", "user.email", "test@test"], { cwd: cleanRepo });
+    spawnSync("git", ["config", "user.name", "test"], { cwd: cleanRepo });
+  });
+
+  afterAll(() => {
+    rmSync(cleanRepo, { recursive: true, force: true });
+  });
+
+  // AC-1: force-push regex skips gh issue/pr payloads
+  it("AC-1: allows gh issue create whose body references force-push", () => {
+    const cmd = `gh issue create --title "x" --body "Use git push --force only when..."`;
+    const { code } = runHook(cmd, cleanRepo);
+    expect(code).toBe(0);
+  });
+
+  it("AC-1b: allows gh pr comment whose body references force-with-lease", () => {
+    const cmd = `gh pr comment 1 --body "see git push --force-with-lease docs"`;
+    const { code } = runHook(cmd, cleanRepo);
+    expect(code).toBe(0);
+  });
+
+  // AC-2: no-changes guard skips gh issue/pr payloads
+  it("AC-2: allows gh issue comment whose body references git commit", () => {
+    const cmd = `gh issue comment 564 --body "Run git commit -m 'msg' to finish"`;
+    const { code } = runHook(cmd, cleanRepo);
+    expect(code).toBe(0);
+  });
+
+  it("AC-2b: allows gh pr create whose body references git commit", () => {
+    const cmd = `gh pr create --title "x" --body "Squash with git commit --amend"`;
+    const { code } = runHook(cmd, cleanRepo);
+    expect(code).toBe(0);
+  });
+
+  // AC-3: force-push regex still blocks the actual command
+  it("AC-3: blocks real `git push --force`", () => {
+    const { code, stderr } = runHook("git push --force", cleanRepo);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
+  });
+
+  it("AC-3b: blocks real `git push -f origin main`", () => {
+    const { code, stderr } = runHook("git push -f origin main", cleanRepo);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
+  });
+
+  // AC-4: no-changes guard still blocks real `git commit` with empty staging
+  it("AC-4: blocks real `git commit -m 'msg'` with no staged changes", () => {
+    const { code, stderr } = runHook("git commit -m 'msg'", cleanRepo);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/HOOK_BLOCKED: No changes to commit/);
+  });
+
+  it("AC-4b: still blocks real `git commit` even when other gh tokens appear later", () => {
+    // Order matters: the gh-skip is anchored to the START of TOOL_INPUT.
+    // A command starting with `git commit` should not get a free pass just
+    // because it mentions `gh issue` somewhere downstream.
+    const cmd = `git commit -m 'mention gh issue 1 in body'`;
+    const { code, stderr } = runHook(cmd, cleanRepo);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/HOOK_BLOCKED: No changes to commit/);
+  });
+
+  // Regression guard: the gh-skip must require the START anchor; a non-anchored
+  // mention of "gh issue" should not bypass the force-push check.
+  it("regression: `echo gh issue && git push --force` is still blocked", () => {
+    const cmd = `echo gh issue && git push --force`;
+    const { code, stderr } = runHook(cmd, cleanRepo);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
+  });
+
+  // Sanity: when there ARE staged changes, the no-changes guard does not fire
+  // for a real `git commit`. (The conventional-commits validator may still
+  // block based on message format — that's a separate guard. We only assert
+  // the no-changes guard is path-correct.)
+  it("sanity: no-changes guard does not fire when changes are staged", () => {
+    const repo = mkdtempSync(join(tmpdir(), "pre-tool-test-staged-"));
+    try {
+      spawnSync("git", ["init", "-q"], { cwd: repo });
+      spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
+      spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+      writeFileSync(join(repo, "f.txt"), "hello\n");
+      spawnSync("git", ["add", "f.txt"], { cwd: repo });
+      const { stderr } = runHook("git commit -m 'feat: x'", repo);
+      // The no-changes guard MUST NOT fire (changes are staged).
+      expect(stderr).not.toMatch(/HOOK_BLOCKED: No changes to commit/);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/__tests__/pre-tool-hook.integration.test.ts
+++ b/__tests__/pre-tool-hook.integration.test.ts
@@ -1,7 +1,10 @@
-// Tests for Issue #564 — pre-tool.sh regexes must skip gh issue/pr body content
-// Spawns the canonical hook script (templates/hooks/pre-tool.sh) with real
-// stdin and asserts on exit codes. AC-4 uses an isolated tmp git repo so the
-// "no staged changes" assertion is independent of the developer's working tree.
+// Tests for Issue #564 — pre-tool.sh regexes must skip gh issue/pr body content.
+//
+// The hook script is mirrored across three locations (templates/hooks/,
+// hooks/, and .claude/hooks/), none of which are symlinks. To prevent
+// future drift in any one copy, this suite parametrizes every assertion
+// over all three. AC-4 uses an isolated tmp git repo so the "no staged
+// changes" assertion is independent of the developer's working tree.
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
@@ -12,7 +15,18 @@ import { fileURLToPath } from "node:url";
 
 const HERE = fileURLToPath(new URL(".", import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
-const HOOK = join(REPO_ROOT, "templates", "hooks", "pre-tool.sh");
+
+const HOOK_COPIES: Array<[label: string, path: string]> = [
+  [
+    "templates/hooks/pre-tool.sh",
+    join(REPO_ROOT, "templates", "hooks", "pre-tool.sh"),
+  ],
+  ["hooks/pre-tool.sh", join(REPO_ROOT, "hooks", "pre-tool.sh")],
+  [
+    ".claude/hooks/pre-tool.sh",
+    join(REPO_ROOT, ".claude", "hooks", "pre-tool.sh"),
+  ],
+];
 
 // Strip env vars that the hook treats as worktree/parallel context — those
 // would change behavior for unrelated reasons.
@@ -25,6 +39,7 @@ function cleanEnv(): NodeJS.ProcessEnv {
 }
 
 function runHook(
+  hookPath: string,
   toolInput: string,
   cwd: string,
 ): { code: number; stderr: string } {
@@ -32,7 +47,7 @@ function runHook(
     tool_name: "Bash",
     tool_input: { command: toolInput },
   });
-  const result = spawnSync("bash", [HOOK], {
+  const result = spawnSync("bash", [hookPath], {
     input: payload,
     cwd,
     env: cleanEnv(),
@@ -44,103 +59,116 @@ function runHook(
   };
 }
 
-describe("pre-tool.sh regex exclusions for gh issue/pr (#564)", () => {
-  let cleanRepo: string;
+describe.each(HOOK_COPIES)(
+  "pre-tool.sh regex exclusions for gh issue/pr (#564) [%s]",
+  (_label, hookPath) => {
+    let cleanRepo: string;
 
-  beforeAll(() => {
-    // AC-4 needs an isolated git repo with no staged or unstaged changes.
-    cleanRepo = mkdtempSync(join(tmpdir(), "pre-tool-test-"));
-    spawnSync("git", ["init", "-q"], { cwd: cleanRepo });
-    spawnSync("git", ["config", "user.email", "test@test"], { cwd: cleanRepo });
-    spawnSync("git", ["config", "user.name", "test"], { cwd: cleanRepo });
-  });
+    beforeAll(() => {
+      // AC-4 needs an isolated git repo with no staged or unstaged changes.
+      cleanRepo = mkdtempSync(join(tmpdir(), "pre-tool-test-"));
+      spawnSync("git", ["init", "-q"], { cwd: cleanRepo });
+      spawnSync("git", ["config", "user.email", "test@test"], {
+        cwd: cleanRepo,
+      });
+      spawnSync("git", ["config", "user.name", "test"], { cwd: cleanRepo });
+    });
 
-  afterAll(() => {
-    rmSync(cleanRepo, { recursive: true, force: true });
-  });
+    afterAll(() => {
+      rmSync(cleanRepo, { recursive: true, force: true });
+    });
 
-  // AC-1: force-push regex skips gh issue/pr payloads
-  it("AC-1: allows gh issue create whose body references force-push", () => {
-    const cmd = `gh issue create --title "x" --body "Use git push --force only when..."`;
-    const { code } = runHook(cmd, cleanRepo);
-    expect(code).toBe(0);
-  });
+    // AC-1: force-push regex skips gh issue/pr payloads
+    it("AC-1: allows gh issue create whose body references force-push", () => {
+      const cmd = `gh issue create --title "x" --body "Use git push --force only when..."`;
+      const { code } = runHook(hookPath, cmd, cleanRepo);
+      expect(code).toBe(0);
+    });
 
-  it("AC-1b: allows gh pr comment whose body references force-with-lease", () => {
-    const cmd = `gh pr comment 1 --body "see git push --force-with-lease docs"`;
-    const { code } = runHook(cmd, cleanRepo);
-    expect(code).toBe(0);
-  });
+    it("AC-1b: allows gh pr comment whose body references force-with-lease", () => {
+      const cmd = `gh pr comment 1 --body "see git push --force-with-lease docs"`;
+      const { code } = runHook(hookPath, cmd, cleanRepo);
+      expect(code).toBe(0);
+    });
 
-  // AC-2: no-changes guard skips gh issue/pr payloads
-  it("AC-2: allows gh issue comment whose body references git commit", () => {
-    const cmd = `gh issue comment 564 --body "Run git commit -m 'msg' to finish"`;
-    const { code } = runHook(cmd, cleanRepo);
-    expect(code).toBe(0);
-  });
+    // AC-2: no-changes guard skips gh issue/pr payloads
+    it("AC-2: allows gh issue comment whose body references git commit", () => {
+      const cmd = `gh issue comment 564 --body "Run git commit -m 'msg' to finish"`;
+      const { code } = runHook(hookPath, cmd, cleanRepo);
+      expect(code).toBe(0);
+    });
 
-  it("AC-2b: allows gh pr create whose body references git commit", () => {
-    const cmd = `gh pr create --title "x" --body "Squash with git commit --amend"`;
-    const { code } = runHook(cmd, cleanRepo);
-    expect(code).toBe(0);
-  });
+    it("AC-2b: allows gh pr create whose body references git commit", () => {
+      const cmd = `gh pr create --title "x" --body "Squash with git commit --amend"`;
+      const { code } = runHook(hookPath, cmd, cleanRepo);
+      expect(code).toBe(0);
+    });
 
-  // AC-3: force-push regex still blocks the actual command
-  it("AC-3: blocks real `git push --force`", () => {
-    const { code, stderr } = runHook("git push --force", cleanRepo);
-    expect(code).toBe(2);
-    expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
-  });
+    // AC-3: force-push regex still blocks the actual command
+    it("AC-3: blocks real `git push --force`", () => {
+      const { code, stderr } = runHook(hookPath, "git push --force", cleanRepo);
+      expect(code).toBe(2);
+      expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
+    });
 
-  it("AC-3b: blocks real `git push -f origin main`", () => {
-    const { code, stderr } = runHook("git push -f origin main", cleanRepo);
-    expect(code).toBe(2);
-    expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
-  });
+    it("AC-3b: blocks real `git push -f origin main`", () => {
+      const { code, stderr } = runHook(
+        hookPath,
+        "git push -f origin main",
+        cleanRepo,
+      );
+      expect(code).toBe(2);
+      expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
+    });
 
-  // AC-4: no-changes guard still blocks real `git commit` with empty staging
-  it("AC-4: blocks real `git commit -m 'msg'` with no staged changes", () => {
-    const { code, stderr } = runHook("git commit -m 'msg'", cleanRepo);
-    expect(code).toBe(2);
-    expect(stderr).toMatch(/HOOK_BLOCKED: No changes to commit/);
-  });
+    // AC-4: no-changes guard still blocks real `git commit` with empty staging
+    it("AC-4: blocks real `git commit -m 'msg'` with no staged changes", () => {
+      const { code, stderr } = runHook(
+        hookPath,
+        "git commit -m 'msg'",
+        cleanRepo,
+      );
+      expect(code).toBe(2);
+      expect(stderr).toMatch(/HOOK_BLOCKED: No changes to commit/);
+    });
 
-  it("AC-4b: still blocks real `git commit` even when other gh tokens appear later", () => {
-    // Order matters: the gh-skip is anchored to the START of TOOL_INPUT.
-    // A command starting with `git commit` should not get a free pass just
-    // because it mentions `gh issue` somewhere downstream.
-    const cmd = `git commit -m 'mention gh issue 1 in body'`;
-    const { code, stderr } = runHook(cmd, cleanRepo);
-    expect(code).toBe(2);
-    expect(stderr).toMatch(/HOOK_BLOCKED: No changes to commit/);
-  });
+    it("AC-4b: still blocks real `git commit` even when other gh tokens appear later", () => {
+      // Order matters: the gh-skip is anchored to the START of TOOL_INPUT.
+      // A command starting with `git commit` should not get a free pass just
+      // because it mentions `gh issue` somewhere downstream.
+      const cmd = `git commit -m 'mention gh issue 1 in body'`;
+      const { code, stderr } = runHook(hookPath, cmd, cleanRepo);
+      expect(code).toBe(2);
+      expect(stderr).toMatch(/HOOK_BLOCKED: No changes to commit/);
+    });
 
-  // Regression guard: the gh-skip must require the START anchor; a non-anchored
-  // mention of "gh issue" should not bypass the force-push check.
-  it("regression: `echo gh issue && git push --force` is still blocked", () => {
-    const cmd = `echo gh issue && git push --force`;
-    const { code, stderr } = runHook(cmd, cleanRepo);
-    expect(code).toBe(2);
-    expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
-  });
+    // Regression guard: the gh-skip must require the START anchor; a non-anchored
+    // mention of "gh issue" should not bypass the force-push check.
+    it("regression: `echo gh issue && git push --force` is still blocked", () => {
+      const cmd = `echo gh issue && git push --force`;
+      const { code, stderr } = runHook(hookPath, cmd, cleanRepo);
+      expect(code).toBe(2);
+      expect(stderr).toMatch(/HOOK_BLOCKED: Force push/);
+    });
 
-  // Sanity: when there ARE staged changes, the no-changes guard does not fire
-  // for a real `git commit`. (The conventional-commits validator may still
-  // block based on message format — that's a separate guard. We only assert
-  // the no-changes guard is path-correct.)
-  it("sanity: no-changes guard does not fire when changes are staged", () => {
-    const repo = mkdtempSync(join(tmpdir(), "pre-tool-test-staged-"));
-    try {
-      spawnSync("git", ["init", "-q"], { cwd: repo });
-      spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
-      spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
-      writeFileSync(join(repo, "f.txt"), "hello\n");
-      spawnSync("git", ["add", "f.txt"], { cwd: repo });
-      const { stderr } = runHook("git commit -m 'feat: x'", repo);
-      // The no-changes guard MUST NOT fire (changes are staged).
-      expect(stderr).not.toMatch(/HOOK_BLOCKED: No changes to commit/);
-    } finally {
-      rmSync(repo, { recursive: true, force: true });
-    }
-  });
-});
+    // Sanity: when there ARE staged changes, the no-changes guard does not fire
+    // for a real `git commit`. (The conventional-commits validator may still
+    // block based on message format — that's a separate guard. We only assert
+    // the no-changes guard is path-correct.)
+    it("sanity: no-changes guard does not fire when changes are staged", () => {
+      const repo = mkdtempSync(join(tmpdir(), "pre-tool-test-staged-"));
+      try {
+        spawnSync("git", ["init", "-q"], { cwd: repo });
+        spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
+        spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+        writeFileSync(join(repo, "f.txt"), "hello\n");
+        spawnSync("git", ["add", "f.txt"], { cwd: repo });
+        const { stderr } = runHook(hookPath, "git commit -m 'feat: x'", repo);
+        // The no-changes guard MUST NOT fire (changes are staged).
+        expect(stderr).not.toMatch(/HOOK_BLOCKED: No changes to commit/);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/hooks/pre-tool.sh
+++ b/hooks/pre-tool.sh
@@ -226,6 +226,7 @@ check_sensitive_files() {
 
 if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
     # Security checks for git commit
+    # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
     if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
         # Skip security checks if --no-verify is used
         if ! echo "$TOOL_INPUT" | grep -qE -- '--no-verify'; then
@@ -258,6 +259,7 @@ fi
 # --- No-Changes Guard (AC-7) ---
 # Block commits when there are no staged or unstaged changes (prevents empty commits)
 # Skips for --amend since amending doesn't require new changes
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     if ! echo "$TOOL_INPUT" | grep -qE -- '--amend|--allow-empty'; then
         # Extract target directory from cd command if present (for worktree commits)
@@ -285,6 +287,7 @@ fi
 # Warn (but don't block) when committing outside a feature worktree
 # This catches accidental commits to main repo during feature work
 QUALITY_LOG="${_LOG_DIR}/claude-quality.log"
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     CWD=$(pwd)
     if ! echo "$CWD" | grep -qE 'worktrees/feature/'; then
@@ -296,6 +299,7 @@ fi
 # --- Commit Message Validation (AC-3) ---
 # Enforce conventional commits format: type(scope): description
 # Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     # Extract message from -m flag
     MSG=""

--- a/hooks/pre-tool.sh
+++ b/hooks/pre-tool.sh
@@ -117,7 +117,8 @@ fi
 
 # Force push
 # Pattern requires -f to be a standalone flag (not part of branch name like -fix)
-if echo "$TOOL_INPUT" | grep -qE 'git push.*(--force| -f($| ))'; then
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
+if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git push.*(--force| -f($| ))'; then
     echo "HOOK_BLOCKED: Force push" | tee -a "$HOOK_LOG" >&2
     exit 2
 fi
@@ -225,7 +226,7 @@ check_sensitive_files() {
 
 if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
     # Security checks for git commit
-    if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+    if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
         # Skip security checks if --no-verify is used
         if ! echo "$TOOL_INPUT" | grep -qE -- '--no-verify'; then
             # Check staged files for secrets
@@ -257,7 +258,7 @@ fi
 # --- No-Changes Guard (AC-7) ---
 # Block commits when there are no staged or unstaged changes (prevents empty commits)
 # Skips for --amend since amending doesn't require new changes
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     if ! echo "$TOOL_INPUT" | grep -qE -- '--amend|--allow-empty'; then
         # Extract target directory from cd command if present (for worktree commits)
         # Handles: "cd /path && git commit" or "cd /path; git commit"
@@ -284,7 +285,7 @@ fi
 # Warn (but don't block) when committing outside a feature worktree
 # This catches accidental commits to main repo during feature work
 QUALITY_LOG="${_LOG_DIR}/claude-quality.log"
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     CWD=$(pwd)
     if ! echo "$CWD" | grep -qE 'worktrees/feature/'; then
         echo "$(date +%H:%M:%S) WORKTREE_WARNING: Committing outside feature worktree ($CWD)" >> "$QUALITY_LOG"
@@ -295,7 +296,7 @@ fi
 # --- Commit Message Validation (AC-3) ---
 # Enforce conventional commits format: type(scope): description
 # Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     # Extract message from -m flag
     MSG=""
 

--- a/templates/hooks/pre-tool.sh
+++ b/templates/hooks/pre-tool.sh
@@ -226,6 +226,7 @@ check_sensitive_files() {
 
 if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
     # Security checks for git commit
+    # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
     if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
         # Skip security checks if --no-verify is used
         if ! echo "$TOOL_INPUT" | grep -qE -- '--no-verify'; then
@@ -258,6 +259,7 @@ fi
 # --- No-Changes Guard (AC-7) ---
 # Block commits when there are no staged or unstaged changes (prevents empty commits)
 # Skips for --amend since amending doesn't require new changes
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     if ! echo "$TOOL_INPUT" | grep -qE -- '--amend|--allow-empty'; then
         # Extract target directory from cd command if present (for worktree commits)
@@ -285,6 +287,7 @@ fi
 # Warn (but don't block) when committing outside a feature worktree
 # This catches accidental commits to main repo during feature work
 QUALITY_LOG="${_LOG_DIR}/claude-quality.log"
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     CWD=$(pwd)
     if ! echo "$CWD" | grep -qE 'worktrees/feature/'; then
@@ -296,6 +299,7 @@ fi
 # --- Commit Message Validation (AC-3) ---
 # Enforce conventional commits format: type(scope): description
 # Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     # Extract message from -m flag
     MSG=""

--- a/templates/hooks/pre-tool.sh
+++ b/templates/hooks/pre-tool.sh
@@ -117,7 +117,8 @@ fi
 
 # Force push
 # Pattern requires -f to be a standalone flag (not part of branch name like -fix)
-if echo "$TOOL_INPUT" | grep -qE 'git push.*(--force| -f($| ))'; then
+# Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
+if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git push.*(--force| -f($| ))'; then
     echo "HOOK_BLOCKED: Force push" | tee -a "$HOOK_LOG" >&2
     exit 2
 fi
@@ -225,7 +226,7 @@ check_sensitive_files() {
 
 if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
     # Security checks for git commit
-    if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+    if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
         # Skip security checks if --no-verify is used
         if ! echo "$TOOL_INPUT" | grep -qE -- '--no-verify'; then
             # Check staged files for secrets
@@ -257,7 +258,7 @@ fi
 # --- No-Changes Guard (AC-7) ---
 # Block commits when there are no staged or unstaged changes (prevents empty commits)
 # Skips for --amend since amending doesn't require new changes
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     if ! echo "$TOOL_INPUT" | grep -qE -- '--amend|--allow-empty'; then
         # Extract target directory from cd command if present (for worktree commits)
         # Handles: "cd /path && git commit" or "cd /path; git commit"
@@ -284,7 +285,7 @@ fi
 # Warn (but don't block) when committing outside a feature worktree
 # This catches accidental commits to main repo during feature work
 QUALITY_LOG="${_LOG_DIR}/claude-quality.log"
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     CWD=$(pwd)
     if ! echo "$CWD" | grep -qE 'worktrees/feature/'; then
         echo "$(date +%H:%M:%S) WORKTREE_WARNING: Committing outside feature worktree ($CWD)" >> "$QUALITY_LOG"
@@ -295,7 +296,7 @@ fi
 # --- Commit Message Validation (AC-3) ---
 # Enforce conventional commits format: type(scope): description
 # Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
+if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     # Extract message from -m flag
     MSG=""
 


### PR DESCRIPTION
## Summary

Fixes the `pre-tool.sh` regexes that match inside quoted `gh issue/pr` body content, blocking tool calls whose payloads merely *reference* the matched literals (e.g. a doc explaining the hook itself).

- **Fix:** wraps the force-push regex (line 120 of canonical) and **all four** `git commit` regex sites (security checks, no-changes guard, worktree warning, conventional-commits validator) behind the same `^gh (issue|pr) ` exclusion that already guarded the secrets/credentials checks at line 87.
- **Mirrored** across all three hook copies — `templates/hooks/pre-tool.sh`, `hooks/pre-tool.sh`, `.claude/hooks/pre-tool.sh` — none of which are symlinks.
- **Tests:** new `__tests__/pre-tool-hook.integration.test.ts` (10 cases) spawns the canonical hook with real stdin/exit-code assertions; AC-4 uses an isolated tmp git repo so "no staged changes" is deterministic.

## AC Coverage

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | Implemented | force-push regex now gated by `^gh (issue|pr) ` exclusion (3 files, line 120/108) — tests `AC-1`, `AC-1b` |
| AC-2 | Implemented | no-changes guard now gated similarly (3 files, line 261/249) — tests `AC-2`, `AC-2b` |
| AC-3 | Implemented | regression test `AC-3` blocks `git push --force`, `AC-3b` blocks `git push -f origin main` |
| AC-4 | Implemented | regression test `AC-4` blocks `git commit -m 'msg'` with no staged changes; `AC-4b` confirms anchor is at start of TOOL_INPUT |
| AC-5 | Implemented | `__tests__/pre-tool-hook.integration.test.ts` — 10 passing cases (4 primary AC pairs + 4 sub-cases + 1 anchor regression + 1 sanity) |
| AC-6 | Implemented | CHANGELOG entry under `[Unreleased] / ### Fixed` references #564 and #532 |

## Scope Note (broader than literal AC text)

The issue's AC-2 names line 248 (no-changes guard) of `.claude/hooks/pre-tool.sh` specifically. The same `grep -qE 'git commit'` regex appears at four places in the canonical `templates/hooks/pre-tool.sh` (security-checks/L228, no-changes/L260, worktree-warning/L287, commit-msg-validation/L298). All four share the same root cause and the same body-content false-positive surface, so the exclusion is applied at all four sites.

Per the spec comment's Open Questions, this is the recommended interpretation of the issue's intent. The `Non-Goals` carve-out ("Don't widen exclusion beyond `gh issue|pr`") refers to not adding exclusions for *other parent commands*, not to under-applying the same exclusion to all instances of the same regex.

## Live reproduction during /spec

Both bugs reproduced live during planning (read-only `grep` inspection of the hook source tripped both regexes), and the heredoc that produced the spec body was itself blocked — it was rewritten via the Write tool instead. Validates the issue without needing synthetic fixtures.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npx vitest run __tests__/pre-tool-hook.integration.test.ts` — 10/10 passing
- [x] `bash -n` syntax check on all 3 hook copies — passes
- [x] Diff of `hooks/pre-tool.sh` vs `templates/hooks/pre-tool.sh` — identical (mirroring preserved)

## Known gaps / out of scope

- `.claude/hooks/pre-tool.sh` has drifted from `templates/hooks/pre-tool.sh` (older byte-count: 17896 vs 18509). This PR fixes the regexes in all three copies but does not re-sync the broader drift — that's a separate hygiene issue.
- The new test file is named `*.integration.test.ts` so it runs in the integration project (subprocess-heavy tests).

Closes #564
