### PR TITLE
fix(#633): eliminate locks-cli takeover test flake via cross-host sentinel

### DIFF
--- a/src/commands/__tests__/locks-cli.integration.test.ts
+++ b/src/commands/__tests__/locks-cli.integration.test.ts
@@ -178,11 +178,18 @@ describe("sequant locks acquire --force --signal-other --skip-pid-check (skill t
   it("takes over an existing skill-shell lock; signal-other prints 'Could not signal' for dead PID", () => {
     // Pre-write a skill lock as if a prior /fullsolve had acquired it and
     // its shell already exited (the canonical skipPidCheck scenario).
+    //
+    // The hostname is intentionally a sentinel non-host string so
+    // signalOther's cross-host short-circuit (lock-manager.ts:289) returns
+    // false WITHOUT invoking process.kill on PID 9999. Previously this used
+    // os.hostname() with pid: 9999, which assumed PID 9999 was dead — on a
+    // busy CI runner PID 9999 can be a live sibling/ancestor process, and
+    // SIGTERMing it killed the CLI mid-spawn → result.status === null (#633).
     writeFileSync(
       join(locksDir, "77.lock"),
       JSON.stringify({
-        pid: 9999, // long-dead PID
-        hostname: require("os").hostname(),
+        pid: 9999,
+        hostname: "definitely-not-this-host",
         startedAt: new Date().toISOString(),
         command: "/fullsolve 77 (prior)",
         skipPidCheck: true,
@@ -212,11 +219,13 @@ describe("sequant locks acquire --force --signal-other --skip-pid-check (skill t
   });
 
   it("--force without --signal-other does NOT print the signal line", () => {
+    // Same sentinel-hostname pattern as the sibling test above (#633), so a
+    // future edit that adds --signal-other here can't regress the flake.
     writeFileSync(
       join(locksDir, "88.lock"),
       JSON.stringify({
         pid: 9999,
-        hostname: require("os").hostname(),
+        hostname: "definitely-not-this-host",
         startedAt: new Date().toISOString(),
         command: "old",
         skipPidCheck: true,

--- a/src/commands/__tests__/locks-cli.integration.test.ts
+++ b/src/commands/__tests__/locks-cli.integration.test.ts
@@ -175,7 +175,7 @@ describe("sequant locks check-batch", () => {
 });
 
 describe("sequant locks acquire --force --signal-other --skip-pid-check (skill takeover)", () => {
-  it("takes over an existing skill-shell lock; signal-other prints 'Could not signal' for dead PID", () => {
+  it("takes over an existing skill-shell lock; signal-other prints 'Could not signal' for cross-host holder", () => {
     // Pre-write a skill lock as if a prior /fullsolve had acquired it and
     // its shell already exited (the canonical skipPidCheck scenario).
     //
@@ -185,6 +185,13 @@ describe("sequant locks acquire --force --signal-other --skip-pid-check (skill t
     // os.hostname() with pid: 9999, which assumed PID 9999 was dead — on a
     // busy CI runner PID 9999 can be a live sibling/ancestor process, and
     // SIGTERMing it killed the CLI mid-spawn → result.status === null (#633).
+    //
+    // The CLI prints the same `(cross-host or already exited)` suffix for
+    // both false-branches of signalOther (cross-host vs same-host-dead-PID),
+    // so the assertion below verifies the not-sent path but cannot
+    // distinguish which internal branch ran — that's a CLI-message-level
+    // limitation. The same-host-dead-PID branch is unit-tested at
+    // lock-manager.test.ts:294 via the isPidAlive constructor seam.
     writeFileSync(
       join(locksDir, "77.lock"),
       JSON.stringify({
@@ -207,8 +214,12 @@ describe("sequant locks acquire --force --signal-other --skip-pid-check (skill t
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("✓ Acquired lock for #77 (forced)");
-    // signal-other should report inability to signal a dead PID.
-    expect(result.stdout).toMatch(/Could not signal PID 9999 for #77/);
+    // signal-other should report inability to signal — anchored on the full
+    // "(cross-host or already exited)" suffix so a future refactor that
+    // accidentally takes the "Signaled ..." (sent) branch would fail loudly.
+    expect(result.stdout).toMatch(
+      /Could not signal PID 9999 for #77 \(cross-host or already exited\)/,
+    );
 
     // The lock file now reflects the new acquirer with the new command label
     // and skipPidCheck still set (we passed --skip-pid-check).


### PR DESCRIPTION
## Summary

- Replace `hostname: os.hostname()` in the `--signal-other` takeover fixture (and its sibling fixture) with a sentinel non-host string so `LockManager.signalOther` takes the cross-host short-circuit (`src/lib/locks/lock-manager.ts:289`) and never invokes `process.kill(9999, 'SIGTERM')`.
- Adds an in-code comment explaining the prior brittleness and the branch the new fixture exercises (AC-5).
- No production-code change; no widening of assertions (per `feedback_flaky_test_fixes.md`).

## Root cause

On a busy CI runner, PID 9999 can be a live sibling/ancestor process (Linux `pid_max` default 32768; PIDs assigned sequentially). The same-host branch of `signalOther` sent a real SIGTERM to that PID. When the victim was an ancestor of the spawned CLI (vitest main/worker), the stdout pipe collapsed and the CLI died with SIGPIPE, surfacing as `result.status === null` at `locks-cli.integration.test.ts:201`. The setup looked safe locally (where PID 9999 is rarely allocated) and only flaked under CI process pressure.

## AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Fixture no longer relies on hardcoded PID being dead | ✅ Implemented | `signalOther` short-circuits on the cross-host check before `isPidAlive`/`process.kill` — verifiable in `src/lib/locks/lock-manager.ts:287-297` |
| AC-2 | `--signal-other` CLI wiring still exercised | ✅ Implemented | Test still passes `--signal-other`; CLI emits `Could not signal PID 9999 for #77 (cross-host or already exited)` via `src/commands/locks.ts:189`, matched by the existing regex `/Could not signal PID 9999 for #77/` |
| AC-3 | No widening of assertions | ✅ Implemented | `expect(result.status).toBe(0)` preserved verbatim; stdout regex preserved; `after.pid !== 9999` preserved (see diff) |
| AC-4 | Determinism under repeat execution | ✅ Implemented | 20/20 local runs of the takeover test pass; architectural guarantee that `process.kill` is no longer invoked on a guessed PID |
| AC-5 | Root cause documented in code | ✅ Implemented | 6-line comment above the fixture (lines 179-186 in the new file) |

## Coverage note

The integration test now exercises the cross-host branch of `signalOther` instead of the same-host-dead-PID branch. The same-host-dead-PID branch retains unit coverage in `src/lib/locks/lock-manager.test.ts:294` (uses the `isPidAlive` constructor seam to stub `process.kill` cleanly). No coverage gap.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run src/commands/__tests__/locks-cli.integration.test.ts` — 13/13 pass
- [x] `npx vitest run src/lib/locks src/commands/__tests__/locks-cli.integration.test.ts` — 59/59 pass
- [x] Repeat-loop locally (`for i in {1..20}; do npx vitest run … -t "skill takeover"; done`) — 20/20 pass
- [ ] CI green on first attempt (verified post-push)

## Optional follow-up (not in scope)

The plan flagged Option C (defense-in-depth self-PID guard in `LockManager.signalOther`) as a potential follow-up. Not adopted here — the test fix is sufficient and doesn't require touching production code.

Closes #633