### PR TITLE
feat(#587): /qa §4 Q5 intra-file sibling-site audit + cross-file §5 reframe

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1924,7 +1924,7 @@ echo "$issue_body" | grep -E '\*\*(Verify|Verbatim|Example|AC verification):\*\*
 | 1 | **Verbatim fixtures** | Run the implementation against EVERY verbatim motivating-example string from the issue body (fenced code blocks, blockquotes, `**Verify:**` / `**Example:**` / `**Repro:**` snippets, `## Repro pattern` sections). Per `feedback_motivating_example_regression.md`, this rule applies to **any** change with motivating-example payload — not only the skill-markdown changes that trigger Section 6c. |
 | 2 | **Evidence framing** | For every "evidence" claim in the QA output (Execution Evidence, self-dogfood notes, smoke tests), check: is it a pre-fix bug reproduction or a post-fix validation? Conflating the two overstates the rigor of the QA. |
 | 3 | **Process state** | Inspect uncommitted work, divergent branches, stashed changes, and any orchestrator state (worktree, phase markers) the structured pipeline normalizes away. The pipeline reads HEAD; the truth is sometimes in the working tree. |
-| 4 | **Sibling sites** | Already covered by Section 5's Sibling-site Scan when applicable. If that scan was Skipped/N/A, briefly justify why no sibling site exists (e.g. "single-pattern file" / "test-only diff"). Do not hand-wave; cite. |
+| 4 | **Sibling sites** | Cross-file siblings: covered by Section 5's Sibling-site Scan when applicable. Intra-file siblings: covered by Section 4 Q5's audit. If both are Skipped/N/A, briefly justify why no sibling site exists (e.g. "no cross-file siblings + single-call-site fix" / "test-only diff"). Do not hand-wave; cite. |
 | 5 | **Out-of-scope but adjacent** | What does the issue body call out as Non-Goals or "left out"? Has any of it become in-scope due to the implementation choices made? Surface explicitly; do not silently expand or silently leave out. |
 
 **Status outcomes:**
@@ -1953,7 +1953,7 @@ echo "$issue_body" | grep -E '\*\*(Verify|Verbatim|Example|AC verification):\*\*
 | 1 | Verbatim fixtures | [List fixtures run, OR "No motivating-example payload in issue body" with citation] |
 | 2 | Evidence framing | [Specific check, OR "No evidence claims to verify"] |
 | 3 | Process state | [What was inspected; clean or noted] |
-| 4 | Sibling sites | [Reference Section 5's scan, OR justify N/A] |
+| 4 | Sibling sites | [Reference Section 5's cross-file scan + Section 4 Q5's intra-file audit, OR justify N/A] |
 | 5 | Out-of-scope/Non-Goals | [Explicit answer, OR "No Non-Goals listed in issue"] |
 
 **Findings:** [Concrete enumeration of gaps surfaced, OR "No gaps found because: <specific reason citing what was scanned/run/traced>"]
@@ -2884,7 +2884,7 @@ You MUST include these sections:
 | 1 | Verbatim fixtures | [List fixtures run, OR "No motivating-example payload in issue body" with citation] |
 | 2 | Evidence framing | [Specific check, OR "No evidence claims to verify"] |
 | 3 | Process state | [What was inspected; clean or noted] |
-| 4 | Sibling sites | [Reference Section 5's scan, OR justify N/A] |
+| 4 | Sibling sites | [Reference Section 5's cross-file scan + Section 4 Q5's intra-file audit, OR justify N/A] |
 | 5 | Out-of-scope/Non-Goals | [Explicit answer, OR "No Non-Goals listed in issue"] |
 
 **Findings:** [Concrete enumeration of gaps surfaced, OR "No gaps found because: <specific reason citing what was scanned/run/traced>"]

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1459,6 +1459,7 @@ Before any READY_FOR_MERGE verdict, complete the adversarial thinking checklist:
 2. **"What assumptions am I making?"** - List and validate key assumptions
 3. **"What's the unhappy path?"** - Test invalid inputs, failed dependencies
 4. **"Did I test the feature's PRIMARY PURPOSE?"** - If it handles errors, trigger an error
+5. **"Does the same root-cause pattern exist at sibling sites in this file?"** - The literal repro from the issue body is necessary but not sufficient. After the cited bug is fixed, audit other call sites in the same file (and same function/loop) that share the root-cause pattern. Example: if a destructive operation invalidates a resource that subsequent code depends on, scan for other destructive operations on that resource type in the same function/loop; if a wrong null-check is the bug, scan for the same access pattern elsewhere. **Complementary to Section 5's cross-file sibling-site scan: §4's question is intra-file (other lines/functions in the same file with the same root cause); §5 is cross-file (other files in the codebase with the same vulnerability).**
 
 See [testing-requirements.md](references/testing-requirements.md) for edge case checklists.
 
@@ -1473,20 +1474,21 @@ See [testing-requirements.md](references/testing-requirements.md) for edge case 
 
 - **Likely failure mode:** [How would this break in production? Be specific.]
 - **Not tested:** [What gaps exist in test coverage for these changes?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 ```
 
 **If either field reveals significant concerns**, factor them into your verdict. A serious failure mode with no test coverage should downgrade to `AC_MET_BUT_NOT_A_PLUS` or `AC_NOT_MET`.
 
 #### Sibling-site Scan (Conditional)
 
-**When to apply:** Focused AC + a localized fix in a multi-pattern file (≥3 instances of the affected pattern in the same file — e.g. the regex blocks in `pre-tool.sh`). Same root cause likely repeats elsewhere in the file/module.
+**When to apply:** Focused AC + a localized fix where the same root-cause pattern likely exists in other files in the codebase (≥3 occurrences of the affected pattern across files — e.g. regex blocks repeated across multiple hook scripts). Intra-file sibling sites are covered by §4 Q5; this scan is the cross-file complement.
 
-**Before declaring AC met**, scan the same file/module for sibling code with the same pattern as the bug being fixed. If sibling sites would exhibit the same root cause but weren't part of the literal AC, surface them in the verdict's `Sibling sites considered:` slot — as expanded scope (only when trivial) or follow-up issue suggestion. **Don't widen scope mid-PR; file a follow-up issue instead.** Sibling sites alone do not produce `NEEDS_VERIFICATION`; that verdict is reserved for external/temporal gates (CI pending, manual-test ACs unexecuted).
+**Before declaring AC met**, scan other files in the codebase for sibling code with the same pattern as the bug being fixed. If sibling sites would exhibit the same root cause but weren't part of the literal AC, surface them in the verdict's `Sibling sites considered:` slot — as expanded scope (only when trivial) or follow-up issue suggestion. **Don't widen scope mid-PR; file a follow-up issue instead.** Sibling sites alone do not produce `NEEDS_VERIFICATION`; that verdict is reserved for external/temporal gates (CI pending, manual-test ACs unexecuted).
 
 **Scope:** orchestrator/inline-review only — `sequant-qa-checker` sub-agents are not asked to do this scan; the orchestrator owns it during verdict synthesis.
 
-This operationalizes the principle in `feedback_qa_second_look.md` (structured QA biases positive on clean code; an adversarial re-read of core logic surfaces real gaps). Don't automate via grep — false-positive risk; this is a "look at the same file" prompt.
+This operationalizes the principle in `feedback_qa_second_look.md` (structured QA biases positive on clean code; an adversarial re-read of core logic surfaces real gaps). Don't automate via grep — false-positive risk; this is a "look at adjacent files" prompt.
 
 #### Skill Change Review (Conditional)
 
@@ -2548,7 +2550,8 @@ When the size gate triggers simple fix mode, use this shorter template:
 
 - **Likely failure mode:** [How would this break in production?]
 - **Not tested:** [What gaps exist in test coverage?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 
 ---
 
@@ -2869,7 +2872,8 @@ You MUST include these sections:
 
 - **Likely failure mode:** [How would this break in production? Be specific.]
 - **Not tested:** [What gaps exist in test coverage for these changes?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 
 ---
 

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -1924,7 +1924,7 @@ echo "$issue_body" | grep -E '\*\*(Verify|Verbatim|Example|AC verification):\*\*
 | 1 | **Verbatim fixtures** | Run the implementation against EVERY verbatim motivating-example string from the issue body (fenced code blocks, blockquotes, `**Verify:**` / `**Example:**` / `**Repro:**` snippets, `## Repro pattern` sections). Per `feedback_motivating_example_regression.md`, this rule applies to **any** change with motivating-example payload — not only the skill-markdown changes that trigger Section 6c. |
 | 2 | **Evidence framing** | For every "evidence" claim in the QA output (Execution Evidence, self-dogfood notes, smoke tests), check: is it a pre-fix bug reproduction or a post-fix validation? Conflating the two overstates the rigor of the QA. |
 | 3 | **Process state** | Inspect uncommitted work, divergent branches, stashed changes, and any orchestrator state (worktree, phase markers) the structured pipeline normalizes away. The pipeline reads HEAD; the truth is sometimes in the working tree. |
-| 4 | **Sibling sites** | Already covered by Section 5's Sibling-site Scan when applicable. If that scan was Skipped/N/A, briefly justify why no sibling site exists (e.g. "single-pattern file" / "test-only diff"). Do not hand-wave; cite. |
+| 4 | **Sibling sites** | Cross-file siblings: covered by Section 5's Sibling-site Scan when applicable. Intra-file siblings: covered by Section 4 Q5's audit. If both are Skipped/N/A, briefly justify why no sibling site exists (e.g. "no cross-file siblings + single-call-site fix" / "test-only diff"). Do not hand-wave; cite. |
 | 5 | **Out-of-scope but adjacent** | What does the issue body call out as Non-Goals or "left out"? Has any of it become in-scope due to the implementation choices made? Surface explicitly; do not silently expand or silently leave out. |
 
 **Status outcomes:**
@@ -1953,7 +1953,7 @@ echo "$issue_body" | grep -E '\*\*(Verify|Verbatim|Example|AC verification):\*\*
 | 1 | Verbatim fixtures | [List fixtures run, OR "No motivating-example payload in issue body" with citation] |
 | 2 | Evidence framing | [Specific check, OR "No evidence claims to verify"] |
 | 3 | Process state | [What was inspected; clean or noted] |
-| 4 | Sibling sites | [Reference Section 5's scan, OR justify N/A] |
+| 4 | Sibling sites | [Reference Section 5's cross-file scan + Section 4 Q5's intra-file audit, OR justify N/A] |
 | 5 | Out-of-scope/Non-Goals | [Explicit answer, OR "No Non-Goals listed in issue"] |
 
 **Findings:** [Concrete enumeration of gaps surfaced, OR "No gaps found because: <specific reason citing what was scanned/run/traced>"]
@@ -2884,7 +2884,7 @@ You MUST include these sections:
 | 1 | Verbatim fixtures | [List fixtures run, OR "No motivating-example payload in issue body" with citation] |
 | 2 | Evidence framing | [Specific check, OR "No evidence claims to verify"] |
 | 3 | Process state | [What was inspected; clean or noted] |
-| 4 | Sibling sites | [Reference Section 5's scan, OR justify N/A] |
+| 4 | Sibling sites | [Reference Section 5's cross-file scan + Section 4 Q5's intra-file audit, OR justify N/A] |
 | 5 | Out-of-scope/Non-Goals | [Explicit answer, OR "No Non-Goals listed in issue"] |
 
 **Findings:** [Concrete enumeration of gaps surfaced, OR "No gaps found because: <specific reason citing what was scanned/run/traced>"]

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -1459,6 +1459,7 @@ Before any READY_FOR_MERGE verdict, complete the adversarial thinking checklist:
 2. **"What assumptions am I making?"** - List and validate key assumptions
 3. **"What's the unhappy path?"** - Test invalid inputs, failed dependencies
 4. **"Did I test the feature's PRIMARY PURPOSE?"** - If it handles errors, trigger an error
+5. **"Does the same root-cause pattern exist at sibling sites in this file?"** - The literal repro from the issue body is necessary but not sufficient. After the cited bug is fixed, audit other call sites in the same file (and same function/loop) that share the root-cause pattern. Example: if a destructive operation invalidates a resource that subsequent code depends on, scan for other destructive operations on that resource type in the same function/loop; if a wrong null-check is the bug, scan for the same access pattern elsewhere. **Complementary to Section 5's cross-file sibling-site scan: §4's question is intra-file (other lines/functions in the same file with the same root cause); §5 is cross-file (other files in the codebase with the same vulnerability).**
 
 See [testing-requirements.md](references/testing-requirements.md) for edge case checklists.
 
@@ -1473,20 +1474,21 @@ See [testing-requirements.md](references/testing-requirements.md) for edge case 
 
 - **Likely failure mode:** [How would this break in production? Be specific.]
 - **Not tested:** [What gaps exist in test coverage for these changes?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 ```
 
 **If either field reveals significant concerns**, factor them into your verdict. A serious failure mode with no test coverage should downgrade to `AC_MET_BUT_NOT_A_PLUS` or `AC_NOT_MET`.
 
 #### Sibling-site Scan (Conditional)
 
-**When to apply:** Focused AC + a localized fix in a multi-pattern file (≥3 instances of the affected pattern in the same file — e.g. the regex blocks in `pre-tool.sh`). Same root cause likely repeats elsewhere in the file/module.
+**When to apply:** Focused AC + a localized fix where the same root-cause pattern likely exists in other files in the codebase (≥3 occurrences of the affected pattern across files — e.g. regex blocks repeated across multiple hook scripts). Intra-file sibling sites are covered by §4 Q5; this scan is the cross-file complement.
 
-**Before declaring AC met**, scan the same file/module for sibling code with the same pattern as the bug being fixed. If sibling sites would exhibit the same root cause but weren't part of the literal AC, surface them in the verdict's `Sibling sites considered:` slot — as expanded scope (only when trivial) or follow-up issue suggestion. **Don't widen scope mid-PR; file a follow-up issue instead.** Sibling sites alone do not produce `NEEDS_VERIFICATION`; that verdict is reserved for external/temporal gates (CI pending, manual-test ACs unexecuted).
+**Before declaring AC met**, scan other files in the codebase for sibling code with the same pattern as the bug being fixed. If sibling sites would exhibit the same root cause but weren't part of the literal AC, surface them in the verdict's `Sibling sites considered:` slot — as expanded scope (only when trivial) or follow-up issue suggestion. **Don't widen scope mid-PR; file a follow-up issue instead.** Sibling sites alone do not produce `NEEDS_VERIFICATION`; that verdict is reserved for external/temporal gates (CI pending, manual-test ACs unexecuted).
 
 **Scope:** orchestrator/inline-review only — `sequant-qa-checker` sub-agents are not asked to do this scan; the orchestrator owns it during verdict synthesis.
 
-This operationalizes the principle in `feedback_qa_second_look.md` (structured QA biases positive on clean code; an adversarial re-read of core logic surfaces real gaps). Don't automate via grep — false-positive risk; this is a "look at the same file" prompt.
+This operationalizes the principle in `feedback_qa_second_look.md` (structured QA biases positive on clean code; an adversarial re-read of core logic surfaces real gaps). Don't automate via grep — false-positive risk; this is a "look at adjacent files" prompt.
 
 #### Skill Change Review (Conditional)
 
@@ -2548,7 +2550,8 @@ When the size gate triggers simple fix mode, use this shorter template:
 
 - **Likely failure mode:** [How would this break in production?]
 - **Not tested:** [What gaps exist in test coverage?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 
 ---
 
@@ -2869,7 +2872,8 @@ You MUST include these sections:
 
 - **Likely failure mode:** [How would this break in production? Be specific.]
 - **Not tested:** [What gaps exist in test coverage for these changes?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 
 ---
 

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -1924,7 +1924,7 @@ echo "$issue_body" | grep -E '\*\*(Verify|Verbatim|Example|AC verification):\*\*
 | 1 | **Verbatim fixtures** | Run the implementation against EVERY verbatim motivating-example string from the issue body (fenced code blocks, blockquotes, `**Verify:**` / `**Example:**` / `**Repro:**` snippets, `## Repro pattern` sections). Per `feedback_motivating_example_regression.md`, this rule applies to **any** change with motivating-example payload — not only the skill-markdown changes that trigger Section 6c. |
 | 2 | **Evidence framing** | For every "evidence" claim in the QA output (Execution Evidence, self-dogfood notes, smoke tests), check: is it a pre-fix bug reproduction or a post-fix validation? Conflating the two overstates the rigor of the QA. |
 | 3 | **Process state** | Inspect uncommitted work, divergent branches, stashed changes, and any orchestrator state (worktree, phase markers) the structured pipeline normalizes away. The pipeline reads HEAD; the truth is sometimes in the working tree. |
-| 4 | **Sibling sites** | Already covered by Section 5's Sibling-site Scan when applicable. If that scan was Skipped/N/A, briefly justify why no sibling site exists (e.g. "single-pattern file" / "test-only diff"). Do not hand-wave; cite. |
+| 4 | **Sibling sites** | Cross-file siblings: covered by Section 5's Sibling-site Scan when applicable. Intra-file siblings: covered by Section 4 Q5's audit. If both are Skipped/N/A, briefly justify why no sibling site exists (e.g. "no cross-file siblings + single-call-site fix" / "test-only diff"). Do not hand-wave; cite. |
 | 5 | **Out-of-scope but adjacent** | What does the issue body call out as Non-Goals or "left out"? Has any of it become in-scope due to the implementation choices made? Surface explicitly; do not silently expand or silently leave out. |
 
 **Status outcomes:**
@@ -1953,7 +1953,7 @@ echo "$issue_body" | grep -E '\*\*(Verify|Verbatim|Example|AC verification):\*\*
 | 1 | Verbatim fixtures | [List fixtures run, OR "No motivating-example payload in issue body" with citation] |
 | 2 | Evidence framing | [Specific check, OR "No evidence claims to verify"] |
 | 3 | Process state | [What was inspected; clean or noted] |
-| 4 | Sibling sites | [Reference Section 5's scan, OR justify N/A] |
+| 4 | Sibling sites | [Reference Section 5's cross-file scan + Section 4 Q5's intra-file audit, OR justify N/A] |
 | 5 | Out-of-scope/Non-Goals | [Explicit answer, OR "No Non-Goals listed in issue"] |
 
 **Findings:** [Concrete enumeration of gaps surfaced, OR "No gaps found because: <specific reason citing what was scanned/run/traced>"]
@@ -2884,7 +2884,7 @@ You MUST include these sections:
 | 1 | Verbatim fixtures | [List fixtures run, OR "No motivating-example payload in issue body" with citation] |
 | 2 | Evidence framing | [Specific check, OR "No evidence claims to verify"] |
 | 3 | Process state | [What was inspected; clean or noted] |
-| 4 | Sibling sites | [Reference Section 5's scan, OR justify N/A] |
+| 4 | Sibling sites | [Reference Section 5's cross-file scan + Section 4 Q5's intra-file audit, OR justify N/A] |
 | 5 | Out-of-scope/Non-Goals | [Explicit answer, OR "No Non-Goals listed in issue"] |
 
 **Findings:** [Concrete enumeration of gaps surfaced, OR "No gaps found because: <specific reason citing what was scanned/run/traced>"]

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -1459,6 +1459,7 @@ Before any READY_FOR_MERGE verdict, complete the adversarial thinking checklist:
 2. **"What assumptions am I making?"** - List and validate key assumptions
 3. **"What's the unhappy path?"** - Test invalid inputs, failed dependencies
 4. **"Did I test the feature's PRIMARY PURPOSE?"** - If it handles errors, trigger an error
+5. **"Does the same root-cause pattern exist at sibling sites in this file?"** - The literal repro from the issue body is necessary but not sufficient. After the cited bug is fixed, audit other call sites in the same file (and same function/loop) that share the root-cause pattern. Example: if a destructive operation invalidates a resource that subsequent code depends on, scan for other destructive operations on that resource type in the same function/loop; if a wrong null-check is the bug, scan for the same access pattern elsewhere. **Complementary to Section 5's cross-file sibling-site scan: §4's question is intra-file (other lines/functions in the same file with the same root cause); §5 is cross-file (other files in the codebase with the same vulnerability).**
 
 See [testing-requirements.md](references/testing-requirements.md) for edge case checklists.
 
@@ -1473,20 +1474,21 @@ See [testing-requirements.md](references/testing-requirements.md) for edge case 
 
 - **Likely failure mode:** [How would this break in production? Be specific.]
 - **Not tested:** [What gaps exist in test coverage for these changes?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 ```
 
 **If either field reveals significant concerns**, factor them into your verdict. A serious failure mode with no test coverage should downgrade to `AC_MET_BUT_NOT_A_PLUS` or `AC_NOT_MET`.
 
 #### Sibling-site Scan (Conditional)
 
-**When to apply:** Focused AC + a localized fix in a multi-pattern file (≥3 instances of the affected pattern in the same file — e.g. the regex blocks in `pre-tool.sh`). Same root cause likely repeats elsewhere in the file/module.
+**When to apply:** Focused AC + a localized fix where the same root-cause pattern likely exists in other files in the codebase (≥3 occurrences of the affected pattern across files — e.g. regex blocks repeated across multiple hook scripts). Intra-file sibling sites are covered by §4 Q5; this scan is the cross-file complement.
 
-**Before declaring AC met**, scan the same file/module for sibling code with the same pattern as the bug being fixed. If sibling sites would exhibit the same root cause but weren't part of the literal AC, surface them in the verdict's `Sibling sites considered:` slot — as expanded scope (only when trivial) or follow-up issue suggestion. **Don't widen scope mid-PR; file a follow-up issue instead.** Sibling sites alone do not produce `NEEDS_VERIFICATION`; that verdict is reserved for external/temporal gates (CI pending, manual-test ACs unexecuted).
+**Before declaring AC met**, scan other files in the codebase for sibling code with the same pattern as the bug being fixed. If sibling sites would exhibit the same root cause but weren't part of the literal AC, surface them in the verdict's `Sibling sites considered:` slot — as expanded scope (only when trivial) or follow-up issue suggestion. **Don't widen scope mid-PR; file a follow-up issue instead.** Sibling sites alone do not produce `NEEDS_VERIFICATION`; that verdict is reserved for external/temporal gates (CI pending, manual-test ACs unexecuted).
 
 **Scope:** orchestrator/inline-review only — `sequant-qa-checker` sub-agents are not asked to do this scan; the orchestrator owns it during verdict synthesis.
 
-This operationalizes the principle in `feedback_qa_second_look.md` (structured QA biases positive on clean code; an adversarial re-read of core logic surfaces real gaps). Don't automate via grep — false-positive risk; this is a "look at the same file" prompt.
+This operationalizes the principle in `feedback_qa_second_look.md` (structured QA biases positive on clean code; an adversarial re-read of core logic surfaces real gaps). Don't automate via grep — false-positive risk; this is a "look at adjacent files" prompt.
 
 #### Skill Change Review (Conditional)
 
@@ -2548,7 +2550,8 @@ When the size gate triggers simple fix mode, use this shorter template:
 
 - **Likely failure mode:** [How would this break in production?]
 - **Not tested:** [What gaps exist in test coverage?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 
 ---
 
@@ -2869,7 +2872,8 @@ You MUST include these sections:
 
 - **Likely failure mode:** [How would this break in production? Be specific.]
 - **Not tested:** [What gaps exist in test coverage for these changes?]
-- **Sibling sites considered:** [List sibling code in the same file/module with the same root cause, or "none — single-pattern file" / "N/A — sibling-site scan does not apply"]
+- **Sibling sites considered:** [List sibling code in other files in the codebase with the same root cause, or "none — no cross-file siblings" / "N/A — cross-file sibling-site scan does not apply"]
+- **Sibling-line audit:** [Adjacent call sites in the same file/function audited with the same root-cause pattern, OR "none — single-call-site fix"]
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a fifth question to `/qa` §4 (Failure Path & Edge Case Testing) prompting reviewers to audit **other call sites in the same file/function** that share the bug's root-cause pattern. Catches the class of bug PR #579 round-1 missed.
- Reframes §5 Sibling-site Scan as the **cross-file** complement (was intra-file-leaning) so §4 and §5 cover the full sibling-site vulnerability class without overlap.
- Adds a `**Sibling-line audit:**` bullet to all three Risk Assessment output templates so skipping the audit is visibly absent from the verdict.

## AC Coverage

| AC | Status | Evidence |
|----|--------|----------|
| AC-1: §4 fifth question, language-neutral example | ✅ | `templates/skills/qa/SKILL.md:1462` |
| AC-2: Distinguishes §4 (intra-file) from §5 (cross-file) | ✅ | §4 Q5 cross-ref + §5 prose reframed (`templates/skills/qa/SKILL.md:1485,1487`) |
| AC-3: Mirrored across all three `qa/SKILL.md` | ✅ | `diff -q` between all three pairs is clean |
| AC-4: `**Sibling-line audit:**` bullet in 3 Risk Assessment instances | ✅ | grep returns 3 hits per file (9 total) |

## Notes

- **§4-vs-§5 framing:** Implemented spec's recommended Option A — reframed §5 prose ("same file/module" → "other files in the codebase") so §4 Q5 owns intra-file. Existing "Sibling sites considered:" bullet description updated for internal consistency.
- **Not a verdict-blocker:** Visible-absence in the template is the lever, matching §5 Scan's stance. Verdict algorithm unchanged.
- **Cost:** ~30s additional review time per PR. Worth it for the bug class it catches.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (117 files / 2819 tests)
- [x] `npm run validate:skills` — `qa/` skill validates clean
- [x] Mirror parity verified (`diff -q` between all three SKILL.md files)
- [x] AC-4 grep returns 3 hits per file
- [ ] Self-dogfood: run §4 Q5 mentally against PR #579's exec-agents loop (deferred to /qa)

Closes #587