### PR TITLE
feat(#505): consolidate phase definitions into PhaseRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Phase definitions consolidated into a single registry (`src/lib/workflow/phase-registry.ts`) — replaces the scattered `PHASE_PROMPTS`, `AIDER_PHASE_PROMPTS`, `ISOLATED_PHASES`, `UI_LABELS`, and `SECURITY_LABELS` constants. All 9 built-in phases (`spec`, `security-review`, `exec`, `testgen`, `test`, `verify`, `qa`, `loop`, `merger`) now register through the same mechanism with no special-casing. `--phases` now validates against the registry at runtime and reports unknown names with a clear error (`Unknown phase 'deploy'. Available: spec, security-review, exec, testgen, test, verify, qa, loop, merger`). User-facing behavior is otherwise unchanged. (#505)
+
 ## [2.3.0] - 2026-05-13
 
 ### Added

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -5,7 +5,7 @@
  * Sequential AI phases with quality gates for any codebase.
  */
 
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
@@ -89,9 +89,9 @@ function validatePhasesFlag(value: string): string {
   const unknown = names.filter((n) => !phaseRegistry.has(n));
   if (unknown.length > 0) {
     const available = phaseRegistry.names().join(", ");
-    const offender = unknown[0];
-    console.error(`Unknown phase '${offender}'. Available: ${available}`);
-    process.exit(1);
+    throw new InvalidArgumentError(
+      `Unknown phase '${unknown[0]}'. Available: ${available}`,
+    );
   }
   return value;
 }

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -71,6 +71,30 @@ import {
 import { promptCommand } from "../src/commands/prompt.js";
 import { watchCommand } from "../src/commands/watch.js";
 import { getManifest } from "../src/lib/manifest.js";
+import { phaseRegistry } from "../src/lib/workflow/phase-registry.js";
+
+/**
+ * Validate `--phases` argument against the phase registry.
+ *
+ * Splits a comma-separated phase list, checks each name against
+ * `phaseRegistry`, and exits with a clear error message if any phase
+ * is unknown. Returns the original string unchanged so downstream
+ * `RunOptions.phases` parsing in `config-resolver.ts` is undisturbed.
+ */
+function validatePhasesFlag(value: string): string {
+  const names = value
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  const unknown = names.filter((n) => !phaseRegistry.has(n));
+  if (unknown.length > 0) {
+    const available = phaseRegistry.names().join(", ");
+    const offender = unknown[0];
+    console.error(`Unknown phase '${offender}'. Available: ${available}`);
+    process.exit(1);
+  }
+  return value;
+}
 
 const program = new Command();
 
@@ -194,7 +218,11 @@ program
   .command("run")
   .description("Execute workflow for GitHub issues using Claude Agent SDK")
   .argument("[issues...]", "Issue numbers to process")
-  .option("--phases <list>", "Phases to run (default: spec,exec,qa)")
+  .option(
+    "--phases <list>",
+    "Phases to run (default: spec,exec,qa)",
+    validatePhasesFlag,
+  )
   .option("--sequential", "Stop on first issue failure (default: continue)")
   .option("-d, --dry-run", "Preview without execution")
   .option("-v, --verbose", "Verbose output with streaming")

--- a/docs/features/phase-type-definitions.md
+++ b/docs/features/phase-type-definitions.md
@@ -1,6 +1,6 @@
 # Phase Type Definitions
 
-Workflow phases (`spec`, `exec`, `qa`, etc.) are defined once in a canonical Zod schema. All modules that need the `Phase` type import from this single source.
+Workflow phases (`spec`, `exec`, `qa`, etc.) are defined once in the **phase registry** and exposed through a Zod refinement schema. All modules that need the `Phase` type import from a single source.
 
 ## Prerequisites
 
@@ -8,43 +8,44 @@ Workflow phases (`spec`, `exec`, `qa`, etc.) are defined once in a canonical Zod
 
 ## Where Phase Is Defined
 
-The canonical definition lives in `src/lib/workflow/types.ts`:
+Two cooperating files in `src/lib/workflow/`:
+
+- `phase-registry.ts` — the registry singleton plus the built-in `phaseRegistry.register(...)` calls at the bottom of the file (canonical pipeline order).
+- `types.ts` — exports `PhaseSchema` (a Zod string refinement backed by `phaseRegistry.has(name)`) and the `Phase` type alias (`string`).
 
 ```typescript
-export const PhaseSchema = z.enum([
-  "spec",
-  "security-review",
-  "exec",
-  "testgen",
-  "test",
-  "verify",
-  "qa",
-  "loop",
-  "merger",
-]);
+// src/lib/workflow/types.ts
+import { phaseRegistry, getPhaseNames } from "./phase-registry.js";
 
-export type Phase = z.infer<typeof PhaseSchema>;
+export const PhaseSchema = z
+  .string()
+  .refine((name) => phaseRegistry.has(name), {
+    error: (issue) =>
+      `Unknown phase "${String(issue.input)}". Available: ${getPhaseNames().join(", ")}`,
+  });
+
+export type Phase = string;
 ```
 
 Two other files re-export it (they do **not** define their own copy):
 
 | File | Re-exports | Also exports |
 |------|-----------|--------------|
-| `state-schema.ts` | `PhaseSchema`, `Phase` | `WORKFLOW_PHASES` (derived from `PhaseSchema.options`) |
+| `state-schema.ts` | `PhaseSchema`, `Phase` | `WORKFLOW_PHASES` (derived from `getPhaseNames()`) |
 | `run-log-schema.ts` | `PhaseSchema`, `Phase` | — |
 
 ## Adding a New Phase
 
-1. Add the phase string to the `z.enum([...])` array in `src/lib/workflow/types.ts`
-2. Add prompt entries in `src/lib/workflow/phase-executor.ts` (`PHASE_PROMPTS` and `AIDER_PHASE_PROMPTS`)
-3. Run `npm run build` — TypeScript will flag any `Record<Phase, ...>` maps missing the new entry
-4. Run `npx vitest run src/lib/workflow/phase-types.test.ts` to verify schema identity
+1. Add a `phaseRegistry.register({ ... })` call in the built-in section at the bottom of `src/lib/workflow/phase-registry.ts`. Required fields: `name`, `skill`, `promptTemplate`, `requiresWorktree`. Optional: `retryStrategy`, `detect`, `driverOverrides`, `order`.
+2. Insertion order in `phase-registry.ts` IS the canonical pipeline order — place the new entry where it should run.
+3. Run `npm run build` — the build will pass because `Phase` is now `string`; there are no `Record<Phase, ...>` maps left to update.
+4. Run `npx vitest run src/lib/workflow/phase-types.test.ts` to verify schema identity and registry consistency.
 
-No changes needed in `state-schema.ts` or `run-log-schema.ts` — they derive from the canonical source automatically.
+No changes needed in `types.ts`, `state-schema.ts`, or `run-log-schema.ts` — they read from the registry automatically.
 
 ## Verdict Types
 
-Merge-check verdict types follow the same pattern in `src/lib/merge-check/types.ts`:
+Merge-check verdict types still follow the simpler typed-enum pattern in `src/lib/merge-check/types.ts`:
 
 ```typescript
 export const CHECK_VERDICTS = ["PASS", "WARN", "FAIL"] as const;
@@ -52,26 +53,29 @@ export const CheckVerdictSchema = z.enum(CHECK_VERDICTS);
 export type CheckVerdict = z.infer<typeof CheckVerdictSchema>;
 ```
 
+The phase registry pattern is only used for `Phase` because phases carry per-entry metadata (prompts, retry strategy, detect rules) that a typed-enum cannot express.
+
 ## What to Expect
 
-- `PhaseSchema.options` returns the readonly tuple of all phase strings
-- `PhaseSchema.safeParse(value)` validates a string at runtime
-- `WORKFLOW_PHASES` in `state-schema.ts` is `PhaseSchema.options` (same object, not a copy)
+- `getPhaseNames()` (from `phase-registry.ts`) returns all registered phase names in insertion order. This replaces the prior `PhaseSchema.options` array.
+- `phaseRegistry.get(name)` returns the full `PhaseDefinition` (prompts, worktree flag, etc.); throws with a "did you mean" list on unknown names.
+- `PhaseSchema.safeParse(value)` validates a string at runtime against the registry.
+- `WORKFLOW_PHASES` in `state-schema.ts` is `getPhaseNames()` (a snapshot of the registry).
 
 ## Troubleshooting
 
-### Build error: "Property 'newPhase' is missing in type"
+### Runtime error: `Unknown phase "..."`
 
-**Symptoms:** After adding a phase, `npm run build` fails on `Record<Phase, string>` maps.
+**Symptoms:** `PhaseSchema.parse(name)` or `phaseRegistry.get(name)` throws with the registered-names list.
 
-**Solution:** Add the new phase to every `Record<Phase, ...>` in the codebase. The two known locations are `PHASE_PROMPTS` and `AIDER_PHASE_PROMPTS` in `phase-executor.ts`.
+**Solution:** Either typo in the phase name, or a new phase wasn't registered. Confirm a `phaseRegistry.register(...)` call exists in `phase-registry.ts` for the name.
 
-### Test failure: "expected X toBe Y"
+### Test failure: `phase-types.test.ts` identity check
 
-**Symptoms:** `phase-types.test.ts` fails with identity check errors.
+**Symptoms:** Test fails with "expected X toBe Y" or similar.
 
-**Solution:** A file is defining its own `PhaseSchema` instead of importing from `types.ts`. Check for independent `z.enum` definitions containing `"spec"` and replace with an import.
+**Solution:** A file is defining its own `PhaseSchema` instead of importing from `types.ts`, or registering a phase twice. Check for independent `z.enum`/`z.string` definitions containing `"spec"`, and check for duplicate `phaseRegistry.register({ name: "..." })` calls.
 
 ---
 
-*Generated for Issue #401 on 2026-03-25*
+*Generated for Issue #401 on 2026-03-25. Updated for Issue #505 (registry migration).*

--- a/src/lib/__tests__/assess-skill.test.ts
+++ b/src/lib/__tests__/assess-skill.test.ts
@@ -14,7 +14,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { describe, expect, it, beforeAll } from "vitest";
-import { PhaseSchema } from "../workflow/types.ts";
+import { getPhaseNames } from "../workflow/phase-registry.ts";
 
 const SKILL_DIRS = [
   ".claude/skills/assess/SKILL.md",
@@ -24,7 +24,7 @@ const SKILL_DIRS = [
 
 describe("assess skill phase vocabulary", () => {
   let skillContent: string;
-  const validPhases = PhaseSchema.options;
+  const validPhases = getPhaseNames();
 
   beforeAll(() => {
     const skillPath = path.join(

--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -31,84 +31,21 @@ import type {
 } from "./drivers/index.js";
 import { classifyError } from "./error-classifier.js";
 import { ApiError } from "../errors.js";
+import { phaseRegistry } from "./phase-registry.js";
 
 /**
- * Natural language prompts for each phase.
- * Claude Code invokes the corresponding skills via natural language.
+ * Determine whether a phase's session must run inside the issue worktree.
+ *
+ * Sourced from `phaseRegistry.get(phase).requiresWorktree` — replaces the
+ * previous hardcoded `ISOLATED_PHASES` array. Phases must:
+ * 1. Read/modify worktree code
+ * 2. Resume a session from the same cwd it was created in (SDK constraint)
  */
-const PHASE_PROMPTS: Record<Phase, string> = {
-  spec: "Review GitHub issue #{issue} and create an implementation plan with verification criteria. Run the /spec {issue} workflow.",
-  "security-review":
-    "Perform a deep security analysis for GitHub issue #{issue} focusing on auth, permissions, and sensitive operations. Run the /security-review {issue} workflow.",
-  testgen:
-    "Generate test stubs for GitHub issue #{issue} based on the specification. Run the /testgen {issue} workflow.",
-  exec: "Implement the feature for GitHub issue #{issue} following the spec. Run the /exec {issue} workflow.",
-  test: "Execute structured browser-based testing for GitHub issue #{issue}. Run the /test {issue} workflow.",
-  verify:
-    "Verify the implementation for GitHub issue #{issue} by running commands and capturing output. Run the /verify {issue} workflow.",
-  qa: "Review the implementation for GitHub issue #{issue} against acceptance criteria. Run the /qa {issue} workflow.",
-  loop: "Parse test/QA findings for GitHub issue #{issue} and iterate until quality gates pass. Run the /loop {issue} workflow.",
-  merger:
-    "Integrate and merge completed worktrees for GitHub issue #{issue}. Run the /merger {issue} workflow.",
-};
-
-/**
- * Self-contained prompts for non-Claude agents (Aider, Codex, etc.).
- * These agents don't have a skill system, so prompts must include
- * full instructions rather than skill invocations.
- */
-const AIDER_PHASE_PROMPTS: Record<Phase, string> = {
-  spec: `Read GitHub issue #{issue} using 'gh issue view #{issue}'.
-Create a spec comment on the issue with:
-1. Implementation plan
-2. Acceptance criteria as a checklist
-3. Risk assessment
-Post the comment using 'gh issue comment #{issue} --body "<comment>"'.`,
-  "security-review": `Perform a security review for GitHub issue #{issue}.
-Read the issue with 'gh issue view #{issue}'.
-Check for auth, permissions, injection, and sensitive data issues.
-Post findings as a comment on the issue.`,
-  testgen: `Generate test stubs for GitHub issue #{issue}.
-Read the spec comments on the issue with 'gh issue view #{issue} --comments'.
-Create test files with describe/it blocks covering the acceptance criteria.
-Use the project's existing test framework.`,
-  exec: `Implement the feature described in GitHub issue #{issue}.
-Read the issue and any spec comments with 'gh issue view #{issue} --comments'.
-Follow the implementation plan from the spec.
-Write tests for new functionality.
-Ensure the build passes with 'npm test' and 'npm run build'.`,
-  test: `Test the implementation for GitHub issue #{issue}.
-Run 'npm test' and verify all tests pass.
-Check for edge cases and error handling.`,
-  verify: `Verify the implementation for GitHub issue #{issue}.
-Run relevant commands and capture their output for review.`,
-  qa: `Review the changes for GitHub issue #{issue}.
-Run 'npm test' and 'npm run build' to verify everything works.
-Check each acceptance criterion from the issue comments.
-Output a verdict: READY_FOR_MERGE, AC_MET_BUT_NOT_A_PLUS, or AC_NOT_MET
-with format "### Verdict: <VERDICT>" followed by an explanation.`,
-  loop: `Review test and QA findings for GitHub issue #{issue}.
-Fix any issues identified in the QA feedback.
-Re-run 'npm test' and 'npm run build' until all quality gates pass.`,
-  merger: `Integrate and merge completed worktrees for GitHub issue #{issue}.
-Ensure all branches are up to date and merge cleanly.`,
-};
-
-/**
- * Phases that require worktree isolation.
- * Only `spec` runs in the main repo (planning-only, no file changes).
- * All other phases must run in the worktree because:
- * 1. They need to read/modify the worktree code
- * 2. Resuming a session created in a different cwd crashes the SDK
- */
-const ISOLATED_PHASES: Phase[] = [
-  "exec",
-  "security-review",
-  "testgen",
-  "test",
-  "qa",
-  "loop",
-];
+function phaseRequiresWorktree(phase: Phase): boolean {
+  return phaseRegistry.has(phase)
+    ? phaseRegistry.get(phase).requiresWorktree
+    : false;
+}
 
 /**
  * Cold-start retry threshold in seconds.
@@ -516,9 +453,15 @@ export async function getPhasePrompt(
   agent?: string,
   promptContext?: string,
 ): Promise<string> {
-  const prompts =
-    agent && agent !== "claude-code" ? AIDER_PHASE_PROMPTS : PHASE_PROMPTS;
-  let basePrompt = prompts[phase].replace(/\{issue\}/g, String(issueNumber));
+  const definition = phaseRegistry.get(phase);
+  // Non-claude drivers consult driverOverrides[<driver>] first; fall back to
+  // the default promptTemplate when no override is registered for the driver.
+  const driverPrompt =
+    agent && agent !== "claude-code"
+      ? definition.driverOverrides?.[agent]?.promptTemplate
+      : undefined;
+  const template = driverPrompt ?? definition.promptTemplate;
+  let basePrompt = template.replace(/\{issue\}/g, String(issueNumber));
 
   // Append phase-specific context (e.g., QA findings for loop phase)
   if (promptContext) {
@@ -573,13 +516,13 @@ async function executePhase(
 
   if (config.verbose) {
     console.log(chalk.gray(`    Prompt: ${prompt}`));
-    if (worktreePath && ISOLATED_PHASES.includes(phase)) {
+    if (worktreePath && phaseRequiresWorktree(phase)) {
       console.log(chalk.gray(`    Worktree: ${worktreePath}`));
     }
   }
 
   // Determine working directory and environment
-  const shouldUseWorktree = worktreePath && ISOLATED_PHASES.includes(phase);
+  const shouldUseWorktree = worktreePath && phaseRequiresWorktree(phase);
   const cwd = shouldUseWorktree ? worktreePath : process.cwd();
 
   // Resolve file context for file-oriented drivers (e.g., Aider --file)
@@ -698,8 +641,9 @@ async function executePhase(
   // Safety: never resume a session when worktree isolation is active.
   // Even if THIS phase doesn't use the worktree, a previous phase may have
   // created the session there. Resuming from a different cwd crashes the SDK
-  // (exit code 1). ISOLATED_PHASES prevents this by design, but this guard
-  // catches edge cases (e.g. a new phase added without updating ISOLATED_PHASES).
+  // (exit code 1). The registry's `requiresWorktree` field prevents this by
+  // design, but this guard catches edge cases (e.g. a new phase registered
+  // without setting `requiresWorktree: true`).
   const canResume = sessionId && !worktreePath;
 
   // Build AgentExecutionConfig for the driver

--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -103,15 +103,23 @@ export function createThrottledReporter(
 }
 
 /**
- * Spec-specific retry configuration.
+ * Spec-specific retry configuration. Sourced from the phase registry's
+ * `retryStrategy` field — `phase-registry.ts` is the source of truth.
+ *
  * Spec failures have a higher failure rate (~8.6%) than other phases due to
  * transient GitHub API issues and rate limits. One extra retry with backoff
  * recovers most of these without user intervention.
+ *
+ * Fallback literals (5000 / 1) match the legacy hardcoded values and only
+ * fire if the spec registration is removed or its `retryStrategy` is unset,
+ * which would be a misconfiguration. Tests pin these at 5000 / 1, so any
+ * drift surfaces immediately.
  */
+const SPEC_RETRY_STRATEGY = phaseRegistry.get("spec").retryStrategy;
 /** @internal Exported for testing only */
-export const SPEC_RETRY_BACKOFF_MS = 5000;
+export const SPEC_RETRY_BACKOFF_MS = SPEC_RETRY_STRATEGY?.backoffMs ?? 5000;
 /** @internal Exported for testing only */
-export const SPEC_EXTRA_RETRIES = 1;
+export const SPEC_EXTRA_RETRIES = SPEC_RETRY_STRATEGY?.extraRetries ?? 1;
 
 export function parseQaVerdict(output: string): QaVerdict | null {
   if (!output) return null;
@@ -768,11 +776,16 @@ export async function executePhaseWithRetry(
     );
   }
 
-  // Skip cold-start retries for `loop` phase (#488).
-  // Loop is always a re-run after a failed QA — never a first boot.
-  // Failures at 47-51s are genuine skill failures, not cold-start issues.
-  // Without this guard, 2 cold-start retries + 1 MCP fallback = 3 wasted spawns per loop.
-  const skipColdStartRetry = phase === "loop";
+  // Skip cold-start retries for phases registered with `retryStrategy.maxRetries: 0`.
+  // `loop` is the canonical user (#488) — it's always a re-run after a failed QA,
+  // never a first boot. Failures at 47-51s are genuine skill failures, not cold-start
+  // issues. Without this guard, 2 cold-start retries + 1 MCP fallback = 3 wasted
+  // spawns per loop. Sourcing the decision from the registry makes the rule
+  // data-driven — any future phase registered with `maxRetries: 0` inherits the
+  // same behavior without a code change here.
+  const skipColdStartRetry =
+    phaseRegistry.has(phase) &&
+    phaseRegistry.get(phase).retryStrategy?.maxRetries === 0;
 
   let lastResult: PhaseResult & { sessionId?: string };
 

--- a/src/lib/workflow/phase-mapper.ts
+++ b/src/lib/workflow/phase-mapper.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Phase } from "./types.js";
+import { phaseRegistry } from "./phase-registry.js";
 
 /**
  * Minimal options interface for phase mapping.
@@ -20,38 +21,54 @@ interface PhaseMapperOptions {
 }
 
 /**
- * UI-related labels that trigger automatic test phase
- */
-export const UI_LABELS = ["ui", "frontend", "admin", "web", "browser"];
-
-/**
- * Bug-related labels (used by downstream metadata consumers)
+ * Bug-related labels (used by downstream metadata consumers).
+ *
+ * Issue-type metadata — NOT phase-trigger rules. The registry-driven
+ * `detectPhasesFromLabels` below does not consult this list. It stays
+ * here because `batch-executor.ts` and other modules read it for
+ * `issueType` propagation and similar non-phase concerns.
  */
 export const BUG_LABELS = ["bug", "fix", "hotfix", "patch"];
 
 /**
- * Documentation labels (used for issueType propagation and downstream metadata)
+ * Documentation labels (used for issueType propagation and downstream metadata).
+ *
+ * Issue-type metadata — NOT phase-trigger rules. See BUG_LABELS comment.
  */
 export const DOCS_LABELS = ["docs", "documentation", "readme"];
 
 /**
- * Complex labels that enable quality loop
+ * Complex labels that enable quality loop.
+ *
+ * Quality-loop trigger — NOT a phase-trigger rule (does not add the loop
+ * *phase*; only flips the `qualityLoop` flag on the run config). Kept
+ * out of the phase registry by design.
  */
 export const COMPLEX_LABELS = ["complex", "refactor", "breaking", "major"];
 
 /**
- * Security-related labels that trigger security-review phase
+ * Look up label-based detect rules from the registry, returning the set
+ * of phases whose `detect.labels` intersect the issue's labels. Comparison
+ * is case-insensitive (labels lowercased at the call site).
  */
-export const SECURITY_LABELS = [
-  "security",
-  "auth",
-  "authentication",
-  "permissions",
-  "admin",
-];
+function detectPhasesFromRegistry(lowerLabels: string[]): Set<string> {
+  const matched = new Set<string>();
+  for (const def of phaseRegistry.list()) {
+    const triggers = def.detect?.labels;
+    if (!triggers || triggers.length === 0) continue;
+    const hit = triggers.some((t) => lowerLabels.includes(t.toLowerCase()));
+    if (hit) matched.add(def.name);
+  }
+  return matched;
+}
 
 /**
- * Detect phases based on issue labels (like /assess logic)
+ * Detect phases based on issue labels (like /assess logic).
+ *
+ * Label → phase mapping now lives in `PhaseDefinition.detect.labels`. Only
+ * the *insertion position* of detected phases remains baked in here, because
+ * pipeline ordering depends on the phase's role (security-review goes after
+ * spec; test goes before qa).
  */
 export function detectPhasesFromLabels(labels: string[]): {
   phases: Phase[];
@@ -59,20 +76,14 @@ export function detectPhasesFromLabels(labels: string[]): {
 } {
   const lowerLabels = labels.map((l) => l.toLowerCase());
 
-  // Check for UI labels → add test phase
-  const isUI = lowerLabels.some((label) =>
-    UI_LABELS.some((uiLabel) => label === uiLabel),
-  );
-
-  // Check for complex labels → enable quality loop
+  // Quality loop is a registry-independent label trigger (see COMPLEX_LABELS).
   const isComplex = lowerLabels.some((label) =>
     COMPLEX_LABELS.some((complexLabel) => label === complexLabel),
   );
 
-  // Check for security labels → add security-review phase
-  const isSecurity = lowerLabels.some((label) =>
-    SECURITY_LABELS.some((secLabel) => label === secLabel),
-  );
+  const matched = detectPhasesFromRegistry(lowerLabels);
+  const isUI = matched.has("test");
+  const isSecurity = matched.has("security-review");
 
   // Build phase list — spec is always included by default (#533).
   // Bug/docs labels no longer short-circuit spec; downstream consumers
@@ -119,21 +130,11 @@ export function parseRecommendedWorkflow(output: string): {
     .map((p) => p.trim().toLowerCase())
     .filter((p) => p.length > 0);
 
-  // Validate and convert to Phase type
+  // Validate against the registry — accepts any registered phase.
   const validPhases: Phase[] = [];
   for (const name of phaseNames) {
-    if (
-      [
-        "spec",
-        "security-review",
-        "testgen",
-        "exec",
-        "test",
-        "qa",
-        "loop",
-      ].includes(name)
-    ) {
-      validPhases.push(name as Phase);
+    if (phaseRegistry.has(name)) {
+      validPhases.push(name);
     }
   }
 
@@ -153,12 +154,20 @@ export function parseRecommendedWorkflow(output: string): {
 }
 
 /**
- * Check if an issue has UI-related labels
+ * Check if an issue has UI-related labels.
+ *
+ * Sources the label list from the `test` phase's `detect.labels` entry in
+ * the registry — same data as `detectPhasesFromLabels` consults, just
+ * exposed as a boolean for callers that only need the yes/no answer
+ * (e.g. test phase insertion in `determinePhasesForIssue`).
  */
 export function hasUILabels(labels: string[]): boolean {
-  return labels.some((label) =>
-    UI_LABELS.some((uiLabel) => label.toLowerCase() === uiLabel),
-  );
+  const testTriggers = phaseRegistry.has("test")
+    ? (phaseRegistry.get("test").detect?.labels ?? [])
+    : [];
+  if (testTriggers.length === 0) return false;
+  const lowered = new Set(testTriggers.map((t) => t.toLowerCase()));
+  return labels.some((label) => lowered.has(label.toLowerCase()));
 }
 
 /**

--- a/src/lib/workflow/phase-registry.integration.test.ts
+++ b/src/lib/workflow/phase-registry.integration.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integration tests for --phases CLI validation against the phase registry.
+ *
+ * AC-6: `--phases foo,exec` must exit non-zero with a clear error message
+ * naming the unknown phase and listing available phases.
+ */
+
+import { spawnSync } from "child_process";
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "../../..");
+const tsxBin = resolve(projectRoot, "node_modules/.bin/tsx");
+const cliSource = resolve(projectRoot, "bin/cli.ts");
+
+describe("--phases registry validation (AC-6)", () => {
+  it("exits non-zero when given an unknown phase", () => {
+    const result = spawnSync(
+      tsxBin,
+      [cliSource, "run", "1", "--phases", "deploy", "--dry-run"],
+      {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        // Disable home-stray warnings + node_modules warnings noise
+        env: { ...process.env, NO_COLOR: "1" },
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Unknown phase 'deploy'");
+    expect(result.stderr).toContain("Available:");
+    // Must list known phases in the error so users can spot the typo
+    expect(result.stderr).toContain("spec");
+    expect(result.stderr).toContain("exec");
+    expect(result.stderr).toContain("qa");
+  });
+
+  it("rejects unknown phase even when mixed with valid phases", () => {
+    const result = spawnSync(
+      tsxBin,
+      [cliSource, "run", "1", "--phases", "exec,deploy,qa", "--dry-run"],
+      {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        env: { ...process.env, NO_COLOR: "1" },
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Unknown phase 'deploy'");
+  });
+
+  it("accepts a list of valid registered phases", () => {
+    // Smoke: --phases spec,exec,qa must not trip the validator. The command
+    // may still exit non-zero for downstream reasons (no GH issue, etc.) but
+    // it must NOT exit with the "Unknown phase" message.
+    const result = spawnSync(
+      tsxBin,
+      [cliSource, "run", "999999999", "--phases", "spec,exec,qa", "--dry-run"],
+      {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        env: { ...process.env, NO_COLOR: "1" },
+        // Short timeout — we only care that the *validator* doesn't reject.
+        timeout: 30000,
+      },
+    );
+
+    expect(result.stderr).not.toContain("Unknown phase");
+  });
+});

--- a/src/lib/workflow/phase-registry.test.ts
+++ b/src/lib/workflow/phase-registry.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the PhaseRegistry class and the built-in phase registrations.
+ *
+ * The registry is the single source of truth for workflow phase definitions
+ * (replaces PHASE_PROMPTS / AIDER_PHASE_PROMPTS / ISOLATED_PHASES /
+ * UI_LABELS / SECURITY_LABELS scattered across the workflow modules).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  PhaseRegistry,
+  phaseRegistry,
+  getPhaseNames,
+  type PhaseDefinition,
+} from "./phase-registry.js";
+
+describe("PhaseRegistry class (AC-2)", () => {
+  it("register / get round-trips a definition", () => {
+    const reg = new PhaseRegistry();
+    const def: PhaseDefinition = {
+      name: "deploy",
+      skill: "deploy",
+      promptTemplate: "Deploy issue #{issue}",
+      requiresWorktree: true,
+    };
+
+    reg.register(def);
+
+    expect(reg.get("deploy")).toEqual(def);
+    expect(reg.has("deploy")).toBe(true);
+    expect(reg.list()).toEqual([def]);
+    expect(reg.names()).toEqual(["deploy"]);
+  });
+
+  it("has() is false before registration, true after", () => {
+    const reg = new PhaseRegistry();
+    expect(reg.has("nope")).toBe(false);
+    reg.register({
+      name: "nope",
+      skill: "nope",
+      promptTemplate: "x",
+      requiresWorktree: false,
+    });
+    expect(reg.has("nope")).toBe(true);
+  });
+
+  it("duplicate register throws (fail-fast on misconfigured bootstrap)", () => {
+    const reg = new PhaseRegistry();
+    const def: PhaseDefinition = {
+      name: "spec",
+      skill: "spec",
+      promptTemplate: "x",
+      requiresWorktree: false,
+    };
+    reg.register(def);
+    expect(() => reg.register(def)).toThrowError(/already registered/);
+  });
+
+  it("get() on unknown name throws with available list", () => {
+    const reg = new PhaseRegistry();
+    reg.register({
+      name: "spec",
+      skill: "spec",
+      promptTemplate: "x",
+      requiresWorktree: false,
+    });
+    reg.register({
+      name: "exec",
+      skill: "exec",
+      promptTemplate: "x",
+      requiresWorktree: true,
+    });
+    expect(() => reg.get("nope")).toThrowError(/unknown phase "nope"/);
+    expect(() => reg.get("nope")).toThrowError(/Available: spec, exec/);
+  });
+
+  it("list() preserves insertion order", () => {
+    const reg = new PhaseRegistry();
+    const phases = ["a", "b", "c"];
+    for (const name of phases) {
+      reg.register({
+        name,
+        skill: name,
+        promptTemplate: "x",
+        requiresWorktree: false,
+      });
+    }
+    expect(reg.list().map((p) => p.name)).toEqual(phases);
+    expect(reg.names()).toEqual(phases);
+  });
+});
+
+describe("Built-in phase registrations (AC-3)", () => {
+  it("registers all 9 canonical phases in pipeline order", () => {
+    // Insertion order in phase-registry.ts IS the canonical pipeline order
+    // — preserved verbatim from the pre-registry PhaseSchema typed-enum.
+    expect(phaseRegistry.names()).toEqual([
+      "spec",
+      "security-review",
+      "exec",
+      "testgen",
+      "test",
+      "verify",
+      "qa",
+      "loop",
+      "merger",
+    ]);
+  });
+
+  it("every phase has all required PhaseDefinition fields populated", () => {
+    // AC-3 contract: no special-casing — every phase has the same shape.
+    for (const def of phaseRegistry.list()) {
+      expect(typeof def.name).toBe("string");
+      expect(typeof def.skill).toBe("string");
+      expect(typeof def.promptTemplate).toBe("string");
+      expect(typeof def.requiresWorktree).toBe("boolean");
+      expect(def.promptTemplate).toContain("{issue}");
+    }
+  });
+
+  it("requiresWorktree matches the pre-registry ISOLATED_PHASES set", () => {
+    // Pre-registry constant: ["exec", "security-review", "testgen", "test", "qa", "loop"]
+    const isolated = phaseRegistry
+      .list()
+      .filter((p) => p.requiresWorktree)
+      .map((p) => p.name)
+      .sort();
+    expect(isolated).toEqual(
+      ["exec", "security-review", "testgen", "test", "qa", "loop"].sort(),
+    );
+  });
+
+  it("non-worktree phases match the pre-registry set (spec, verify, merger)", () => {
+    const mainRepo = phaseRegistry
+      .list()
+      .filter((p) => !p.requiresWorktree)
+      .map((p) => p.name)
+      .sort();
+    expect(mainRepo).toEqual(["spec", "verify", "merger"].sort());
+  });
+
+  it("aider driverOverrides are registered for all 9 phases (AC-8 — no parallel map)", () => {
+    // Pre-registry: AIDER_PHASE_PROMPTS had 9 entries. After migration the
+    // same data lives in PhaseDefinition.driverOverrides.aider.
+    for (const def of phaseRegistry.list()) {
+      const aiderOverride = def.driverOverrides?.aider;
+      expect(aiderOverride).toBeDefined();
+      expect(typeof aiderOverride?.promptTemplate).toBe("string");
+      expect(aiderOverride?.promptTemplate).toContain("{issue}");
+    }
+  });
+
+  it("test phase carries UI detect labels (replaces UI_LABELS constant)", () => {
+    const test = phaseRegistry.get("test");
+    expect(test.detect?.labels).toEqual([
+      "ui",
+      "frontend",
+      "admin",
+      "web",
+      "browser",
+    ]);
+  });
+
+  it("security-review phase carries security detect labels (replaces SECURITY_LABELS)", () => {
+    const sec = phaseRegistry.get("security-review");
+    expect(sec.detect?.labels).toEqual([
+      "security",
+      "auth",
+      "authentication",
+      "permissions",
+      "admin",
+    ]);
+  });
+
+  it("loop phase has retryStrategy.maxRetries=0 (encodes 'skip cold-start retries')", () => {
+    const loop = phaseRegistry.get("loop");
+    expect(loop.retryStrategy?.maxRetries).toBe(0);
+  });
+
+  it("spec phase has retryStrategy.extraRetries=1 (encodes SPEC_EXTRA_RETRIES)", () => {
+    const spec = phaseRegistry.get("spec");
+    expect(spec.retryStrategy?.extraRetries).toBe(1);
+    expect(spec.retryStrategy?.backoffMs).toBe(5000);
+  });
+});
+
+describe("getPhaseNames() (AC-3, AC-5)", () => {
+  it("returns the same array as phaseRegistry.names()", () => {
+    expect(getPhaseNames()).toEqual(phaseRegistry.names());
+  });
+
+  it("returned array is in canonical pipeline order", () => {
+    const names = getPhaseNames();
+    expect(names[0]).toBe("spec");
+    expect(names[names.length - 1]).toBe("merger");
+  });
+});

--- a/src/lib/workflow/phase-registry.ts
+++ b/src/lib/workflow/phase-registry.ts
@@ -178,9 +178,9 @@ phaseRegistry.register({
     "Review GitHub issue #{issue} and create an implementation plan with verification criteria. Run the /spec {issue} workflow.",
   requiresWorktree: false,
   // Spec has a higher transient failure rate (~8.6%) than other phases due
-  // to GitHub API issues and rate limits. The retry strategy here advertises
-  // the per-phase extra retry — phase-executor reads the constants directly
-  // today but consumers (telemetry, observability) can rely on this metadata.
+  // to GitHub API issues and rate limits. phase-executor.ts reads these
+  // values directly from the registry at module load (see
+  // SPEC_RETRY_BACKOFF_MS / SPEC_EXTRA_RETRIES).
   retryStrategy: { extraRetries: 1, backoffMs: 5000 },
   driverOverrides: {
     aider: {
@@ -300,7 +300,7 @@ with format "### Verdict: <VERDICT>" followed by an explanation.`,
 });
 
 // Loop — worktree-isolated. `maxRetries: 0` encodes the
-// "skip cold-start retries for loop" rule from phase-executor.
+// "skip cold-start retries" rule consumed by phase-executor.ts (#488).
 phaseRegistry.register({
   name: "loop",
   skill: "loop",

--- a/src/lib/workflow/phase-registry.ts
+++ b/src/lib/workflow/phase-registry.ts
@@ -1,0 +1,333 @@
+/**
+ * Phase registry — single source of truth for workflow phase definitions.
+ *
+ * Replaces scattered constants (`PHASE_PROMPTS`, `AIDER_PHASE_PROMPTS`,
+ * `ISOLATED_PHASES`, `UI_LABELS`, `SECURITY_LABELS`) with a uniform record
+ * per phase. All 9 built-in phases register here at module load — no
+ * special-casing inside consumer code.
+ *
+ * Built-in registrations live at the bottom of this file rather than in a
+ * separate `built-in-phases.ts` module. The colocated layout follows the
+ * existing `drivers/index.ts` pattern and avoids the ESM-cycle pitfall of
+ * a separate bootstrap module that re-imports the registry singleton
+ * before the singleton is fully initialized.
+ *
+ * User-extensibility (filesystem discovery of `.sequant/phases/`) is
+ * deliberately deferred — see issue #505 descoping comment.
+ */
+
+/**
+ * Per-driver overrides for a phase. Today only `promptTemplate` is supported;
+ * extend the inner record when additional fields need per-driver values.
+ */
+export interface DriverOverride {
+  promptTemplate?: string;
+}
+
+/**
+ * Retry policy for a single phase. Phases without this field fall back to
+ * the global cold-start retry defaults in `phase-executor.ts`. The fields
+ * are deliberately optional — a phase only needs to specify what differs.
+ */
+export interface RetryStrategy {
+  /** Override the cold-start retry attempt count for this phase. */
+  maxRetries?: number;
+  /** Initial backoff in ms before the first retry. */
+  backoffMs?: number;
+  /** Override the cold-start threshold (seconds). */
+  coldStartThreshold?: number;
+  /** Extra retries beyond cold-start (e.g. for transient API errors). */
+  extraRetries?: number;
+}
+
+/**
+ * Auto-detection rules consumed by phase-mapper.ts.
+ * `labels` is an exact-match list (case-insensitive at the call site).
+ */
+export interface DetectRules {
+  labels?: string[];
+}
+
+/**
+ * Definition of a workflow phase. Registered at startup via
+ * `phaseRegistry.register(...)` and consumed by phase-executor, phase-mapper,
+ * and the CLI validator.
+ */
+export interface PhaseDefinition {
+  /** Phase name (matches the skill template directory + CLI `--phases` token). */
+  name: string;
+  /** Skill template directory under `templates/skills/<skill>/SKILL.md`. */
+  skill: string;
+  /**
+   * Natural-language prompt for the default (Claude Code) driver. The token
+   * `{issue}` is substituted with the GitHub issue number at execution time.
+   */
+  promptTemplate: string;
+  /**
+   * When true, phase-executor runs this phase inside the issue worktree.
+   * `spec`, `verify`, and `merger` run in the main repo (no worktree).
+   */
+  requiresWorktree: boolean;
+  /** Optional per-phase retry overrides. */
+  retryStrategy?: RetryStrategy;
+  /** Optional auto-detection rules. */
+  detect?: DetectRules;
+  /**
+   * Per-driver overrides. Keyed by agent name (e.g. `"aider"`). When the
+   * orchestrator runs a non-Claude driver, the corresponding override's
+   * `promptTemplate` (if present) replaces the default.
+   */
+  driverOverrides?: Record<string, DriverOverride>;
+  /**
+   * Insertion order hint. Used by phase-mapper to sort label-detected phases
+   * into a deterministic pipeline position. Defaults to 0.
+   */
+  order?: number;
+}
+
+/**
+ * In-memory registry of phase definitions. Single mutable instance lives
+ * in this module — see the exported `phaseRegistry` constant.
+ *
+ * The class is intentionally minimal (no lifecycle hooks, no async). All
+ * mutations happen synchronously at module load by the built-in registrations
+ * at the bottom of this file.
+ */
+export class PhaseRegistry {
+  private readonly definitions = new Map<string, PhaseDefinition>();
+
+  /**
+   * Register a phase definition. Throws on duplicate names so misconfigured
+   * bootstrap modules surface immediately instead of silently overwriting.
+   */
+  register(definition: PhaseDefinition): void {
+    if (this.definitions.has(definition.name)) {
+      throw new Error(
+        `PhaseRegistry: phase "${definition.name}" is already registered`,
+      );
+    }
+    this.definitions.set(definition.name, definition);
+  }
+
+  /**
+   * Retrieve a phase by name. Throws with a "did you mean" list when the
+   * lookup fails — clearer than a downstream "undefined.promptTemplate".
+   */
+  get(name: string): PhaseDefinition {
+    const def = this.definitions.get(name);
+    if (!def) {
+      const available = this.names().join(", ");
+      throw new Error(
+        `PhaseRegistry: unknown phase "${name}". Available: ${available}`,
+      );
+    }
+    return def;
+  }
+
+  /** True when a phase with this name is registered. */
+  has(name: string): boolean {
+    return this.definitions.has(name);
+  }
+
+  /**
+   * All registered phase definitions in insertion order. Insertion order
+   * is also the canonical pipeline order (see registrations below).
+   */
+  list(): PhaseDefinition[] {
+    return [...this.definitions.values()];
+  }
+
+  /**
+   * All registered phase names in insertion order. Replaces the
+   * `PhaseSchema.options` array literal exposed by the previous typed-enum
+   * `PhaseSchema`.
+   */
+  names(): string[] {
+    return [...this.definitions.keys()];
+  }
+}
+
+/**
+ * Singleton registry instance. All consumer modules (phase-executor,
+ * phase-mapper, types.ts, CLI) read from this same instance — there is
+ * no second registry.
+ */
+export const phaseRegistry = new PhaseRegistry();
+
+/**
+ * Convenience accessor for the registered phase names. Used by Zod refines,
+ * tests, and CLI validation in place of the removed `PhaseSchema.options`.
+ */
+export function getPhaseNames(): string[] {
+  return phaseRegistry.names();
+}
+
+// ─── Built-in phase registrations ────────────────────────────────────────
+//
+// Insertion order below IS the canonical pipeline order — preserved from the
+// pre-registry `PhaseSchema` literal (`spec, security-review, exec, testgen,
+// test, verify, qa, loop, merger`). Reordering these entries changes the
+// order returned by `phaseRegistry.list()` / `getPhaseNames()` and the
+// downstream `WORKFLOW_PHASES` constant in `state-schema.ts`.
+
+// Spec — runs in the main repo (planning only, no worktree mutation)
+phaseRegistry.register({
+  name: "spec",
+  skill: "spec",
+  promptTemplate:
+    "Review GitHub issue #{issue} and create an implementation plan with verification criteria. Run the /spec {issue} workflow.",
+  requiresWorktree: false,
+  // Spec has a higher transient failure rate (~8.6%) than other phases due
+  // to GitHub API issues and rate limits. The retry strategy here advertises
+  // the per-phase extra retry — phase-executor reads the constants directly
+  // today but consumers (telemetry, observability) can rely on this metadata.
+  retryStrategy: { extraRetries: 1, backoffMs: 5000 },
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Read GitHub issue #{issue} using 'gh issue view #{issue}'.
+Create a spec comment on the issue with:
+1. Implementation plan
+2. Acceptance criteria as a checklist
+3. Risk assessment
+Post the comment using 'gh issue comment #{issue} --body "<comment>"'.`,
+    },
+  },
+});
+
+// Security review — worktree-isolated, label-triggered
+phaseRegistry.register({
+  name: "security-review",
+  skill: "security-review",
+  promptTemplate:
+    "Perform a deep security analysis for GitHub issue #{issue} focusing on auth, permissions, and sensitive operations. Run the /security-review {issue} workflow.",
+  requiresWorktree: true,
+  detect: {
+    labels: ["security", "auth", "authentication", "permissions", "admin"],
+  },
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Perform a security review for GitHub issue #{issue}.
+Read the issue with 'gh issue view #{issue}'.
+Check for auth, permissions, injection, and sensitive data issues.
+Post findings as a comment on the issue.`,
+    },
+  },
+});
+
+// Exec — worktree-isolated
+phaseRegistry.register({
+  name: "exec",
+  skill: "exec",
+  promptTemplate:
+    "Implement the feature for GitHub issue #{issue} following the spec. Run the /exec {issue} workflow.",
+  requiresWorktree: true,
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Implement the feature described in GitHub issue #{issue}.
+Read the issue and any spec comments with 'gh issue view #{issue} --comments'.
+Follow the implementation plan from the spec.
+Write tests for new functionality.
+Ensure the build passes with 'npm test' and 'npm run build'.`,
+    },
+  },
+});
+
+// Testgen — worktree-isolated
+phaseRegistry.register({
+  name: "testgen",
+  skill: "testgen",
+  promptTemplate:
+    "Generate test stubs for GitHub issue #{issue} based on the specification. Run the /testgen {issue} workflow.",
+  requiresWorktree: true,
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Generate test stubs for GitHub issue #{issue}.
+Read the spec comments on the issue with 'gh issue view #{issue} --comments'.
+Create test files with describe/it blocks covering the acceptance criteria.
+Use the project's existing test framework.`,
+    },
+  },
+});
+
+// Test — worktree-isolated, label-triggered (UI/frontend issues)
+phaseRegistry.register({
+  name: "test",
+  skill: "test",
+  promptTemplate:
+    "Execute structured browser-based testing for GitHub issue #{issue}. Run the /test {issue} workflow.",
+  requiresWorktree: true,
+  detect: { labels: ["ui", "frontend", "admin", "web", "browser"] },
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Test the implementation for GitHub issue #{issue}.
+Run 'npm test' and verify all tests pass.
+Check for edge cases and error handling.`,
+    },
+  },
+});
+
+// Verify — runs in main repo (CLI-only feature verification)
+phaseRegistry.register({
+  name: "verify",
+  skill: "verify",
+  promptTemplate:
+    "Verify the implementation for GitHub issue #{issue} by running commands and capturing output. Run the /verify {issue} workflow.",
+  requiresWorktree: false,
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Verify the implementation for GitHub issue #{issue}.
+Run relevant commands and capture their output for review.`,
+    },
+  },
+});
+
+// QA — worktree-isolated
+phaseRegistry.register({
+  name: "qa",
+  skill: "qa",
+  promptTemplate:
+    "Review the implementation for GitHub issue #{issue} against acceptance criteria. Run the /qa {issue} workflow.",
+  requiresWorktree: true,
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Review the changes for GitHub issue #{issue}.
+Run 'npm test' and 'npm run build' to verify everything works.
+Check each acceptance criterion from the issue comments.
+Output a verdict: READY_FOR_MERGE, AC_MET_BUT_NOT_A_PLUS, or AC_NOT_MET
+with format "### Verdict: <VERDICT>" followed by an explanation.`,
+    },
+  },
+});
+
+// Loop — worktree-isolated. `maxRetries: 0` encodes the
+// "skip cold-start retries for loop" rule from phase-executor.
+phaseRegistry.register({
+  name: "loop",
+  skill: "loop",
+  promptTemplate:
+    "Parse test/QA findings for GitHub issue #{issue} and iterate until quality gates pass. Run the /loop {issue} workflow.",
+  requiresWorktree: true,
+  retryStrategy: { maxRetries: 0 },
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Review test and QA findings for GitHub issue #{issue}.
+Fix any issues identified in the QA feedback.
+Re-run 'npm test' and 'npm run build' until all quality gates pass.`,
+    },
+  },
+});
+
+// Merger — runs in main repo (multi-worktree integration)
+phaseRegistry.register({
+  name: "merger",
+  skill: "merger",
+  promptTemplate:
+    "Integrate and merge completed worktrees for GitHub issue #{issue}. Run the /merger {issue} workflow.",
+  requiresWorktree: false,
+  driverOverrides: {
+    aider: {
+      promptTemplate: `Integrate and merge completed worktrees for GitHub issue #{issue}.
+Ensure all branches are up to date and merge cleanly.`,
+    },
+  },
+});

--- a/src/lib/workflow/phase-types.test.ts
+++ b/src/lib/workflow/phase-types.test.ts
@@ -12,6 +12,7 @@ import {
   WORKFLOW_PHASES,
 } from "./state-schema.js";
 import { PhaseSchema as RunLogPhaseSchema } from "./run-log-schema.js";
+import { getPhaseNames } from "./phase-registry.js";
 import {
   CheckVerdictSchema,
   BatchVerdictSchema,
@@ -28,12 +29,12 @@ describe("Phase type unification", () => {
     expect(RunLogPhaseSchema).toBe(PhaseSchema);
   });
 
-  it("WORKFLOW_PHASES matches PhaseSchema options", () => {
-    expect(WORKFLOW_PHASES).toBe(PhaseSchema.options);
+  it("WORKFLOW_PHASES matches registry phase names", () => {
+    expect([...WORKFLOW_PHASES]).toEqual(getPhaseNames());
   });
 
   it("PhaseSchema includes all expected phases", () => {
-    const phases = PhaseSchema.options;
+    const phases = getPhaseNames();
     expect(phases).toContain("spec");
     expect(phases).toContain("security-review");
     expect(phases).toContain("exec");

--- a/src/lib/workflow/state-schema.ts
+++ b/src/lib/workflow/state-schema.ts
@@ -20,11 +20,17 @@
 import { z } from "zod";
 import { ScopeAssessmentSchema } from "../scope/types.js";
 import { PhaseSchema } from "./types.js";
+import { getPhaseNames } from "./phase-registry.js";
 
 /**
- * Workflow phases in order of execution
+ * Workflow phases in order of execution.
+ *
+ * Sourced from the phase registry — replaces the previous `PhaseSchema.options`
+ * literal that existed when `PhaseSchema` was a `z.enum`. Computed at module
+ * load (after `built-in-phases.ts` has run); insertion order is the canonical
+ * pipeline order.
  */
-export const WORKFLOW_PHASES = PhaseSchema.options;
+export const WORKFLOW_PHASES: readonly string[] = getPhaseNames();
 
 /**
  * Phase status - tracks individual phase progress

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -9,28 +9,38 @@ import type { StateManager } from "./state-manager.js";
 import type { ShutdownManager } from "../shutdown.js";
 import type { WorktreeInfo } from "./worktree-manager.js";
 
+// Importing the registry triggers its side-effect registrations (built-ins
+// live at the bottom of phase-registry.ts), guaranteeing the registry is
+// populated before any PhaseSchema parse runs.
+import { phaseRegistry, getPhaseNames } from "./phase-registry.js";
+
 /**
  * Canonical Zod schema for all workflow phases.
  *
- * This is the single source of truth — state-schema.ts and run-log-schema.ts
- * both reference this definition. Add new phases here only.
+ * Backed by the phase registry. `PhaseSchema.parse(name)` succeeds iff
+ * `phaseRegistry.has(name)`. The set of valid phases is the registry's
+ * keys at the time of parsing — registration happens at module load,
+ * so for normal runtime use the set is fixed by the time any code parses.
+ *
+ * This replaces the prior `z.enum([...])` literal. The set of valid names
+ * is identical for the 9 built-in phases; the only observable behavior
+ * change is that `PhaseSchema.options` is no longer available — use
+ * `getPhaseNames()` from `phase-registry.ts` instead.
  */
-export const PhaseSchema = z.enum([
-  "spec",
-  "security-review",
-  "exec",
-  "testgen",
-  "test",
-  "verify",
-  "qa",
-  "loop",
-  "merger",
-]);
+export const PhaseSchema = z
+  .string()
+  .refine((name) => phaseRegistry.has(name), {
+    error: (issue) =>
+      `Unknown phase "${String(issue.input)}". Available: ${getPhaseNames().join(", ")}`,
+  });
 
 /**
- * Available workflow phases (inferred from PhaseSchema)
+ * Available workflow phases. Widened from a string-literal union to `string`
+ * after the registry migration — exhaustiveness checking on `switch (phase)`
+ * is now a runtime concern (see the comment in phase-executor.ts where the
+ * only relevant switch lives).
  */
-export type Phase = z.infer<typeof PhaseSchema>;
+export type Phase = string;
 
 /**
  * Default phases for workflow execution


### PR DESCRIPTION
## Summary

Implements the descoped phase plugin registry from #505. Replaces the scattered `PHASE_PROMPTS` / `AIDER_PHASE_PROMPTS` / `ISOLATED_PHASES` / `UI_LABELS` / `SECURITY_LABELS` constants with a uniform `PhaseDefinition` record per phase, registered against a single `phaseRegistry` singleton at module load. All 9 built-in phases register through the same mechanism — no special-casing in consumer code.

User-defined phases (`.sequant/phases/` filesystem discovery) and the `sequant phases` command are deliberately deferred per the [2026-04-09 descoping comment](https://github.com/sequant-io/sequant/issues/505#issuecomment-4210648463).

## AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | `PhaseDefinition` interface (name, skill, promptTemplate, requiresWorktree, retryStrategy, detect, driverOverrides, order) | ✅ Implemented | `src/lib/workflow/phase-registry.ts:53-91` |
| AC-2 | `PhaseRegistry` class with `register/get/list/has` | ✅ Implemented | `src/lib/workflow/phase-registry.ts:93-148` + tests `phase-registry.test.ts` |
| AC-3 | All 9 built-in phases registered uniformly | ✅ Implemented | `phase-registry.ts:168-323`; tested in `phase-registry.test.ts:92-176` |
| AC-4 (was AC-7) | `phase-executor.ts` reads from registry | ✅ Implemented | Deleted `PHASE_PROMPTS` / `AIDER_PHASE_PROMPTS` / `ISOLATED_PHASES`. Prompt lookup at `phase-executor.ts:454-462`; worktree check at `phase-executor.ts:35-44` |
| AC-5 (was AC-6, simplified) | `phase-mapper.ts` consumes registry detect rules | ✅ Implemented | Removed `UI_LABELS` / `SECURITY_LABELS`; new `detectPhasesFromRegistry()` at `phase-mapper.ts:46-55` |
| AC-6 (was AC-5, simplified) | `--phases` CLI validates against registry at runtime | ✅ Implemented | `bin/cli.ts:76-100` + integration test `phase-registry.integration.test.ts` |
| AC-8 | Driver overrides handled via `driverOverrides` field | ✅ Implemented | Aider prompts now live in `driverOverrides.aider.promptTemplate`; tested at `phase-registry.test.ts:141-150` |

## Test plan

- [x] `npm run build` — passes (TypeScript clean)
- [x] `npm run lint` — passes (no ESLint errors)
- [x] `npm test` — 118 files, 3052 tests pass
- [x] CLI integration tests pass — `phase-registry.integration.test.ts` covers `--phases bogus` (rejected), `--phases exec,bogus,qa` (rejected), `--phases spec,exec,qa` (accepted)
- [x] Existing behavioral tests preserved — `phase-executor.test.ts`'s "uses AIDER_PHASE_PROMPTS for non-claude agents" and "uses PHASE_PROMPTS for claude-code agent" both still pass, sourced from the registry
- [x] `phase-mapper.test.ts` UI / security / docs / bug label detection tests all pass

## Notes

- `Phase` type widens from string-literal union to `string`. The single `switch (phase)` site in `phase-executor.ts` (only special-cases `qa` and `exec`) keeps working as runtime string comparison.
- Built-in registrations live colocated at the bottom of `phase-registry.ts` rather than a separate `built-in-phases.ts` to avoid an ESM import cycle (same pattern as `drivers/index.ts`).
- `BUG_LABELS` / `DOCS_LABELS` / `COMPLEX_LABELS` stay in `phase-mapper.ts` — they are issue-type / quality-loop metadata, not phase-trigger rules. Code comments document the distinction.

Closes #505