### PR TITLE
chore(#645): reconcile .claude/hooks/ with templates/hooks/

### DIFF
--- a/.claude/hooks/post-tool.sh
+++ b/.claude/hooks/post-tool.sh
@@ -49,24 +49,35 @@ else
     TOOL_OUTPUT=$(echo "$INPUT_JSON" | grep -oE '"tool_response"\s*:\s*\{[^}]+\}' | head -1)
 fi
 
-TIMING_LOG="/tmp/claude-timing.log"
-QUALITY_LOG="/tmp/claude-quality.log"
-TESTS_LOG="/tmp/claude-tests.log"
-PARALLEL_MARKER_PREFIX="/tmp/claude-parallel-"
+_TMPDIR="${TMPDIR:-/tmp}"
+
+# Use CLAUDE_PLUGIN_DATA for persistent logs (survives plugin updates)
+if [[ -n "${CLAUDE_PLUGIN_DATA}" ]]; then
+  _LOG_DIR="${CLAUDE_PLUGIN_DATA}/logs"
+  mkdir -p "$_LOG_DIR"
+else
+  _LOG_DIR="${_TMPDIR}"
+fi
+
+TIMING_LOG="${_LOG_DIR}/claude-timing.log"
+QUALITY_LOG="${_LOG_DIR}/claude-quality.log"
+TESTS_LOG="${_LOG_DIR}/claude-tests.log"
+PARALLEL_MARKER_PREFIX="${_TMPDIR}/claude-parallel-"
 
 # === AGENT ID DETECTION ===
 # For parallel agents, detect group ID from marker files
-# Format: /tmp/claude-parallel-<group-id>.marker
+# Format: ${_TMPDIR}/claude-parallel-<group-id>.marker
 AGENT_ID=""
 IS_PARALLEL_AGENT="false"
-for marker in "${PARALLEL_MARKER_PREFIX}"*.marker; do
-    if [[ -f "$marker" ]]; then
+# Find marker files using find (works in both bash and zsh)
+while IFS= read -r marker; do
+    if [[ -n "$marker" && -f "$marker" ]]; then
         # Extract group ID from marker filename
         AGENT_ID=$(basename "$marker" | sed 's/claude-parallel-//' | sed 's/\.marker//')
         IS_PARALLEL_AGENT="true"
         break
     fi
-done
+done < <(find "${_TMPDIR}" -maxdepth 1 -name "claude-parallel-*.marker" 2>/dev/null)
 
 # === TIMING END ===
 # Include agent ID in log format if available (AC-4)
@@ -201,14 +212,16 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
 fi
 
 # === DETECT TEST FAILURES ===
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'npm (test|run test)'; then
+# Supports: npm, bun, yarn, pnpm
+if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE '(npm (test|run test)|bun (test|run test)|yarn (test|run test)|pnpm (test|run test))'; then
     if echo "$TOOL_OUTPUT" | grep -qE '(FAIL|failed|Error:)'; then
         echo "$(date +%H:%M:%S) TEST_FAILURE detected" >> "$QUALITY_LOG"
     fi
 fi
 
 # === DETECT BUILD FAILURES ===
-if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'npm run build'; then
+# Supports: npm, bun, yarn, pnpm
+if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE '(npm run build|bun run build|yarn build|yarn run build|pnpm run build)'; then
     if echo "$TOOL_OUTPUT" | grep -qE '(error TS|Build failed|Error:)'; then
         echo "$(date +%H:%M:%S) BUILD_FAILURE detected" >> "$QUALITY_LOG"
     fi
@@ -219,10 +232,10 @@ fi
 # Automatically appends coverage analysis to npm test output
 # Logs which changed files have/don't have corresponding tests
 if [[ "${CLAUDE_HOOKS_COVERAGE:-}" == "true" ]]; then
-    if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'npm (test|run test)'; then
+    if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE '(npm (test|run test)|bun (test|run test)|yarn (test|run test)|pnpm (test|run test))'; then
         # Only run if tests passed (don't clutter failure output)
         if ! echo "$TOOL_OUTPUT" | grep -qE '(FAIL|failed|Error:)'; then
-            COVERAGE_LOG="/tmp/claude-coverage.log"
+            COVERAGE_LOG="${_LOG_DIR}/claude-coverage.log"
 
             # Get changed source files (excluding tests)
             changed_files=$(git diff main...HEAD --name-only 2>/dev/null | grep -E '\.(ts|tsx|js|jsx)$' | grep -v -E '\.test\.|\.spec\.|__tests__' || true)
@@ -239,9 +252,7 @@ if [[ "${CLAUDE_HOOKS_COVERAGE:-}" == "true" ]]; then
                     base=$(basename "$file" .ts | sed 's/\.tsx$//')
 
                     # Check for test file
-                    has_test="no"
                     if find . -name "${base}.test.*" -o -name "${base}.spec.*" 2>/dev/null | grep -q .; then
-                        has_test="yes"
                         ((files_with_tests++))
                     else
                         ((files_without_tests++))
@@ -371,7 +382,7 @@ if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'gh pr merge'; 
 
                 if [[ -n "$WORKTREE_PATH" && -d "$WORKTREE_PATH" ]]; then
                     git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
-                    echo "POST-MERGE: Removed worktree $WORKTREE_PATH for branch $BRANCH_NAME" >> /tmp/claude-hook.log
+                    echo "POST-MERGE: Removed worktree $WORKTREE_PATH for branch $BRANCH_NAME" >> "${_LOG_DIR}/claude-hook.log"
                 fi
 
                 # Clean up local branch

--- a/.claude/hooks/pre-tool.sh
+++ b/.claude/hooks/pre-tool.sh
@@ -33,20 +33,32 @@ else
     fi
 fi
 
-TIMING_LOG="/tmp/claude-timing.log"
-PARALLEL_MARKER_PREFIX="/tmp/claude-parallel-"
+_TMPDIR="${TMPDIR:-/tmp}"
+
+# Use CLAUDE_PLUGIN_DATA for persistent logs (survives plugin updates)
+if [[ -n "${CLAUDE_PLUGIN_DATA}" ]]; then
+  _LOG_DIR="${CLAUDE_PLUGIN_DATA}/logs"
+  mkdir -p "$_LOG_DIR"
+else
+  _LOG_DIR="${_TMPDIR}"
+fi
+
+TIMING_LOG="${_LOG_DIR}/claude-timing.log"
+HOOK_LOG="${_LOG_DIR}/claude-hook.log"
+PARALLEL_MARKER_PREFIX="${_TMPDIR}/claude-parallel-"
 
 # === AGENT ID DETECTION ===
 # For parallel agents, detect group ID from marker files
-# Format: /tmp/claude-parallel-<group-id>.marker
+# Format: ${_TMPDIR}/claude-parallel-<group-id>.marker
 AGENT_ID=""
-for marker in "${PARALLEL_MARKER_PREFIX}"*.marker; do
-    if [[ -f "$marker" ]]; then
+# Find marker files using find (works in both bash and zsh)
+while IFS= read -r marker; do
+    if [[ -n "$marker" && -f "$marker" ]]; then
         # Extract group ID from marker filename
         AGENT_ID=$(basename "$marker" | sed 's/claude-parallel-//' | sed 's/\.marker//')
         break
     fi
-done
+done < <(find "${_TMPDIR}" -maxdepth 1 -name "claude-parallel-*.marker" 2>/dev/null)
 
 # === TIMING START ===
 # Include agent ID in log format if available (AC-4)
@@ -75,33 +87,33 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
 if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) '; then
     # Pattern requires command to START with file reader (not match in quoted strings)
     if echo "$TOOL_INPUT" | grep -qE '^(cat|less|head|tail|more) .*\.(env|pem|key)'; then
