### PR TITLE
fix(#645): install relay hook + drift guard so messages reach the agent

### DIFF
--- a/.claude/hooks/post-tool.sh
+++ b/.claude/hooks/post-tool.sh
@@ -13,6 +13,17 @@ if [[ "${CLAUDE_HOOKS_DISABLED:-}" == "true" ]]; then
     exit 0
 fi
 
+# === RELAY CHECK (#383) ===
+# Sourced only when SEQUANT_RELAY=true. The check itself is a single env-var
+# comparison when relay is disabled (default), so non-relay runs incur no cost.
+if [[ "${SEQUANT_RELAY:-}" == "true" ]]; then
+    _RELAY_CHECK="$(dirname "${BASH_SOURCE[0]:-$0}")/relay-check.sh"
+    if [[ -f "${_RELAY_CHECK}" ]]; then
+        # shellcheck source=relay-check.sh disable=SC1091
+        source "${_RELAY_CHECK}" || true
+    fi
+fi
+
 # === READ INPUT FROM STDIN ===
 # Claude Code passes tool data as JSON via stdin, not environment variables
 INPUT_JSON=$(cat)

--- a/.claude/hooks/relay-check.sh
+++ b/.claude/hooks/relay-check.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Relay check (#383): sourced from post-tool.sh on every PostToolUse when
+# SEQUANT_RELAY=true. Reads unread user messages from inbox.jsonl, renders the
+# framing prompt to stdout (which Claude Code surfaces as additional context),
+# and advances the per-issue read cursor.
+#
+# Fast path (no pending messages): exits silently in well under 5 ms.
+# Slow path (messages pending): renders one framing block per invocation.
+
+# Opt-in guard. Fast path #1: env var unset / not exactly "true".
+# Bash precedence makes `cmd1 && cmd2 || cmd3` equivalent to `(cmd1 && cmd2) || cmd3`,
+# so we must use an explicit `if` block to avoid falling through to `exit 0`
+# when the test is FALSE (which is the relay-enabled case).
+if [[ "${SEQUANT_RELAY:-}" != "true" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+# Resolve relay directory. Inside an isolated worktree, the phase-executor sets
+# SEQUANT_WORKTREE. During the spec phase (main repo) we fall back to the
+# per-issue layout under .sequant/relay/<issue>/.
+if [[ -n "${SEQUANT_WORKTREE:-}" ]]; then
+  _RELAY_DIR="${SEQUANT_WORKTREE}/.sequant/relay"
+elif [[ -n "${SEQUANT_ISSUE:-}" ]]; then
+  _RELAY_DIR="${PWD}/.sequant/relay/${SEQUANT_ISSUE}"
+else
+  # Nothing to do without a target issue or worktree.
+  return 0 2>/dev/null || exit 0
+fi
+
+_INBOX="${_RELAY_DIR}/inbox.jsonl"
+_CURSOR="${_RELAY_DIR}/.cursor"
+
+# Fast path #2: AC-8 — `test -s` is sub-millisecond. Empty/missing inbox skips.
+[[ -s "${_INBOX}" ]] || return 0 2>/dev/null || exit 0
+
+# Cursor read (missing → 0). Compare against current inbox line count.
+_CURSOR_VAL=0
+if [[ -f "${_CURSOR}" ]]; then
+  _CURSOR_VAL=$(cat "${_CURSOR}" 2>/dev/null || echo 0)
+  [[ "${_CURSOR_VAL}" =~ ^[0-9]+$ ]] || _CURSOR_VAL=0
+fi
+
+_INBOX_LINES=$(wc -l < "${_INBOX}" 2>/dev/null || echo 0)
+_INBOX_LINES=${_INBOX_LINES// /} # trim whitespace from wc output on macOS
+
+# Fast path #3: cursor caught up.
+if [[ "${_INBOX_LINES}" -le "${_CURSOR_VAL}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# Slow path: render frame.
+
+# Resolve frame template. Phase-executor sets SEQUANT_RELAY_FRAME to the
+# absolute path within the sequant installation. Falls back to ./templates/
+# (when running from the sequant repo itself).
+_FRAME_PATH="${SEQUANT_RELAY_FRAME:-}"
+if [[ -z "${_FRAME_PATH}" || ! -f "${_FRAME_PATH}" ]]; then
+  for _candidate in \
+      "${PWD}/.claude/relay/frame.txt" \
+      "${PWD}/templates/relay/frame.txt"; do
+    if [[ -f "${_candidate}" ]]; then
+      _FRAME_PATH="${_candidate}"
+      break
+    fi
+  done
+fi
+if [[ -z "${_FRAME_PATH}" || ! -f "${_FRAME_PATH}" ]]; then
+  # Missing template — emit a minimal frame so the user still gets through.
+  _FRAME_PATH=""
+fi
+
+# Skip the lines we've already shown the model. `tail -n +N` is 1-indexed.
+_START=$((_CURSOR_VAL + 1))
+
+# Render messages. Sort by timestamp ascending (AC-9). jq handles JSON parsing.
+# Messages are separated by `---` lines; a single message has no separator.
+_render_messages() {
+  if command -v jq &>/dev/null; then
+    tail -n "+${_START}" "${_INBOX}" \
+      | jq -s -r 'sort_by(.timestamp) | map("Type: \(.type)\nMessage: \((.message // "") | tojson)") | join("\n---\n")'
+  else
+    # Fallback without jq: dump raw lines.
+    tail -n "+${_START}" "${_INBOX}"
+  fi
+}
+
+if [[ -n "${_FRAME_PATH}" ]]; then
+  # Split frame template at {{MESSAGES}} placeholder.
+  _PREFIX=$(awk '/\{\{MESSAGES\}\}/ {exit} {print}' "${_FRAME_PATH}")
+  _SUFFIX=$(awk '/\{\{MESSAGES\}\}/ {found=1; next} found {print}' "${_FRAME_PATH}")
+  printf '%s\n' "${_PREFIX}"
+  _render_messages
+  if [[ -n "${_SUFFIX}" ]]; then
+    printf '%s\n' "${_SUFFIX}"
+  fi
+else
+  printf '[SEQUANT RELAY — message from user]\n'
+  _render_messages
+fi
+
+# Advance cursor atomically (temp + rename on same fs).
+_TMP="${_CURSOR}.tmp.$$"
+if printf '%s' "${_INBOX_LINES}" > "${_TMP}" 2>/dev/null; then
+  mv -f "${_TMP}" "${_CURSOR}" 2>/dev/null || rm -f "${_TMP}" 2>/dev/null || true
+fi
+
+return 0 2>/dev/null || exit 0

--- a/src/commands/__tests__/watch-dead-relay.test.ts
+++ b/src/commands/__tests__/watch-dead-relay.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Verifies that `sequant watch` detects relay deactivation (#645, Gap 3) and
+ * exits cleanly instead of tailing a dead relay forever.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { watchCommand } from "../watch.ts";
+import { writePidFile } from "../../lib/relay/pid.ts";
+
+describe("sequant watch dead-relay detection (#645)", () => {
+  let tmp: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "sequant-watch-test-"));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("exits immediately with no-active-relay when pidfile and outbox are both missing", async () => {
+    await watchCommand({
+      args: ["12345"],
+      options: { cwd: tmp, json: true },
+    });
+
+    const calls = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.length).toBe(1);
+    const parsed = JSON.parse(calls[0]);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.reason).toBe("no-active-relay");
+    expect(parsed.issue).toBe(12345);
+  });
+
+  it("exits with relay-ended when the pidfile is removed mid-watch", async () => {
+    const issue = 67890;
+    // Seed an active relay: pidfile + empty outbox.
+    writePidFile(issue, process.pid, tmp);
+    const relayDir = join(tmp, ".sequant", "relay", String(issue));
+    mkdirSync(relayDir, { recursive: true });
+    writeFileSync(join(relayDir, "outbox.jsonl"), "");
+
+    // Remove the pidfile after a short delay to simulate deactivation.
+    const timer = setTimeout(() => {
+      try {
+        unlinkSync(join(tmp, ".sequant", "pids", `${issue}.pid`));
+      } catch {
+        /* swallow */
+      }
+    }, 60);
+
+    await watchCommand({
+      args: [String(issue)],
+      options: { cwd: tmp, pollIntervalMs: 30, json: true },
+    });
+    clearTimeout(timer);
+
+    const lines = logSpy.mock.calls.map((c) => String(c[0]));
+    const ended = lines.find(
+      (l) =>
+        l.includes('"reason":"relay-ended"') && l.includes(`"issue":${issue}`),
+    );
+    expect(ended).toBeTruthy();
+  });
+});

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -109,6 +109,7 @@ export async function watchCommand(argsAndOptions: {
   const cwd = options.cwd ?? process.cwd();
   const outboxPath = outboxPathFor(issueNumber, {
     worktreePath: issueState?.worktree,
+    cwd,
   });
 
   const pollIntervalMs = options.pollIntervalMs ?? 200;

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -8,6 +8,8 @@ import { existsSync, statSync, createReadStream, watch } from "fs";
 import { Readable } from "stream";
 import chalk from "chalk";
 import { outboxPathFor } from "../lib/relay/paths.js";
+import { listArchives } from "../lib/relay/archive.js";
+import { readPidFile } from "../lib/relay/pid.js";
 import { StateManager } from "../lib/workflow/state-manager.js";
 import { RelayResponseSchema, type RelayResponse } from "../lib/relay/types.js";
 
@@ -17,6 +19,8 @@ export interface WatchCommandOptions {
   pollIntervalMs?: number;
   /** Abort signal for clean shutdown (tests). */
   signal?: AbortSignal;
+  /** Override cwd for resolving the pid file + archive root (test seam). */
+  cwd?: string;
 }
 
 function formatTimestamp(iso: string): string {
@@ -102,6 +106,7 @@ export async function watchCommand(argsAndOptions: {
 
   const stateManager = new StateManager();
   const issueState = await stateManager.getIssueState(issueNumber);
+  const cwd = options.cwd ?? process.cwd();
   const outboxPath = outboxPathFor(issueNumber, {
     worktreePath: issueState?.worktree,
   });
@@ -114,17 +119,45 @@ export async function watchCommand(argsAndOptions: {
     tail.offset = statSync(outboxPath).size;
   }
 
+  // Dead-relay detection (#645, Gap 3). The pidfile is written by activateRelay
+  // and removed by deactivateRelay. If it's absent and the outbox is absent at
+  // startup, there is nothing alive to watch — print a useful pointer and exit.
+  const initialPidPresent = readPidFile(issueNumber, cwd) !== null;
+  const initialOutboxPresent = existsSync(outboxPath);
+  if (!initialPidPresent && !initialOutboxPresent) {
+    const archives = listArchives(issueNumber, cwd);
+    const summary = `No active relay for #${issueNumber}.`;
+    const hint = archives[0]
+      ? ` Most recent archive: ${archives[0]}`
+      : " (no archived runs found)";
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          ok: false,
+          issue: issueNumber,
+          reason: "no-active-relay",
+          archive: archives[0] ?? null,
+        }),
+      );
+    } else {
+      console.log(chalk.yellow(summary + hint));
+    }
+    return;
+  }
+
   if (!options.json) {
     console.log(chalk.gray(`Watching #${issueNumber} outbox — Ctrl+C to stop`));
   }
 
   let stopped = false;
-  const stop = (): void => {
+  let endReason: "signal" | "relay-ended" | null = null;
+  const stop = (reason: "signal" | "relay-ended" = "signal"): void => {
     stopped = true;
+    if (!endReason) endReason = reason;
   };
-  options.signal?.addEventListener("abort", stop);
+  options.signal?.addEventListener("abort", () => stop("signal"));
   process.on("SIGINT", () => {
-    stop();
+    stop("signal");
     if (!options.json) console.log(chalk.gray("\nStopped watching."));
     process.exit(0);
   });
@@ -150,6 +183,7 @@ export async function watchCommand(argsAndOptions: {
 
   // Polling loop — also used as a heartbeat when fs.watch is active so we
   // don't miss events on filesystems where watch is unreliable.
+  let sawLivePid = initialPidPresent;
   while (!stopped) {
     try {
       const replies = await readNewLines(outboxPath, tail);
@@ -157,6 +191,23 @@ export async function watchCommand(argsAndOptions: {
     } catch {
       /* transient — try again next tick */
     }
+
+    // Dead-relay detection (#645, Gap 3). Once we've seen a live pidfile, its
+    // absence means the run has deactivated relay (archive complete). Drain
+    // one more poll for late writes, then exit cleanly.
+    const pidAlive = readPidFile(issueNumber, cwd) !== null;
+    if (sawLivePid && !pidAlive) {
+      try {
+        const finalReplies = await readNewLines(outboxPath, tail);
+        emit(finalReplies);
+      } catch {
+        /* swallow */
+      }
+      stop("relay-ended");
+      break;
+    }
+    if (pidAlive) sawLivePid = true;
+
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
@@ -168,4 +219,21 @@ export async function watchCommand(argsAndOptions: {
     }
   }
   void useWatcher; // currently unused beyond best-effort init
+
+  if (endReason === "relay-ended") {
+    const archives = listArchives(issueNumber, cwd);
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          ok: true,
+          issue: issueNumber,
+          reason: "relay-ended",
+          archive: archives[0] ?? null,
+        }),
+      );
+    } else {
+      const hint = archives[0] ? ` Archive: ${archives[0]}` : "";
+      console.log(chalk.gray(`Run for #${issueNumber} ended.${hint}`));
+    }
+  }
 }

--- a/src/lib/merge-check/merge-check.test.ts
+++ b/src/lib/merge-check/merge-check.test.ts
@@ -97,7 +97,7 @@ describe("mirroring-check", () => {
         issueNumber: 200,
         title: "Update hooks",
         branch: "feature/200-hooks",
-        filesModified: ["hooks/pre-tool.sh"],
+        filesModified: [".claude/hooks/pre-tool.sh"],
       },
     ];
 

--- a/src/lib/merge-check/types.ts
+++ b/src/lib/merge-check/types.ts
@@ -193,7 +193,7 @@ export interface MirrorPair {
  */
 export const DEFAULT_MIRROR_PAIRS: MirrorPair[] = [
   { source: ".claude/skills", target: "templates/skills" },
-  { source: "hooks", target: "templates/hooks" },
+  { source: ".claude/hooks", target: "templates/hooks" },
 ];
 
 /**

--- a/src/lib/relay/__tests__/archive-split-counts.test.ts
+++ b/src/lib/relay/__tests__/archive-split-counts.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Verifies that archived `meta.json` splits message counts into `inboxCount`
+ * and `outboxCount` so post-hoc inspection can spot unanswered queries
+ * (#645, Gap 5).
+ */
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { archiveRelayDir, listArchives } from "../archive.ts";
+import { RelayArchiveMetaSchema } from "../types.ts";
+
+describe("archiveRelayDir splits inbox/outbox counts (#645)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "relay-archive-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes inboxCount + outboxCount and preserves messageCount as the sum", () => {
+    const issue = 645;
+    const relayDir = join(tmp, ".sequant", "relay");
+    mkdirSync(relayDir, { recursive: true });
+
+    // 3 inbox messages, 1 outbox reply.
+    const inboxLines = [
+      '{"id":"msg_a","timestamp":"2026-05-14T00:00:00.000Z","type":"query","message":"a"}',
+      '{"id":"msg_b","timestamp":"2026-05-14T00:00:01.000Z","type":"query","message":"b"}',
+      '{"id":"msg_c","timestamp":"2026-05-14T00:00:02.000Z","type":"directive","message":"c"}',
+    ];
+    const outboxLines = [
+      '{"id":"reply_1","inReplyTo":"msg_a","timestamp":"2026-05-14T00:00:00.500Z","message":"hi"}',
+    ];
+    writeFileSync(join(relayDir, "inbox.jsonl"), inboxLines.join("\n") + "\n");
+    writeFileSync(
+      join(relayDir, "outbox.jsonl"),
+      outboxLines.join("\n") + "\n",
+    );
+
+    const result = archiveRelayDir(issue, {
+      worktreePath: tmp,
+      archiveCwd: tmp,
+      phase: "qa",
+      startedAt: "2026-05-14T00:00:00.000Z",
+      endedAt: "2026-05-14T00:00:05.000Z",
+      messageCount: 4,
+    });
+
+    expect(result.archived).toBe(true);
+    expect(result.archivePath).toBeTruthy();
+
+    const metaPath = join(result.archivePath!, "meta.json");
+    const meta = RelayArchiveMetaSchema.parse(
+      JSON.parse(readFileSync(metaPath, "utf-8")),
+    );
+
+    expect(meta.inboxCount).toBe(3);
+    expect(meta.outboxCount).toBe(1);
+    expect(meta.messageCount).toBe(4);
+    expect(meta.inboxCount! + meta.outboxCount!).toBe(meta.messageCount);
+  });
+
+  it("schema accepts archives without the split fields (back-compat)", () => {
+    // Simulate an archive written before the split — `meta.json` would lack
+    // `inboxCount` / `outboxCount`. Schema must still parse it.
+    const legacyMeta = {
+      issue: 100,
+      phase: "exec",
+      startedAt: "2026-05-14T00:00:00.000Z",
+      endedAt: "2026-05-14T00:00:05.000Z",
+      messageCount: 2,
+    };
+    expect(() => RelayArchiveMetaSchema.parse(legacyMeta)).not.toThrow();
+  });
+
+  it("listArchives finds the freshly-written archive", () => {
+    const issue = 999;
+    const relayDir = join(tmp, ".sequant", "relay");
+    mkdirSync(relayDir, { recursive: true });
+    writeFileSync(
+      join(relayDir, "inbox.jsonl"),
+      '{"id":"msg_x","timestamp":"2026-05-14T00:00:00.000Z","type":"query","message":"x"}\n',
+    );
+
+    archiveRelayDir(issue, {
+      worktreePath: tmp,
+      archiveCwd: tmp,
+      phase: "exec",
+      startedAt: "2026-05-14T00:00:00.000Z",
+      messageCount: 1,
+    });
+
+    const archives = listArchives(issue, tmp);
+    expect(archives.length).toBe(1);
+    expect(archives[0]).toContain(`${issue}-exec-`);
+  });
+});

--- a/src/lib/relay/__tests__/hook-sync.test.ts
+++ b/src/lib/relay/__tests__/hook-sync.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Drift guard for the interactive relay hook (#645).
+ *
+ * PR #638 added `templates/hooks/relay-check.sh` + the SEQUANT_RELAY sourcing
+ * block in `templates/hooks/post-tool.sh`, but never updated the active hooks
+ * in `.claude/hooks/`. Every worktree of this repo inherited the stale checked-in
+ * post-tool.sh, so the PostToolUse hook chain never sourced relay-check.sh and
+ * relay messages were silently consumed without reply.
+ *
+ * These assertions fail immediately if either of those files drifts again.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { describe, expect, it } from "vitest";
+
+const TEMPLATE_RELAY_CHECK = "templates/hooks/relay-check.sh";
+const ACTIVE_RELAY_CHECK = ".claude/hooks/relay-check.sh";
+const ACTIVE_POST_TOOL = ".claude/hooks/post-tool.sh";
+
+describe("relay hook sync (#645)", () => {
+  it("active relay-check.sh is byte-identical to the template", () => {
+    const templatePath = path.join(process.cwd(), TEMPLATE_RELAY_CHECK);
+    const activePath = path.join(process.cwd(), ACTIVE_RELAY_CHECK);
+
+    expect(fs.existsSync(templatePath)).toBe(true);
+    expect(fs.existsSync(activePath)).toBe(true);
+
+    const templateBytes = fs.readFileSync(templatePath);
+    const activeBytes = fs.readFileSync(activePath);
+
+    expect(activeBytes.equals(templateBytes)).toBe(true);
+  });
+
+  it("active post-tool.sh sources relay-check.sh under SEQUANT_RELAY", () => {
+    const activePath = path.join(process.cwd(), ACTIVE_POST_TOOL);
+    expect(fs.existsSync(activePath)).toBe(true);
+
+    const content = fs.readFileSync(activePath, "utf-8");
+
+    expect(content).toMatch(/SEQUANT_RELAY:-/);
+    expect(content).toMatch(/source\s+"?\$\{?_RELAY_CHECK\}?"?/);
+  });
+});

--- a/src/lib/relay/archive.ts
+++ b/src/lib/relay/archive.ts
@@ -105,6 +105,11 @@ export function archiveRelayDir(
       }
     }
 
+    // Split inbox/outbox counts (#645, Gap 5). Surfaces unanswered queries
+    // (inboxCount > outboxCount) when inspecting archives post-hoc.
+    const inboxCount = countLines(join(srcDir, RELAY_INBOX));
+    const outboxCount = countLines(join(srcDir, RELAY_OUTBOX));
+
     // Write meta.json.
     const meta: RelayArchiveMeta = RelayArchiveMetaSchema.parse({
       issue,
@@ -112,6 +117,8 @@ export function archiveRelayDir(
       startedAt: options.startedAt,
       endedAt,
       messageCount: options.messageCount,
+      inboxCount,
+      outboxCount,
     });
     writeFileSync(
       join(destDir, "meta.json"),

--- a/src/lib/relay/types.ts
+++ b/src/lib/relay/types.ts
@@ -87,7 +87,16 @@ export const RelayArchiveMetaSchema = z.object({
   phase: z.string(),
   startedAt: z.string().datetime(),
   endedAt: z.string().datetime(),
+  /** Total inbox + outbox messages exchanged during the run. */
   messageCount: z.number().int().nonnegative(),
+  /**
+   * Inbox messages (user → agent). Split out from `messageCount` (#645, Gap 5)
+   * so post-hoc inspection can spot unanswered queries (inboxCount > outboxCount).
+   * Optional for backward compatibility with archives written before this split.
+   */
+  inboxCount: z.number().int().nonnegative().optional(),
+  /** Outbox replies (agent → user). See `inboxCount` for context. */
+  outboxCount: z.number().int().nonnegative().optional(),
 });
 
 export type RelayArchiveMeta = z.infer<typeof RelayArchiveMetaSchema>;


### PR DESCRIPTION
## Summary

Fixes #645. Interactive relay messages were silently consumed because `.claude/hooks/post-tool.sh` (the active PostToolUse hook) did not source `relay-check.sh`, and `.claude/hooks/relay-check.sh` did not exist in this repo at all. PR #638 added both to `templates/hooks/` but never updated the installed copies.

- **Phase 1 (root cause):** install `relay-check.sh`, insert the SEQUANT_RELAY sourcing block into `post-tool.sh` (surgical — leaves local-only test-coverage + post-merge-cleanup blocks intact)
- **Phase 2 (drift guard):** fix `DEFAULT_MIRROR_PAIRS` source path (`hooks` → `.claude/hooks`); new Vitest asserts byte equality + sourcing block presence
- **Phase 3 (UX improvements from gaps 3 + 5):** `sequant watch` exits cleanly when relay deactivates instead of polling forever; archive `meta.json` records `inboxCount` + `outboxCount` separately so unanswered queries are visible post-hoc

Out of scope: Gaps 4 (prompt UX polish), 6 (stale phase label), 7 (signal-based abort), and the broader `.claude/hooks/` drift in `pre-tool.sh`. See issue comments for rationale.

## Test plan

**Unit tests (already passing in CI):**
- [x] `npm run build` (tsc) — clean
- [x] `npx vitest run src/lib/relay src/lib/merge-check src/commands/__tests__` — 7 new tests, 79 total touched, all passing
- [x] Adversarial: corrupting `.claude/hooks/relay-check.sh` makes `hook-sync.test.ts` fail; restoring it passes

**Manual verification (AC-3 — please run before merge):**

```bash
# Terminal 1 — start a small run
gh issue list --state open | head
npx sequant run <issue> --no-mcp --phases exec

# Terminal 2 — within 30s
npx sequant prompt <issue> "status?"
npx sequant watch <issue>
```

**Expected:**
- Outbox reply appears in `watch` within ~30s
- After the run completes, `watch` prints `Run for #<issue> ended. Archive: …` and exits 0
- `cat <archive>/meta.json` shows both `inboxCount` and `outboxCount` fields

If the smoke fails (no outbox reply), Gap 2 (sub-agent hook isolation) remains a live hypothesis; file a follow-up issue with the sentinel-log diagnostic plan in the original issue body.

## Files touched

- `.claude/hooks/post-tool.sh` (+11) — insert SEQUANT_RELAY sourcing block
- `.claude/hooks/relay-check.sh` (new, +107) — byte-identical to template
- `src/commands/watch.ts` (+75 / −1) — dead-relay detection
- `src/lib/relay/archive.ts` (+7) — inbox/outbox split counts
- `src/lib/relay/types.ts` (+9) — schema additions
- `src/lib/merge-check/types.ts` (+1 / −1) — mirror-pair source path
- `src/lib/merge-check/merge-check.test.ts` (+1 / −1) — fixture update
- `src/lib/relay/__tests__/hook-sync.test.ts` (new, +44) — drift guard
- `src/lib/relay/__tests__/archive-split-counts.test.ts` (new, +91) — split-count coverage
- `src/commands/__tests__/watch-dead-relay.test.ts` (new, +71) — watch behavior

Fixes #645