-        echo "HOOK_BLOCKED: Reading secret file" | tee -a /tmp/claude-hook.log >&2
+        echo "HOOK_BLOCKED: Reading secret file" | tee -a "$HOOK_LOG" >&2
         exit 2
     fi
 
     if echo "$TOOL_INPUT" | grep -qE '^(cat|less) .*~/\.(ssh|aws|gnupg|config/gh)'; then
-        echo "HOOK_BLOCKED: Reading credential directory" | tee -a /tmp/claude-hook.log >&2
+        echo "HOOK_BLOCKED: Reading credential directory" | tee -a "$HOOK_LOG" >&2
         exit 2
     fi
 fi
 
 # Bare environment dump
 if echo "$TOOL_INPUT" | grep -qE '^(env|printenv|export)$'; then
-    echo "HOOK_BLOCKED: Environment dump" | tee -a /tmp/claude-hook.log >&2
+    echo "HOOK_BLOCKED: Environment dump" | tee -a "$HOOK_LOG" >&2
     exit 2
 fi
 
 # Destructive system commands
 # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#570)
 if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'sudo|rm -rf /|rm -rf ~|rm -rf \$HOME'; then
-    echo "HOOK_BLOCKED: Destructive system command" | tee -a /tmp/claude-hook.log >&2
+    echo "HOOK_BLOCKED: Destructive system command" | tee -a "$HOOK_LOG" >&2
     exit 2
 fi
 
 # Deployment (should never happen in issue automation)
 # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#570)
 if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'vercel (deploy|--prod)|terraform (apply|destroy)|kubectl (apply|delete)'; then
-    echo "HOOK_BLOCKED: Deployment command" | tee -a /tmp/claude-hook.log >&2
+    echo "HOOK_BLOCKED: Deployment command" | tee -a "$HOOK_LOG" >&2
     exit 2
 fi
 
@@ -109,7 +121,7 @@ fi
 # Pattern requires -f to be a standalone flag (not part of branch name like -fix)
 # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git push.*(--force| -f($| ))'; then
-    echo "HOOK_BLOCKED: Force push" | tee -a /tmp/claude-hook.log >&2
+    echo "HOOK_BLOCKED: Force push" | tee -a "$HOOK_LOG" >&2
     exit 2
 fi
 
@@ -153,7 +165,7 @@ if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | gre
             echo "    git stash                        # save changes"
             echo "    git merge --abort                # cancel merge"
             echo "  Or run directly in terminal (outside Claude Code) to bypass"
-        } | tee -a /tmp/claude-hook.log >&2
+        } | tee -a "$HOOK_LOG" >&2
         exit 2
     fi
 fi
@@ -161,7 +173,7 @@ fi
 # CI/CD triggers (automation shouldn't trigger more automation)
 # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#570)
 if ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'gh workflow run'; then
-    echo "HOOK_BLOCKED: Workflow trigger" | tee -a /tmp/claude-hook.log >&2
+    echo "HOOK_BLOCKED: Workflow trigger" | tee -a "$HOOK_LOG" >&2
     exit 2
 fi
 
@@ -228,7 +240,7 @@ if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
                 {
                     echo "HOOK_BLOCKED: Hardcoded secret detected in staged changes"
                     echo "  Use 'git commit --no-verify' to bypass if this is a false positive"
-                } | tee -a /tmp/claude-hook.log >&2
+                } | tee -a "$HOOK_LOG" >&2
                 exit 2
             fi
 
@@ -239,7 +251,7 @@ if [[ "${CLAUDE_HOOKS_SECURITY:-true}" != "false" ]]; then
                     echo "HOOK_BLOCKED: Sensitive file in commit (${STAGED_FILES})"
                     echo "  Files like .env, *.pem, *.key should not be committed"
                     echo "  Use 'git commit --no-verify' to bypass if this is intentional"
-                } | tee -a /tmp/claude-hook.log >&2
+                } | tee -a "$HOOK_LOG" >&2
                 exit 2
             fi
         fi
@@ -269,7 +281,7 @@ if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|p
         fi
 
         if [[ "$CHANGES" -eq 0 ]]; then
-            echo "HOOK_BLOCKED: No changes to commit. Stage files with 'git add' first." | tee -a /tmp/claude-hook.log >&2
+            echo "HOOK_BLOCKED: No changes to commit. Stage files with 'git add' first." | tee -a "$HOOK_LOG" >&2
             exit 2
         fi
     fi
@@ -278,7 +290,7 @@ fi
 # --- Worktree Validation (AC-8) ---
 # Warn (but don't block) when committing outside a feature worktree
 # This catches accidental commits to main repo during feature work
-QUALITY_LOG="/tmp/claude-quality.log"
+QUALITY_LOG="${_LOG_DIR}/claude-quality.log"
 # Skip for gh issue/pr commands — body text may legitimately reference these tokens (#564)
 if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|pr) ' && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
     CWD=$(pwd)
@@ -322,9 +334,15 @@ if [[ "$TOOL_NAME" == "Bash" ]] && ! echo "$TOOL_INPUT" | grep -qE '^gh (issue|p
             {
                 echo "HOOK_BLOCKED: Commit must follow conventional commits format"
                 echo "  Expected: type(scope): description"
+                # AC-1 & AC-2 (Issue #198): Detect merge commits and provide helpful suggestion
+                if [[ "$MSG" == Merge\ * ]]; then
+                    echo ""
+                    echo "  💡 For merge commits, use: chore: merge main into feature branch"
+                    echo ""
+                fi
                 echo "  Types: feat|fix|docs|style|refactor|test|chore|ci|build|perf"
                 echo "  Got: $MSG"
-            } | tee -a /tmp/claude-hook.log >&2
+            } | tee -a "$HOOK_LOG" >&2
             exit 2
         fi
     fi
@@ -359,7 +377,7 @@ if [[ "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Write" ]]; then
         # AC-4 (Issue #31): Check worktree directory exists before path validation
         # Prevents Write tool from creating non-existent worktree directories
         if [[ ! -d "$EXPECTED_WORKTREE" ]]; then
-            echo "HOOK_BLOCKED: Worktree does not exist: $EXPECTED_WORKTREE" | tee -a /tmp/claude-hook.log >&2
+            echo "HOOK_BLOCKED: Worktree does not exist: $EXPECTED_WORKTREE" | tee -a "$HOOK_LOG" >&2
             exit 2
         fi
 
@@ -388,7 +406,7 @@ if [[ "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Write" ]]; then
                     if [[ -n "${SEQUANT_ISSUE:-}" ]]; then
                         echo "  Issue: #$SEQUANT_ISSUE"
                     fi
-                } | tee -a /tmp/claude-hook.log >&2
+                } | tee -a "$HOOK_LOG" >&2
                 exit 2
             fi
         fi
@@ -411,7 +429,7 @@ if [[ "${CLAUDE_HOOKS_FILE_LOCKING:-true}" == "true" ]]; then
 
         if [[ -n "$FILE_PATH" ]]; then
             # Create a lock file based on file path hash (handles special chars)
-            LOCK_FILE="/tmp/claude-lock-$(echo "$FILE_PATH" | md5 -q 2>/dev/null || echo "$FILE_PATH" | md5sum | cut -d' ' -f1).lock"
+            LOCK_FILE="${_TMPDIR}/claude-lock-$(echo "$FILE_PATH" | md5 -q 2>/dev/null || echo "$FILE_PATH" | md5sum | cut -d' ' -f1).lock"
 
             # Try to acquire lock with 30 second timeout
             # Use a subshell to hold the lock during the tool execution
@@ -419,7 +437,7 @@ if [[ "${CLAUDE_HOOKS_FILE_LOCKING:-true}" == "true" ]]; then
                 # macOS: use lockf
                 exec 200>"$LOCK_FILE"
                 if ! lockf -t 30 200 2>/dev/null; then
-                    echo "HOOK_BLOCKED: File locked by another agent: $FILE_PATH" | tee -a /tmp/claude-hook.log >&2
+                    echo "HOOK_BLOCKED: File locked by another agent: $FILE_PATH" | tee -a "$HOOK_LOG" >&2
                     exit 2
                 fi
                 # Lock will be released when the file descriptor closes (process exits)
@@ -427,7 +445,7 @@ if [[ "${CLAUDE_HOOKS_FILE_LOCKING:-true}" == "true" ]]; then
                 # Linux: use flock
                 exec 200>"$LOCK_FILE"
                 if ! flock -w 30 200 2>/dev/null; then
-                    echo "HOOK_BLOCKED: File locked by another agent: $FILE_PATH" | tee -a /tmp/claude-hook.log >&2
+                    echo "HOOK_BLOCKED: File locked by another agent: $FILE_PATH" | tee -a "$HOOK_LOG" >&2
                     exit 2
                 fi
             fi
@@ -435,6 +453,7 @@ if [[ "${CLAUDE_HOOKS_FILE_LOCKING:-true}" == "true" ]]; then
         fi
     fi
 fi
+
 # === ALLOW EVERYTHING ELSE ===
 # Slash commands need: git, npm, file edits, gh pr/issue, MCP tools
 exit 0

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run",
     "lint": "eslint src/ bin/ --max-warnings 0",
     "sync:skills": "cp -r templates/skills/* .claude/skills/",
+    "sync:hooks": "bash scripts/sync-hooks.sh",
     "validate:skills": "for skill in templates/skills/*/; do npx skills-ref validate \"$skill\"; done",
     "lint:skill-calls": "npx tsx scripts/lint-skill-calls.ts",
     "prepare:marketplace": "npx tsx scripts/prepare-marketplace.ts",

--- a/scripts/sync-hooks.sh
+++ b/scripts/sync-hooks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Sync .claude/hooks/ from templates/hooks/ (#645).
+#
+# The drift test in src/lib/relay/__tests__/hook-sync.test.ts fails when these
+# two directories diverge for any file that exists in templates/. Run this
+# script after editing a template hook to regenerate the installed copy.
+#
+# Local-only files (e.g. capture-tokens.sh) are left untouched.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+TEMPLATES_DIR="${REPO_ROOT}/templates/hooks"
+ACTIVE_DIR="${REPO_ROOT}/.claude/hooks"
+
+if [[ ! -d "$TEMPLATES_DIR" ]]; then
+  echo "templates/hooks/ not found at $TEMPLATES_DIR" >&2
+  exit 1
+fi
+mkdir -p "$ACTIVE_DIR"
+
+changed=0
+for src in "$TEMPLATES_DIR"/*; do
+  [[ -f "$src" ]] || continue
+  name=$(basename "$src")
+  dest="$ACTIVE_DIR/$name"
+  if [[ -f "$dest" ]] && cmp -s "$src" "$dest"; then
+    continue
+  fi
+  cp -p "$src" "$dest"
+  chmod 0755 "$dest"
+  echo "synced: $name"
+  changed=$((changed + 1))
+done
+
+if [[ $changed -eq 0 ]]; then
+  echo "hooks already in sync."
+fi

--- a/src/lib/relay/__tests__/hook-sync.test.ts
+++ b/src/lib/relay/__tests__/hook-sync.test.ts
@@ -1,43 +1,82 @@
 /**
- * Drift guard for the interactive relay hook (#645).
+ * Drift guard for hooks (#645).
  *
- * PR #638 added `templates/hooks/relay-check.sh` + the SEQUANT_RELAY sourcing
- * block in `templates/hooks/post-tool.sh`, but never updated the active hooks
- * in `.claude/hooks/`. Every worktree of this repo inherited the stale checked-in
- * post-tool.sh, so the PostToolUse hook chain never sourced relay-check.sh and
- * relay messages were silently consumed without reply.
+ * PR #638 added relay support to `templates/hooks/` but never updated the
+ * active hooks in `.claude/hooks/`. The installed `post-tool.sh` was
+ * Mar-25-era and missed the SEQUANT_RELAY sourcing block, so the
+ * PostToolUse chain never advanced the relay cursor. After the reconcile
+ * in PR #649, every file present in `templates/hooks/` MUST be byte-identical
+ * to its `.claude/hooks/` counterpart — there is no allowed divergence.
  *
- * These assertions fail immediately if either of those files drifts again.
+ * `.claude/hooks/` MAY contain extra files that templates don't have (e.g.
+ * `capture-tokens.sh`, which is sequant-specific and intentionally local).
+ *
+ * Run `npm run sync-hooks` to regenerate `.claude/hooks/` from the
+ * templates after editing any template hook.
  */
 
 import * as fs from "fs";
 import * as path from "path";
 import { describe, expect, it } from "vitest";
 
-const TEMPLATE_RELAY_CHECK = "templates/hooks/relay-check.sh";
-const ACTIVE_RELAY_CHECK = ".claude/hooks/relay-check.sh";
-const ACTIVE_POST_TOOL = ".claude/hooks/post-tool.sh";
+const TEMPLATES_DIR = "templates/hooks";
+const ACTIVE_DIR = ".claude/hooks";
 
-describe("relay hook sync (#645)", () => {
-  it("active relay-check.sh is byte-identical to the template", () => {
-    const templatePath = path.join(process.cwd(), TEMPLATE_RELAY_CHECK);
-    const activePath = path.join(process.cwd(), ACTIVE_RELAY_CHECK);
+function listHookFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((n) => fs.statSync(path.join(dir, n)).isFile())
+    .sort();
+}
 
-    expect(fs.existsSync(templatePath)).toBe(true);
+describe("hook sync (#645)", () => {
+  const templatesPath = path.join(process.cwd(), TEMPLATES_DIR);
+  const activePath = path.join(process.cwd(), ACTIVE_DIR);
+
+  it("every file in templates/hooks/ exists byte-identically in .claude/hooks/", () => {
+    expect(fs.existsSync(templatesPath)).toBe(true);
     expect(fs.existsSync(activePath)).toBe(true);
 
-    const templateBytes = fs.readFileSync(templatePath);
-    const activeBytes = fs.readFileSync(activePath);
+    const templateFiles = listHookFiles(templatesPath);
+    expect(templateFiles.length).toBeGreaterThan(0);
 
-    expect(activeBytes.equals(templateBytes)).toBe(true);
+    const drift: string[] = [];
+    for (const name of templateFiles) {
+      const tBytes = fs.readFileSync(path.join(templatesPath, name));
+      const aPath = path.join(activePath, name);
+      if (!fs.existsSync(aPath)) {
+        drift.push(`MISSING: .claude/hooks/${name}`);
+        continue;
+      }
+      const aBytes = fs.readFileSync(aPath);
+      if (!aBytes.equals(tBytes)) {
+        drift.push(`DRIFT: .claude/hooks/${name}`);
+      }
+    }
+
+    expect(drift).toEqual([]);
   });
 
-  it("active post-tool.sh sources relay-check.sh under SEQUANT_RELAY", () => {
-    const activePath = path.join(process.cwd(), ACTIVE_POST_TOOL);
-    expect(fs.existsSync(activePath)).toBe(true);
+  it(".claude/hooks/ may have extra local-only files (e.g. capture-tokens.sh)", () => {
+    // This is documentation-as-test: we intentionally allow `.claude/hooks/`
+    // to contain files that aren't in templates. If we ever decide that's
+    // wrong, flip this test to enforce parity in both directions.
+    const templateFiles = new Set(listHookFiles(templatesPath));
+    const activeFiles = listHookFiles(activePath);
+    const extras = activeFiles.filter((n) => !templateFiles.has(n));
+    // Just assert the contract; don't fail on extras.
+    expect(extras.every((n) => typeof n === "string")).toBe(true);
+  });
 
-    const content = fs.readFileSync(activePath, "utf-8");
-
+  it("post-tool.sh sources relay-check.sh under SEQUANT_RELAY (kept for clarity)", () => {
+    // Redundant with the byte-equality check above, but kept so a failure
+    // here points directly at the relay regression rather than a generic
+    // "files differ" message.
+    const content = fs.readFileSync(
+      path.join(activePath, "post-tool.sh"),
+      "utf-8",
+    );
     expect(content).toMatch(/SEQUANT_RELAY:-/);
     expect(content).toMatch(/source\s+"?\$\{?_RELAY_CHECK\}?"?/);
   });

--- a/templates/hooks/post-tool.sh
+++ b/templates/hooks/post-tool.sh
@@ -227,6 +227,60 @@ if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE '(npm run build
     fi
 fi
 
+# === TEST COVERAGE ANALYSIS (P3) ===
+# Opt-in: Set CLAUDE_HOOKS_COVERAGE=true to enable
+# Automatically appends coverage analysis to npm test output
+# Logs which changed files have/don't have corresponding tests
+if [[ "${CLAUDE_HOOKS_COVERAGE:-}" == "true" ]]; then
+    if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE '(npm (test|run test)|bun (test|run test)|yarn (test|run test)|pnpm (test|run test))'; then
+        # Only run if tests passed (don't clutter failure output)
+        if ! echo "$TOOL_OUTPUT" | grep -qE '(FAIL|failed|Error:)'; then
+            COVERAGE_LOG="${_LOG_DIR}/claude-coverage.log"
+
+            # Get changed source files (excluding tests)
+            changed_files=$(git diff main...HEAD --name-only 2>/dev/null | grep -E '\.(ts|tsx|js|jsx)$' | grep -v -E '\.test\.|\.spec\.|__tests__' || true)
+
+            if [[ -n "$changed_files" ]]; then
+                echo "$(date +%H:%M:%S) COVERAGE_ANALYSIS: Checking test coverage for changed files" >> "$QUALITY_LOG"
+
+                files_with_tests=0
+                files_without_tests=0
+                critical_without_tests=""
+
+                while IFS= read -r file; do
+                    [[ -z "$file" ]] && continue
+                    base=$(basename "$file" .ts | sed 's/\.tsx$//')
+
+                    # Check for test file
+                    if find . -name "${base}.test.*" -o -name "${base}.spec.*" 2>/dev/null | grep -q .; then
+                        ((files_with_tests++))
+                    else
+                        ((files_without_tests++))
+                        # Check if critical path
+                        if echo "$file" | grep -qE 'auth|payment|security|server-action|middleware|admin'; then
+                            critical_without_tests="$critical_without_tests $file"
+                        fi
+                    fi
+                done <<< "$changed_files"
+
+                total=$((files_with_tests + files_without_tests))
+
+                # Log coverage summary
+                echo "$(date +%H:%M:%S) COVERAGE: $files_with_tests/$total changed files have tests" >> "$COVERAGE_LOG"
+
+                if [[ -n "$critical_without_tests" ]]; then
+                    echo "$(date +%H:%M:%S) ⚠️ CRITICAL_NO_TESTS:$critical_without_tests" >> "$COVERAGE_LOG"
+                    echo "$(date +%H:%M:%S) CRITICAL_NO_TESTS:$critical_without_tests" >> "$QUALITY_LOG"
+                fi
+
+                if [[ $files_without_tests -gt 0 ]]; then
+                    echo "$(date +%H:%M:%S) COVERAGE_GAP: $files_without_tests files without tests" >> "$QUALITY_LOG"
+                fi
+            fi
+        fi
+    fi
+fi
+
 # === SMART TEST RUNNING (P3) ===
 # Opt-in: Set CLAUDE_HOOKS_SMART_TESTS=true to enable
 # Runs related tests asynchronously after file edits
@@ -307,6 +361,33 @@ if [[ -n "${CLAUDE_HOOKS_WEBHOOK_URL:-}" ]]; then
                     -d "{\"text\":\"Issue #$ISSUE_NUM completed by Claude Code automation\"}" \
                     --max-time 5 2>/dev/null || true
             ) &
+        fi
+    fi
+fi
+
+# === POST-MERGE WORKTREE CLEANUP ===
+# Clean up worktree AFTER `gh pr merge` succeeds (not before).
+# Previous approach removed worktree pre-merge, which lost work if merge failed.
+if [[ "$TOOL_NAME" == "Bash" ]] && echo "$TOOL_INPUT" | grep -qE 'gh pr merge'; then
+    # Only clean up if merge succeeded (output contains merge confirmation)
+    if echo "$TOOL_OUTPUT" | grep -qiE '(merged|Merged pull request|Pull request .* merged)'; then
+        PR_NUM=$(echo "$TOOL_INPUT" | grep -oE 'gh pr merge [0-9]+' | grep -oE '[0-9]+')
+
+        if [[ -n "$PR_NUM" ]]; then
+            BRANCH_NAME=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+
+            if [[ -n "$BRANCH_NAME" ]]; then
+                # Note: worktree line is 2 lines before branch line in porcelain output
+                WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | grep -B2 "branch refs/heads/$BRANCH_NAME" | grep "^worktree " | sed 's/^worktree //' || true)
+
+                if [[ -n "$WORKTREE_PATH" && -d "$WORKTREE_PATH" ]]; then
+                    git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
+                    echo "POST-MERGE: Removed worktree $WORKTREE_PATH for branch $BRANCH_NAME" >> "${_LOG_DIR}/claude-hook.log"
+                fi
+
+                # Clean up local branch
+                git branch -D "$BRANCH_NAME" 2>/dev/null || true
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

Closes the broader hook-drift recurrence risk that originally caused #645. PR #646 fixed the visible symptom (added the missing relay-sourcing block + a partial drift guard for `relay-check.sh` only). This PR closes the underlying issue across the entire `.claude/hooks/` directory.

### What was diverged

| File | Template had | Installed had |
|---|---|---|
| `post-tool.sh` | `CLAUDE_PLUGIN_DATA` log dir, multi-PM test/build detection, cross-shell marker discovery | TEST COVERAGE ANALYSIS block, POST-MERGE WORKTREE CLEANUP block |
| `pre-tool.sh` | `CLAUDE_PLUGIN_DATA`, `$HOOK_LOG` variable, merge-commit hint, cross-shell marker discovery | (nothing unique) |
| `relay-check.sh` | (template-only) | — (`#646` installed it) |

### What this PR does

- **Port to template (`templates/hooks/post-tool.sh`)**: the two local-only blocks from `.claude/hooks/post-tool.sh` so the template is a strict superset.
- **Sync `.claude/hooks/`**: replace both `post-tool.sh` and `pre-tool.sh` with byte-identical copies of the now-superset templates.
- **Widen drift guard** (`src/lib/relay/__tests__/hook-sync.test.ts`): assert byte-equality for every file in `templates/hooks/` against its `.claude/hooks/` counterpart, instead of relay-check.sh only. Local-only files in `.claude/hooks/` (e.g. `capture-tokens.sh`) are still permitted.
- **Add `npm run sync:hooks`** (`scripts/sync-hooks.sh`): regenerates `.claude/hooks/` from templates. Run this after editing any template hook.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run sync:hooks` — reports "hooks already in sync" after the commit
- [x] `npx vitest run src/lib/relay` — 6/6 passing
- [x] Adversarial: appending `# drift` to `.claude/hooks/pre-tool.sh` fails the byte-equality test; removing it passes
- [x] Smoke: invoking `bash .claude/hooks/post-tool.sh` and `pre-tool.sh` with sample JSON exits 0
- [ ] Manual verification (post-merge): `npx sequant doctor` still reports clean

## Why this is risky-but-low-risk

This commit touches the file that fires on every Claude Code tool call. Two protections:

1. The merged `post-tool.sh` is a STRICT SUPERSET of both prior versions — no feature lost, only gained.
2. The drift test enforces byte-equality going forward, so any future template edit must explicitly sync via `npm run sync:hooks` or CI fails.

Refs #645