### PR TITLE
fix(#652): renderer bottom-output corruption — column-binding + renderSummary teardown order

### DIFF
--- a/src/lib/cli-ui/run-renderer.ts
+++ b/src/lib/cli-ui/run-renderer.ts
@@ -538,6 +538,20 @@ export class TTYRenderer extends BaseRenderer {
     clearCalls: number;
     doneCalls: number;
   } | null;
+  /**
+   * #652: when the renderer is on the production code path (no
+   * `logUpdateInstance` override), this is the stream wrapper bound to
+   * `log-update`. Tests can read its `columns`/`rows`/`isTTY` getters to
+   * verify the bound-stream behaviour directly, rather than inferring it
+   * from emitted frame widths. `null` when the harness or test-stub path
+   * is taken (no bound stream involved).
+   */
+  private _boundStream: {
+    readonly columns: number;
+    readonly rows: number;
+    readonly isTTY: boolean;
+    write: (chunk: string) => boolean;
+  } | null = null;
 
   constructor(options: RenderOptions) {
     super(options);
@@ -654,12 +668,14 @@ export class TTYRenderer extends BaseRenderer {
       // write lands on top of — corrupting characters mid-string.
       const getColumnsForStream = () => this.getColumns();
       const getRowsForStream = () => this.getRows();
-      const boundStream: Partial<NodeJS.WriteStream> & {
-        write: (chunk: string) => boolean;
-        readonly columns: number;
-        readonly rows: number;
-        readonly isTTY: true;
-      } = {
+      // #652 follow-up: do NOT hardcode `isTTY: true`. log-update v7 reads
+      // `stream.isTTY === true` to decide whether to wrap each write in the
+      // synchronized-output escapes (`ESC[?2026h` ... `ESC[?2026l`). Under a
+      // redirect or pipe (`> file`, CI log capture, `npx ... | tee`), real
+      // stdout has `isTTY: false` and the singleton-based old code did not
+      // emit those escapes. Hardcoding `true` would leak the escapes into
+      // non-TTY output streams.
+      const boundStream = {
         write: (chunk: string) => process.stdout.write(chunk),
         get columns() {
           return getColumnsForStream();
@@ -667,9 +683,22 @@ export class TTYRenderer extends BaseRenderer {
         get rows() {
           return getRowsForStream();
         },
-        isTTY: true,
+        get isTTY() {
+          return Boolean(process.stdout.isTTY);
+        },
       };
-      const lu = createLogUpdate(boundStream as unknown as NodeJS.WriteStream);
+      // Double-cast: log-update's signature requires `NodeJS.WritableStream`
+      // (which includes `end`/`emit`/listener methods we don't need); the
+      // bound stream only implements the four fields log-update actually
+      // reads at runtime (`write`/`columns`/`rows`/`isTTY`) — verified
+      // against log-update@7 source. Matches the same pattern the harness
+      // uses in `scrollback-harness.ts:343`.
+      const lu = createLogUpdate(
+        boundStream as unknown as NodeJS.WritableStream,
+      );
+      // Stash for tests: lets the harness assert on the bound stream's
+      // `columns` getter directly without inferring from emitted frame width.
+      this._boundStream = boundStream;
       this.logUpdateImpl = (text: string) => {
         frameCounter++;
         emitDebug("impl", text);
@@ -807,15 +836,29 @@ export class TTYRenderer extends BaseRenderer {
 
   renderSummary(input: SummaryRenderInput): void {
     if (this.disposed) return;
-    // #652 Symptom B defensive fix: cancel the live timer FIRST, before any
-    // log-update teardown or summary write. The prior order ran `clearInterval`
-    // *after* `logUpdateClear`/`Done`, leaving a window where a pending tick
-    // (queued in the event loop before the cancel) could fire between the
-    // teardown and the summary write — re-rendering the live frame into the
-    // summary's output stream. A frame write mid-summary can split a multibyte
-    // box-drawing char at a byte boundary, producing U+FFFD in the rendered
-    // table, and lands the cursor on the wrong row so the next summary line
-    // overlays the prior separator row.
+    // #652 Symptom B — structural cleanup, not the actual fix.
+    //
+    // The original Symptom B PR comment claimed a setInterval tick could
+    // fire *between* `logUpdateClear` and the subsequent `clearInterval`
+    // statement, allowing the live frame to redraw mid-summary and produce
+    // U+FFFD / row overlap. That claim is false: JS is single-threaded;
+    // setInterval callbacks are macrotasks and cannot preempt synchronous
+    // code. The race window described doesn't exist.
+    //
+    // The likely real fix for Symptom B is #647's AC-3 grid-width math
+    // correction (`-7` → `-9`), which prevented box-drawing rows from
+    // being 2 chars wider than the terminal column count. The prior
+    // width-overshoot forced log-update's `wrap-ansi` to hard-wrap inside
+    // a multibyte character — exactly the byte-boundary split that
+    // produces U+FFFD when the terminal decodes the partial sequence.
+    //
+    // We keep the `clearInterval`-first ordering here because:
+    //   1. It costs nothing — single-statement move.
+    //   2. It guarantees no future `redraw()` call (via `setBanner`,
+    //      `setPullRequest`, etc.) accidentally invoked from this method's
+    //      teardown can re-create the live zone after `done()` was called.
+    //   3. It documents intent: when rendering the summary, we are
+    //      *finished* with the live zone; cancel its timer first.
     if (this.liveTimer !== null) {
       clearInterval(this.liveTimer);
       this.liveTimer = null;

--- a/src/lib/cli-ui/run-renderer.ts
+++ b/src/lib/cli-ui/run-renderer.ts
@@ -15,7 +15,7 @@
  */
 
 import chalk from "chalk";
-import { createLogUpdate } from "log-update";
+import logUpdate from "log-update";
 import stringWidth from "string-width";
 import { formatElapsedTime, formatTimestamp } from "./format.js";
 import type {
@@ -642,46 +642,18 @@ export class TTYRenderer extends BaseRenderer {
       };
     } else {
       this._testStub = null;
-      // #652 Symptom A defensive fix: bind log-update to a stream wrapper
-      // whose `columns`/`rows` getters return the renderer's view, not
-      // `process.stdout`'s raw view. Under `npx`, `process.stdout.columns`
-      // is sometimes undefined → the default `logUpdate` singleton falls
-      // back to its own `defaultColumns` (typically 80) while the renderer
-      // builds frames at `getColumns()` (falls back to 100). The width
-      // disagreement makes log-update's `previousLineCount` desync from the
-      // real terminal-row-count, so `eraseLines(prevCount)` over- or
-      // under-clears, leaving partial frame rows that the next event-line
-      // write lands on top of — corrupting characters mid-string.
-      const getColumnsForStream = () => this.getColumns();
-      const getRowsForStream = () => this.getRows();
-      const boundStream: Partial<NodeJS.WriteStream> & {
-        write: (chunk: string) => boolean;
-        readonly columns: number;
-        readonly rows: number;
-        readonly isTTY: true;
-      } = {
-        write: (chunk: string) => process.stdout.write(chunk),
-        get columns() {
-          return getColumnsForStream();
-        },
-        get rows() {
-          return getRowsForStream();
-        },
-        isTTY: true,
-      };
-      const lu = createLogUpdate(boundStream as unknown as NodeJS.WriteStream);
       this.logUpdateImpl = (text: string) => {
         frameCounter++;
         emitDebug("impl", text);
-        lu(text);
+        logUpdate(text);
       };
       this.logUpdateClear = () => {
         emitDebug("clear");
-        lu.clear();
+        logUpdate.clear();
       };
       this.logUpdateDone = () => {
         emitDebug("done");
-        lu.done();
+        logUpdate.done();
       };
     }
 
@@ -807,24 +779,15 @@ export class TTYRenderer extends BaseRenderer {
 
   renderSummary(input: SummaryRenderInput): void {
     if (this.disposed) return;
-    // #652 Symptom B defensive fix: cancel the live timer FIRST, before any
-    // log-update teardown or summary write. The prior order ran `clearInterval`
-    // *after* `logUpdateClear`/`Done`, leaving a window where a pending tick
-    // (queued in the event loop before the cancel) could fire between the
-    // teardown and the summary write — re-rendering the live frame into the
-    // summary's output stream. A frame write mid-summary can split a multibyte
-    // box-drawing char at a byte boundary, producing U+FFFD in the rendered
-    // table, and lands the cursor on the wrong row so the next summary line
-    // overlays the prior separator row.
-    if (this.liveTimer !== null) {
-      clearInterval(this.liveTimer);
-      this.liveTimer = null;
-    }
     // #624 Item 2: tear down the live zone *before* writing the summary so any
     // subsequent `console.log` from displaySummary (reflection block, merge
     // tip) cannot overlap with the trailing border of the summary table.
     this.logUpdateClear();
     this.logUpdateDone();
+    if (this.liveTimer !== null) {
+      clearInterval(this.liveTimer);
+      this.liveTimer = null;
+    }
     // #624 Item 2 (AC-2.3): clamp summary columns to SUMMARY_COLUMN_CAP so wide
     // terminals don't produce a grid that overflows narrower readers (CI logs,
     // VS Code terminal panes).

--- a/src/lib/cli-ui/run-renderer.ts
+++ b/src/lib/cli-ui/run-renderer.ts
@@ -15,7 +15,7 @@
  */
 
 import chalk from "chalk";
-import logUpdate from "log-update";
+import { createLogUpdate } from "log-update";
 import stringWidth from "string-width";
 import { formatElapsedTime, formatTimestamp } from "./format.js";
 import type {
@@ -642,18 +642,46 @@ export class TTYRenderer extends BaseRenderer {
       };
     } else {
       this._testStub = null;
+      // #652 Symptom A defensive fix: bind log-update to a stream wrapper
+      // whose `columns`/`rows` getters return the renderer's view, not
+      // `process.stdout`'s raw view. Under `npx`, `process.stdout.columns`
+      // is sometimes undefined → the default `logUpdate` singleton falls
+      // back to its own `defaultColumns` (typically 80) while the renderer
+      // builds frames at `getColumns()` (falls back to 100). The width
+      // disagreement makes log-update's `previousLineCount` desync from the
+      // real terminal-row-count, so `eraseLines(prevCount)` over- or
+      // under-clears, leaving partial frame rows that the next event-line
+      // write lands on top of — corrupting characters mid-string.
+      const getColumnsForStream = () => this.getColumns();
+      const getRowsForStream = () => this.getRows();
+      const boundStream: Partial<NodeJS.WriteStream> & {
+        write: (chunk: string) => boolean;
+        readonly columns: number;
+        readonly rows: number;
+        readonly isTTY: true;
+      } = {
+        write: (chunk: string) => process.stdout.write(chunk),
+        get columns() {
+          return getColumnsForStream();
+        },
+        get rows() {
+          return getRowsForStream();
+        },
+        isTTY: true,
+      };
+      const lu = createLogUpdate(boundStream as unknown as NodeJS.WriteStream);
       this.logUpdateImpl = (text: string) => {
         frameCounter++;
         emitDebug("impl", text);
-        logUpdate(text);
+        lu(text);
       };
       this.logUpdateClear = () => {
         emitDebug("clear");
-        logUpdate.clear();
+        lu.clear();
       };
       this.logUpdateDone = () => {
         emitDebug("done");
-        logUpdate.done();
+        lu.done();
       };
     }
 
@@ -779,15 +807,24 @@ export class TTYRenderer extends BaseRenderer {
 
   renderSummary(input: SummaryRenderInput): void {
     if (this.disposed) return;
+    // #652 Symptom B defensive fix: cancel the live timer FIRST, before any
+    // log-update teardown or summary write. The prior order ran `clearInterval`
+    // *after* `logUpdateClear`/`Done`, leaving a window where a pending tick
+    // (queued in the event loop before the cancel) could fire between the
+    // teardown and the summary write — re-rendering the live frame into the
+    // summary's output stream. A frame write mid-summary can split a multibyte
+    // box-drawing char at a byte boundary, producing U+FFFD in the rendered
+    // table, and lands the cursor on the wrong row so the next summary line
+    // overlays the prior separator row.
+    if (this.liveTimer !== null) {
+      clearInterval(this.liveTimer);
+      this.liveTimer = null;
+    }
     // #624 Item 2: tear down the live zone *before* writing the summary so any
     // subsequent `console.log` from displaySummary (reflection block, merge
     // tip) cannot overlap with the trailing border of the summary table.
     this.logUpdateClear();
     this.logUpdateDone();
-    if (this.liveTimer !== null) {
-      clearInterval(this.liveTimer);
-      this.liveTimer = null;
-    }
     // #624 Item 2 (AC-2.3): clamp summary columns to SUMMARY_COLUMN_CAP so wide
     // terminals don't produce a grid that overflows narrower readers (CI logs,
     // VS Code terminal panes).

--- a/src/lib/cli-ui/scrollback-harness.test.ts
+++ b/src/lib/cli-ui/scrollback-harness.test.ts
@@ -405,6 +405,123 @@ describe("#652 Symptom A — event-line mid-string char loss", () => {
     expect(mangledTokens).toBeNull();
     renderer.dispose();
   });
+
+  it("binds log-update to the renderer's column count even when process.stdout.columns is undefined (RED→GREEN column-mismatch invariant)", () => {
+    // RED→GREEN gate for the Symptom A defensive fix. The harness cannot
+    // reproduce the visible mid-string corruption deterministically (it
+    // requires real OS-level cursor/erase interleaving the synchronous VT
+    // model doesn't capture). This invariant test instead pins the
+    // *underlying* property the fix enforces: log-update MUST wrap at the
+    // renderer's `getColumns()` value, not at its own `defaultColumns`
+    // fallback. If the production code path reverts to the unbound
+    // `logUpdate` singleton, `process.stdout.columns = undefined` will leak
+    // through and this test goes RED.
+    //
+    // Method: spy on the stream that log-update wraps. The bound stream has
+    // `columns` as a getter that delegates to the renderer. If the renderer
+    // changes its columns (via `columnsOverride`), the next log-update
+    // write sees the new value. We assert that a write under
+    // `process.stdout.columns = undefined` still wraps at the renderer's
+    // configured 200-col width (not log-update's 80-col default).
+    //
+    // We use the production code path (not the harness path) by creating a
+    // TTYRenderer without `logUpdateInstance`. That forces the constructor
+    // into the `else` branch where the bound stream lives.
+    const writes: string[] = [];
+    const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+    const originalColumns = process.stdout.columns;
+    const originalRows = process.stdout.rows;
+    const originalIsTTY = process.stdout.isTTY;
+    try {
+      // Simulate `npx` stripping the TTY signals.
+      Object.defineProperty(process.stdout, "columns", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdout, "rows", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+      // Capture writes that log-update's bound stream produces.
+      process.stdout.write = ((chunk: string | Uint8Array) => {
+        writes.push(
+          typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+        );
+        return true;
+      }) as typeof process.stdout.write;
+
+      // Production code path: no logUpdateInstance, no stdoutWrite override.
+      // This forces the constructor's `else` branch (the patched path).
+      const r = new TTYRenderer({
+        isTTY: true,
+        noColor: true,
+        columns: 200, // Renderer view: 200 cols
+        rows: 24,
+        liveTickMs: 0,
+        noSignalListeners: true,
+        now: () => FIXED_NOW,
+        wallClock: () => FIXED_DATE,
+      });
+
+      r.registerIssue({ issueNumber: 504 });
+      r.onEvent({ issue: 504, phase: "spec", event: "start" });
+      // A second event drives a log-update redraw — by which point the
+      // bound stream's `columns` getter has been read by log-update for
+      // its wrap math.
+      r.onEvent({
+        issue: 504,
+        phase: "spec",
+        event: "complete",
+        durationSeconds: 30,
+      });
+      r.dispose();
+
+      // Invariant: the renderer rendered frames sized to 200-cols, not
+      // log-update's 80-col fallback. We check by looking at the longest
+      // line in any of the captured writes: if log-update wrapped at 80,
+      // no line would exceed 80 visible chars (stripping ANSI). If
+      // log-update wrapped at 200 (or didn't wrap because the frame
+      // already fit), lines can be longer than 80.
+      // Strip ANSI escapes so we measure visible width.
+      const stripAnsi = (s: string) => s.replace(/\[[0-9;]*[A-Za-z]/g, "");
+      const allText = writes.join("");
+      const lines = allText.split("\n");
+      const longestVisible = Math.max(
+        ...lines.map((line) => stripAnsi(line).length),
+      );
+      // The frame's box-drawing rows are sized to roughly the renderer's
+      // columns (capped at 110 internally for SUMMARY_COLUMN_CAP, but the
+      // single-issue grid uses up to `min(cols, 110)`). So we expect to
+      // see at least one line wider than 80 visible chars — proving
+      // log-update did NOT wrap at its 80-col fallback.
+      expect(longestVisible).toBeGreaterThan(80);
+    } finally {
+      // Restore process.stdout state.
+      process.stdout.write = originalStdoutWrite;
+      Object.defineProperty(process.stdout, "columns", {
+        value: originalColumns,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdout, "rows", {
+        value: originalRows,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: originalIsTTY,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
 });
 
 describe("#652 Symptom B — U+FFFD and row overlap in summary table", () => {

--- a/src/lib/cli-ui/scrollback-harness.test.ts
+++ b/src/lib/cli-ui/scrollback-harness.test.ts
@@ -239,3 +239,343 @@ describe("#647 scrollback harness — duplicate-header regression", () => {
     renderer.dispose();
   });
 });
+
+// ============================================================================
+// #652 — renderer bottom-output corruption regression
+//
+// Two symptoms (per the issue body) that are NOT explained by #647's
+// duplicate-header mechanisms:
+//
+//   Symptom A — characters vanish mid-event-line ("✔ #5loop" instead of
+//     "✔ #505 loop"). Cause: the `loop` phase event-line writes the same
+//     issue+phase tuple as the immediately-prior `start` event, so when the
+//     live-frame redraw (via log-update.clear) under-erases a wrapped row,
+//     the new line is rendered atop the old one at a row offset that drops
+//     characters from the middle.
+//
+//   Symptom B — U+FFFD appears in the summary table separator
+//     ("├───────�     │ 33m 41s    │"). Cause: `renderSummary` writes the
+//     entire table in one `stdoutWrite(out.join("\n"))` call, but the live
+//     timer is still running when the very first `logUpdateClear()` lands.
+//     If the timer fires between `logUpdateClear` and the `clearInterval`
+//     two statements later, log-update redraws WITHIN the summary table
+//     output stream, splitting a multibyte box-drawing char at a byte
+//     boundary so the terminal renders U+FFFD.
+//
+// Both tests assert on `harness.vt.getAllText()` so corruption shows up in
+// (visible + scrollback) regardless of which side of the viewport the
+// affected row landed in.
+// ============================================================================
+
+describe("#652 Symptom A — event-line mid-string char loss", () => {
+  it("preserves the full `#NNN <phase>` token in every event line under tick interleaving", () => {
+    // The motivating transcript (`npx sequant run 504 505 -q`, v2.3.0):
+    //   ✘ #505 qa  QA verdict: AC_MET_BUT_NOT_A_PLUS
+    //   ▸ #505 loop
+    //   ✔ #5loop  Claude Code returned an error result: ...
+    //
+    // `#505 loop` lost the `05 ` substring mid-string. We drive the same
+    // sequence with a live tick interleaved between the `loop start` and
+    // `loop complete` events so the redraw-then-clear-then-redraw cycle
+    // exercises the same path the production transcript hit.
+    const { renderer, harness } = makeHarnessRenderer({ rows: 24, cols: 100 });
+
+    renderer.registerIssue({ issueNumber: 504 });
+    renderer.registerIssue({ issueNumber: 505 });
+
+    const events: ProgressEvent[] = [
+      { issue: 504, phase: "spec", event: "start" },
+      { issue: 505, phase: "spec", event: "start" },
+      { issue: 504, phase: "spec", event: "complete", durationSeconds: 232 },
+      { issue: 504, phase: "exec", event: "start" },
+      { issue: 505, phase: "spec", event: "complete", durationSeconds: 262 },
+      { issue: 505, phase: "exec", event: "start" },
+      { issue: 504, phase: "exec", event: "complete", durationSeconds: 820 },
+      { issue: 504, phase: "qa", event: "start" },
+      { issue: 505, phase: "exec", event: "complete", durationSeconds: 1005 },
+      { issue: 505, phase: "qa", event: "start" },
+      { issue: 504, phase: "qa", event: "complete", durationSeconds: 293 },
+      {
+        issue: 505,
+        phase: "qa",
+        event: "failed",
+        error: "QA verdict: AC_MET_BUT_NOT_A_PLUS",
+      },
+      { issue: 505, phase: "loop", event: "start" },
+    ];
+    for (const ev of events) {
+      renderer.onEvent(ev);
+      // Interleave a live-frame tick between events to model the production
+      // ~1Hz redraw firing between asynchronous event callbacks.
+      renderer.tickNow();
+    }
+    renderer.onEvent({
+      issue: 505,
+      phase: "loop",
+      event: "failed",
+      error: "Claude Code returned an error result: ETIMEDOUT",
+    });
+
+    const text = harness.vt.getAllText();
+
+    // The exact AC-1 invariant: each `#505 <phase>` token from the event log
+    // must survive into (visible + scrollback) without any chars dropped.
+    // We check for the specific token from the transcript first, and also
+    // assert no corruption of any rendered "#NNN <phase>" pattern.
+    const corruptionRegex = /#5(?!05 )(loop|exec|qa|spec)/;
+    if (corruptionRegex.test(text)) {
+      const visible = harness.vt
+        .getVisibleLines()
+        .map((l, i) => `  v${i.toString().padStart(2, "0")} | ${l}`)
+        .join("\n");
+      const scrollback = harness.vt.scrollback
+        .map((l, i) => `  s${i.toString().padStart(2, "0")} | ${l}`)
+        .join("\n");
+      throw new Error(
+        `Found corrupted #5<phase> token (e.g. "#5loop" instead of "#505 loop").\n\n` +
+          `Scrollback (${harness.vt.scrollback.length} rows):\n${scrollback}\n\n` +
+          `Visible (${harness.vt.rows} rows):\n${visible}`,
+      );
+    }
+    expect(text).not.toMatch(corruptionRegex);
+    // Positive: at least one fully-formed `#505 loop` token landed somewhere.
+    expect(text).toMatch(/#505 loop/);
+    renderer.dispose();
+  });
+
+  it("preserves event-line content when log-update reports a narrower stream than the terminal renders (npx column mismatch)", () => {
+    // Production cause hypothesis: `process.stdout.columns` is sometimes
+    // undefined under `npx`, so log-update falls back to defaultColumns (~80)
+    // while the real terminal is wider. Wrap math diverges → eraseLines under-
+    // or over-counts → previous event-line rows get overwritten mid-string.
+    //
+    // Harness models this by passing `streamColumns: 80` while keeping the VT
+    // at `cols: 200`. The renderer is told `cols: 200` too, so it builds wide
+    // frames; log-update wraps them at 80 (its view of the stream) which
+    // shifts the cursor differently than the terminal does after each redraw.
+    const { renderer, harness } = makeHarnessRenderer({
+      rows: 24,
+      cols: 200,
+      streamColumns: 80,
+      rendererColumns: 200,
+    });
+
+    renderer.registerIssue({ issueNumber: 504 });
+    renderer.registerIssue({ issueNumber: 505 });
+
+    const events: ProgressEvent[] = [
+      { issue: 504, phase: "spec", event: "start" },
+      { issue: 505, phase: "spec", event: "start" },
+      { issue: 504, phase: "qa", event: "start" },
+      {
+        issue: 504,
+        phase: "qa",
+        event: "failed",
+        error:
+          "QA verdict: AC_MET_BUT_NOT_A_PLUS — long error string that exceeds 80 cols so log-update wraps it but terminal does not",
+      },
+      { issue: 504, phase: "loop", event: "start" },
+      { issue: 504, phase: "loop", event: "complete", durationSeconds: 30 },
+    ];
+    for (const ev of events) {
+      renderer.onEvent(ev);
+      renderer.tickNow();
+    }
+
+    const text = harness.vt.getAllText();
+
+    // No `#NNN <phase>` token may be mangled in (visible + scrollback). The
+    // production symptom was `#5loop` for `#505 loop`; assert the inverse
+    // across all rendered phase tokens.
+    const mangledTokens = text.match(/#5(?!05 )(?:loop|qa|exec|spec)/g);
+    if (mangledTokens && mangledTokens.length > 0) {
+      const visible = harness.vt
+        .getVisibleLines()
+        .map((l, i) => `  v${i.toString().padStart(2, "0")} | ${l}`)
+        .join("\n");
+      const scrollback = harness.vt.scrollback
+        .map((l, i) => `  s${i.toString().padStart(2, "0")} | ${l}`)
+        .join("\n");
+      throw new Error(
+        `Found ${mangledTokens.length} mangled phase token(s): ${JSON.stringify(mangledTokens)}.\n\n` +
+          `Scrollback (${harness.vt.scrollback.length} rows):\n${scrollback}\n\n` +
+          `Visible (${harness.vt.rows} rows):\n${visible}`,
+      );
+    }
+    expect(mangledTokens).toBeNull();
+    renderer.dispose();
+  });
+});
+
+describe("#652 Symptom B — U+FFFD and row overlap in summary table", () => {
+  it("emits a summary table with no U+FFFD and no digit/letter content inside separator rows", () => {
+    // Production symptom: ├───────�     │ 33m 41s    │
+    //
+    // The U+FFFD is the smoking gun — a multibyte char split at a byte
+    // boundary. The "33m 41s" is a data row's "Total" cell rendered ON TOP OF
+    // a separator row, meaning the terminal cursor was positioned at the
+    // wrong row when the data row was emitted.
+    //
+    // Both effects trace back to the same cause: `renderSummary` calls
+    // `logUpdateClear()`, then `logUpdateDone()`, THEN `clearInterval` on
+    // the live timer. If the timer fires between those calls, it redraws the
+    // live frame INTO the summary's output stream.
+    //
+    // The harness can't fire setInterval mid-call (JS single-threaded), so
+    // we simulate the same hazard by manually driving `tickNow()` between
+    // events that lead into the summary, and by passing `liveTickMs: 0` to
+    // disable the real interval (otherwise it would fire under real time).
+    const { renderer, harness } = makeHarnessRenderer({
+      rows: 30,
+      cols: 100,
+    });
+
+    renderer.registerIssue({ issueNumber: 504 });
+    renderer.registerIssue({ issueNumber: 505 });
+
+    const events: ProgressEvent[] = [
+      { issue: 504, phase: "spec", event: "start" },
+      { issue: 504, phase: "spec", event: "complete", durationSeconds: 30 },
+      { issue: 505, phase: "spec", event: "start" },
+      { issue: 505, phase: "spec", event: "complete", durationSeconds: 45 },
+      { issue: 504, phase: "exec", event: "start" },
+      { issue: 504, phase: "exec", event: "complete", durationSeconds: 600 },
+      { issue: 505, phase: "exec", event: "start" },
+      { issue: 505, phase: "exec", event: "complete", durationSeconds: 720 },
+      { issue: 504, phase: "qa", event: "start" },
+      { issue: 504, phase: "qa", event: "complete", durationSeconds: 60 },
+      { issue: 505, phase: "qa", event: "start" },
+      {
+        issue: 505,
+        phase: "qa",
+        event: "failed",
+        error: "QA verdict: AC_MET_BUT_NOT_A_PLUS",
+      },
+    ];
+    for (const ev of events) {
+      renderer.onEvent(ev);
+      renderer.tickNow();
+    }
+    renderer.renderSummary({
+      issues: [
+        {
+          issueNumber: 504,
+          success: true,
+          phases: [
+            { name: "spec", success: true },
+            { name: "exec", success: true },
+            { name: "qa", success: true },
+          ],
+          durationSeconds: 2021,
+        },
+        {
+          issueNumber: 505,
+          success: false,
+          phases: [
+            { name: "spec", success: true },
+            { name: "exec", success: true },
+            { name: "qa", success: false },
+          ],
+          durationSeconds: 765,
+          failureReason: "qa failed",
+          qaVerdict: "AC_MET_BUT_NOT_A_PLUS",
+        },
+      ],
+      totalDurationSeconds: 2786,
+    });
+
+    const text = harness.vt.getAllText();
+
+    // AC-2 invariant #1: no Unicode replacement chars anywhere.
+    if (text.includes("�")) {
+      throw new Error(`Found U+FFFD in rendered output. Full text:\n${text}`);
+    }
+    expect(text).not.toContain("�");
+
+    // AC-2 invariant #2: every separator row (one that starts with `  ├` or
+    // contains `├`/`┼`/`┤`/`┬`/`┴`) must consist of *only* box-drawing chars
+    // and spaces — never digits or letters. A digit/letter in a separator row
+    // means a data row was rendered atop the separator row.
+    const allLines = text.split("\n");
+    const separatorWithContent = allLines.find((line) => {
+      const isSeparator = /[├┼┤┬┴]/.test(line);
+      if (!isSeparator) return false;
+      // Strip ANSI to inspect raw content (renderer emits SGR codes for dim).
+      const stripped = line.replace(/\[[0-9;]*[A-Za-z]/g, "");
+      return /[0-9A-Za-z]/.test(stripped);
+    });
+    if (separatorWithContent) {
+      throw new Error(
+        `Found separator row with digit/letter content (data row overlaid on separator):\n  ${separatorWithContent}\n\nFull text:\n${text}`,
+      );
+    }
+    expect(separatorWithContent).toBeUndefined();
+    renderer.dispose();
+  });
+
+  it("cancels the live timer before tearing down log-update (RED→GREEN call-order invariant)", () => {
+    // RED→GREEN gate for the renderSummary fix. The harness cannot model OS
+    // pipe buffering or real setInterval preemption, so the visible-output
+    // assertion in the test above passes on both old and new code. This
+    // invariant test instead captures the *underlying* mechanism: the live
+    // timer MUST be `null` by the time `logUpdateClear` runs, otherwise a
+    // pending tick (already queued in the event loop) can still fire between
+    // the log-update teardown and the summary write.
+    //
+    // Before fix: renderSummary called logUpdateClear/Done first, then
+    // clearInterval → liveTimer was still set at clear time. RED.
+    // After fix: clearInterval runs first → liveTimer is null at clear time.
+    // GREEN.
+    const { renderer } = makeHarnessRenderer({ rows: 30, cols: 100 });
+
+    type RendererPrivate = {
+      logUpdateClear: () => void;
+      logUpdateDone: () => void;
+      liveTimer: NodeJS.Timeout | null;
+    };
+    const r = renderer as unknown as RendererPrivate;
+    const observations: Array<{ op: string; liveTimerWasSet: boolean }> = [];
+    const origClear = r.logUpdateClear.bind(renderer);
+    const origDone = r.logUpdateDone.bind(renderer);
+    r.logUpdateClear = () => {
+      observations.push({
+        op: "logUpdateClear",
+        liveTimerWasSet: r.liveTimer !== null,
+      });
+      origClear();
+    };
+    r.logUpdateDone = () => {
+      observations.push({
+        op: "logUpdateDone",
+        liveTimerWasSet: r.liveTimer !== null,
+      });
+      origDone();
+    };
+
+    renderer.registerIssue({ issueNumber: 504 });
+    // The harness sets liveTickMs: 0 so no live timer is started by default.
+    // Force one to exist so we can observe whether renderSummary cancels it
+    // BEFORE the log-update teardown.
+    r.liveTimer = setInterval(() => {}, 100_000);
+
+    renderer.renderSummary({
+      issues: [
+        {
+          issueNumber: 504,
+          success: true,
+          phases: [{ name: "spec", success: true }],
+          durationSeconds: 30,
+        },
+      ],
+      totalDurationSeconds: 30,
+    });
+
+    // Invariant: liveTimer must be null at the moment logUpdateClear runs.
+    const clearCall = observations.find((c) => c.op === "logUpdateClear");
+    expect(clearCall).toBeDefined();
+    if (clearCall) {
+      expect(clearCall.liveTimerWasSet).toBe(false);
+    }
+    renderer.dispose();
+  });
+});

--- a/src/lib/cli-ui/scrollback-harness.test.ts
+++ b/src/lib/cli-ui/scrollback-harness.test.ts
@@ -267,179 +267,49 @@ describe("#647 scrollback harness — duplicate-header regression", () => {
 // affected row landed in.
 // ============================================================================
 
-describe("#652 Symptom A — event-line mid-string char loss", () => {
-  it("preserves the full `#NNN <phase>` token in every event line under tick interleaving", () => {
-    // The motivating transcript (`npx sequant run 504 505 -q`, v2.3.0):
-    //   ✘ #505 qa  QA verdict: AC_MET_BUT_NOT_A_PLUS
-    //   ▸ #505 loop
-    //   ✔ #5loop  Claude Code returned an error result: ...
+// ============================================================================
+// #652 — renderer bottom-output corruption regression
+//
+// Two symptoms (per the issue body) that are NOT explained by #647's
+// duplicate-header mechanisms:
+//
+//   Symptom A — characters vanish mid-event-line ("✔ #5loop" instead of
+//     "✔ #505 loop").
+//
+//   Symptom B — U+FFFD appears in the summary table separator
+//     ("├───────�     │ 33m 41s    │").
+//
+// **Harness limitation acknowledged up-front.** The synchronous VirtualTerminal
+// model cannot reproduce either visible symptom — they depend on real OS-level
+// pipe buffering, SIGWINCH races, or subprocess stdout interleaving that the
+// harness fundamentally doesn't model. Earlier drafts of this file shipped
+// scaffolding tests that *appeared* to exercise these scenarios but actually
+// ran through the `logUpdateInstance` constructor branch, bypassing the
+// production fix path entirely. Those were removed (PR #654 follow-up review).
+//
+// What remains: two invariant tests that pin *properties* the production
+// fixes enforce. They go RED on pre-fix code and GREEN on post-fix code,
+// verified by reverting each fix locally. They do NOT prove the visible
+// symptoms cannot occur via some other mechanism (SIGWINCH, subprocess
+// interleaving) — that requires a PTY-based harness or production replay.
+// ============================================================================
+
+describe("#652 Symptom A — log-update column binding", () => {
+  it("binds log-update to the renderer's columns even when process.stdout.columns is undefined (RED→GREEN)", () => {
+    // Pins the property the column-binding fix enforces: log-update reads
+    // its wrap width from the renderer's `getColumns()`, NOT from
+    // `process.stdout.columns` (which is undefined under `npx`).
     //
-    // `#505 loop` lost the `05 ` substring mid-string. We drive the same
-    // sequence with a live tick interleaved between the `loop start` and
-    // `loop complete` events so the redraw-then-clear-then-redraw cycle
-    // exercises the same path the production transcript hit.
-    const { renderer, harness } = makeHarnessRenderer({ rows: 24, cols: 100 });
-
-    renderer.registerIssue({ issueNumber: 504 });
-    renderer.registerIssue({ issueNumber: 505 });
-
-    const events: ProgressEvent[] = [
-      { issue: 504, phase: "spec", event: "start" },
-      { issue: 505, phase: "spec", event: "start" },
-      { issue: 504, phase: "spec", event: "complete", durationSeconds: 232 },
-      { issue: 504, phase: "exec", event: "start" },
-      { issue: 505, phase: "spec", event: "complete", durationSeconds: 262 },
-      { issue: 505, phase: "exec", event: "start" },
-      { issue: 504, phase: "exec", event: "complete", durationSeconds: 820 },
-      { issue: 504, phase: "qa", event: "start" },
-      { issue: 505, phase: "exec", event: "complete", durationSeconds: 1005 },
-      { issue: 505, phase: "qa", event: "start" },
-      { issue: 504, phase: "qa", event: "complete", durationSeconds: 293 },
-      {
-        issue: 505,
-        phase: "qa",
-        event: "failed",
-        error: "QA verdict: AC_MET_BUT_NOT_A_PLUS",
-      },
-      { issue: 505, phase: "loop", event: "start" },
-    ];
-    for (const ev of events) {
-      renderer.onEvent(ev);
-      // Interleave a live-frame tick between events to model the production
-      // ~1Hz redraw firing between asynchronous event callbacks.
-      renderer.tickNow();
-    }
-    renderer.onEvent({
-      issue: 505,
-      phase: "loop",
-      event: "failed",
-      error: "Claude Code returned an error result: ETIMEDOUT",
-    });
-
-    const text = harness.vt.getAllText();
-
-    // The exact AC-1 invariant: each `#505 <phase>` token from the event log
-    // must survive into (visible + scrollback) without any chars dropped.
-    // We check for the specific token from the transcript first, and also
-    // assert no corruption of any rendered "#NNN <phase>" pattern.
-    const corruptionRegex = /#5(?!05 )(loop|exec|qa|spec)/;
-    if (corruptionRegex.test(text)) {
-      const visible = harness.vt
-        .getVisibleLines()
-        .map((l, i) => `  v${i.toString().padStart(2, "0")} | ${l}`)
-        .join("\n");
-      const scrollback = harness.vt.scrollback
-        .map((l, i) => `  s${i.toString().padStart(2, "0")} | ${l}`)
-        .join("\n");
-      throw new Error(
-        `Found corrupted #5<phase> token (e.g. "#5loop" instead of "#505 loop").\n\n` +
-          `Scrollback (${harness.vt.scrollback.length} rows):\n${scrollback}\n\n` +
-          `Visible (${harness.vt.rows} rows):\n${visible}`,
-      );
-    }
-    expect(text).not.toMatch(corruptionRegex);
-    // Positive: at least one fully-formed `#505 loop` token landed somewhere.
-    expect(text).toMatch(/#505 loop/);
-    renderer.dispose();
-  });
-
-  it("preserves event-line content when log-update reports a narrower stream than the terminal renders (npx column mismatch)", () => {
-    // Production cause hypothesis: `process.stdout.columns` is sometimes
-    // undefined under `npx`, so log-update falls back to defaultColumns (~80)
-    // while the real terminal is wider. Wrap math diverges → eraseLines under-
-    // or over-counts → previous event-line rows get overwritten mid-string.
-    //
-    // Harness models this by passing `streamColumns: 80` while keeping the VT
-    // at `cols: 200`. The renderer is told `cols: 200` too, so it builds wide
-    // frames; log-update wraps them at 80 (its view of the stream) which
-    // shifts the cursor differently than the terminal does after each redraw.
-    const { renderer, harness } = makeHarnessRenderer({
-      rows: 24,
-      cols: 200,
-      streamColumns: 80,
-      rendererColumns: 200,
-    });
-
-    renderer.registerIssue({ issueNumber: 504 });
-    renderer.registerIssue({ issueNumber: 505 });
-
-    const events: ProgressEvent[] = [
-      { issue: 504, phase: "spec", event: "start" },
-      { issue: 505, phase: "spec", event: "start" },
-      { issue: 504, phase: "qa", event: "start" },
-      {
-        issue: 504,
-        phase: "qa",
-        event: "failed",
-        error:
-          "QA verdict: AC_MET_BUT_NOT_A_PLUS — long error string that exceeds 80 cols so log-update wraps it but terminal does not",
-      },
-      { issue: 504, phase: "loop", event: "start" },
-      { issue: 504, phase: "loop", event: "complete", durationSeconds: 30 },
-    ];
-    for (const ev of events) {
-      renderer.onEvent(ev);
-      renderer.tickNow();
-    }
-
-    const text = harness.vt.getAllText();
-
-    // No `#NNN <phase>` token may be mangled in (visible + scrollback). The
-    // production symptom was `#5loop` for `#505 loop`; assert the inverse
-    // across all rendered phase tokens.
-    const mangledTokens = text.match(/#5(?!05 )(?:loop|qa|exec|spec)/g);
-    if (mangledTokens && mangledTokens.length > 0) {
-      const visible = harness.vt
-        .getVisibleLines()
-        .map((l, i) => `  v${i.toString().padStart(2, "0")} | ${l}`)
-        .join("\n");
-      const scrollback = harness.vt.scrollback
-        .map((l, i) => `  s${i.toString().padStart(2, "0")} | ${l}`)
-        .join("\n");
-      throw new Error(
-        `Found ${mangledTokens.length} mangled phase token(s): ${JSON.stringify(mangledTokens)}.\n\n` +
-          `Scrollback (${harness.vt.scrollback.length} rows):\n${scrollback}\n\n` +
-          `Visible (${harness.vt.rows} rows):\n${visible}`,
-      );
-    }
-    expect(mangledTokens).toBeNull();
-    renderer.dispose();
-  });
-
-  it("binds log-update to the renderer's column count even when process.stdout.columns is undefined (RED→GREEN column-mismatch invariant)", () => {
-    // RED→GREEN gate for the Symptom A defensive fix. The harness cannot
-    // reproduce the visible mid-string corruption deterministically (it
-    // requires real OS-level cursor/erase interleaving the synchronous VT
-    // model doesn't capture). This invariant test instead pins the
-    // *underlying* property the fix enforces: log-update MUST wrap at the
-    // renderer's `getColumns()` value, not at its own `defaultColumns`
-    // fallback. If the production code path reverts to the unbound
-    // `logUpdate` singleton, `process.stdout.columns = undefined` will leak
-    // through and this test goes RED.
-    //
-    // Method: spy on the stream that log-update wraps. The bound stream has
-    // `columns` as a getter that delegates to the renderer. If the renderer
-    // changes its columns (via `columnsOverride`), the next log-update
-    // write sees the new value. We assert that a write under
-    // `process.stdout.columns = undefined` still wraps at the renderer's
-    // configured 200-col width (not log-update's 80-col default).
-    //
-    // We use the production code path (not the harness path) by creating a
-    // TTYRenderer without `logUpdateInstance`. That forces the constructor
-    // into the `else` branch where the bound stream lives.
-    const writes: string[] = [];
-    const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+    // Verification method: construct a production-path TTYRenderer (no
+    // `logUpdateInstance` override) and read its `_boundStream.columns`
+    // getter directly. The getter delegates to `renderer.getColumns()`.
+    // If the production code is reverted to use the singleton `logUpdate`
+    // import, `_boundStream` is null and this test goes RED.
     const originalColumns = process.stdout.columns;
-    const originalRows = process.stdout.rows;
     const originalIsTTY = process.stdout.isTTY;
     try {
-      // Simulate `npx` stripping the TTY signals.
+      // Simulate `npx` stripping the TTY signals (no columns, no isTTY).
       Object.defineProperty(process.stdout, "columns", {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(process.stdout, "rows", {
         value: undefined,
         writable: true,
         configurable: true,
@@ -449,20 +319,11 @@ describe("#652 Symptom A — event-line mid-string char loss", () => {
         writable: true,
         configurable: true,
       });
-      // Capture writes that log-update's bound stream produces.
-      process.stdout.write = ((chunk: string | Uint8Array) => {
-        writes.push(
-          typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
-        );
-        return true;
-      }) as typeof process.stdout.write;
 
-      // Production code path: no logUpdateInstance, no stdoutWrite override.
-      // This forces the constructor's `else` branch (the patched path).
       const r = new TTYRenderer({
         isTTY: true,
         noColor: true,
-        columns: 200, // Renderer view: 200 cols
+        columns: 200, // Renderer's view: 200 cols
         rows: 24,
         liveTickMs: 0,
         noSignalListeners: true,
@@ -470,48 +331,59 @@ describe("#652 Symptom A — event-line mid-string char loss", () => {
         wallClock: () => FIXED_DATE,
       });
 
-      r.registerIssue({ issueNumber: 504 });
-      r.onEvent({ issue: 504, phase: "spec", event: "start" });
-      // A second event drives a log-update redraw — by which point the
-      // bound stream's `columns` getter has been read by log-update for
-      // its wrap math.
-      r.onEvent({
-        issue: 504,
-        phase: "spec",
-        event: "complete",
-        durationSeconds: 30,
-      });
+      // Read the bound stream directly (private field exposed for tests).
+      const boundStream = (r as unknown as {
+        _boundStream: {
+          readonly columns: number;
+          readonly rows: number;
+          readonly isTTY: boolean;
+        } | null;
+      })._boundStream;
+
+      // Invariant 1: the renderer takes the production path → bound stream exists.
+      expect(boundStream).not.toBeNull();
+      if (boundStream === null) return;
+
+      // Invariant 2: bound stream's columns getter returns the renderer's
+      // view (200), not log-update's 80-col fallback or process.stdout's
+      // undefined.
+      expect(boundStream.columns).toBe(200);
+
+      // Invariant 3: bound stream's `isTTY` is derived from `process.stdout`,
+      // not hardcoded. Setting process.stdout.isTTY = true above → bound
+      // stream sees true. (Guards against the synchronized-output ANSI
+      // pollution regression flagged in PR #654 review.)
+      expect(boundStream.isTTY).toBe(true);
+
       r.dispose();
 
-      // Invariant: the renderer rendered frames sized to 200-cols, not
-      // log-update's 80-col fallback. We check by looking at the longest
-      // line in any of the captured writes: if log-update wrapped at 80,
-      // no line would exceed 80 visible chars (stripping ANSI). If
-      // log-update wrapped at 200 (or didn't wrap because the frame
-      // already fit), lines can be longer than 80.
-      // Strip ANSI escapes so we measure visible width.
-      const stripAnsi = (s: string) => s.replace(/\[[0-9;]*[A-Za-z]/g, "");
-      const allText = writes.join("");
-      const lines = allText.split("\n");
-      const longestVisible = Math.max(
-        ...lines.map((line) => stripAnsi(line).length),
-      );
-      // The frame's box-drawing rows are sized to roughly the renderer's
-      // columns (capped at 110 internally for SUMMARY_COLUMN_CAP, but the
-      // single-issue grid uses up to `min(cols, 110)`). So we expect to
-      // see at least one line wider than 80 visible chars — proving
-      // log-update did NOT wrap at its 80-col fallback.
-      expect(longestVisible).toBeGreaterThan(80);
-    } finally {
-      // Restore process.stdout state.
-      process.stdout.write = originalStdoutWrite;
-      Object.defineProperty(process.stdout, "columns", {
-        value: originalColumns,
+      // Invariant 4: when process.stdout.isTTY is false (piped/redirected),
+      // bound stream also reports false → log-update won't emit
+      // synchronized-output escapes (`ESC[?2026h`) into the pipe.
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
         writable: true,
         configurable: true,
       });
-      Object.defineProperty(process.stdout, "rows", {
-        value: originalRows,
+      const r2 = new TTYRenderer({
+        isTTY: true,
+        noColor: true,
+        columns: 100,
+        rows: 24,
+        liveTickMs: 0,
+        noSignalListeners: true,
+        now: () => FIXED_NOW,
+        wallClock: () => FIXED_DATE,
+      });
+      const bs2 = (r2 as unknown as {
+        _boundStream: { readonly isTTY: boolean } | null;
+      })._boundStream;
+      expect(bs2).not.toBeNull();
+      expect(bs2?.isTTY).toBe(false);
+      r2.dispose();
+    } finally {
+      Object.defineProperty(process.stdout, "columns", {
+        value: originalColumns,
         writable: true,
         configurable: true,
       });
@@ -524,125 +396,17 @@ describe("#652 Symptom A — event-line mid-string char loss", () => {
   });
 });
 
-describe("#652 Symptom B — U+FFFD and row overlap in summary table", () => {
-  it("emits a summary table with no U+FFFD and no digit/letter content inside separator rows", () => {
-    // Production symptom: ├───────�     │ 33m 41s    │
+describe("#652 Symptom B — renderSummary live-timer cancel ordering", () => {
+  it("cancels the live timer BEFORE logUpdateClear (RED→GREEN call-order invariant)", () => {
+    // Pins the property the renderSummary reorder enforces: by the time
+    // `logUpdateClear` runs inside `renderSummary`, `liveTimer` is null.
     //
-    // The U+FFFD is the smoking gun — a multibyte char split at a byte
-    // boundary. The "33m 41s" is a data row's "Total" cell rendered ON TOP OF
-    // a separator row, meaning the terminal cursor was positioned at the
-    // wrong row when the data row was emitted.
-    //
-    // Both effects trace back to the same cause: `renderSummary` calls
-    // `logUpdateClear()`, then `logUpdateDone()`, THEN `clearInterval` on
-    // the live timer. If the timer fires between those calls, it redraws the
-    // live frame INTO the summary's output stream.
-    //
-    // The harness can't fire setInterval mid-call (JS single-threaded), so
-    // we simulate the same hazard by manually driving `tickNow()` between
-    // events that lead into the summary, and by passing `liveTickMs: 0` to
-    // disable the real interval (otherwise it would fire under real time).
-    const { renderer, harness } = makeHarnessRenderer({
-      rows: 30,
-      cols: 100,
-    });
-
-    renderer.registerIssue({ issueNumber: 504 });
-    renderer.registerIssue({ issueNumber: 505 });
-
-    const events: ProgressEvent[] = [
-      { issue: 504, phase: "spec", event: "start" },
-      { issue: 504, phase: "spec", event: "complete", durationSeconds: 30 },
-      { issue: 505, phase: "spec", event: "start" },
-      { issue: 505, phase: "spec", event: "complete", durationSeconds: 45 },
-      { issue: 504, phase: "exec", event: "start" },
-      { issue: 504, phase: "exec", event: "complete", durationSeconds: 600 },
-      { issue: 505, phase: "exec", event: "start" },
-      { issue: 505, phase: "exec", event: "complete", durationSeconds: 720 },
-      { issue: 504, phase: "qa", event: "start" },
-      { issue: 504, phase: "qa", event: "complete", durationSeconds: 60 },
-      { issue: 505, phase: "qa", event: "start" },
-      {
-        issue: 505,
-        phase: "qa",
-        event: "failed",
-        error: "QA verdict: AC_MET_BUT_NOT_A_PLUS",
-      },
-    ];
-    for (const ev of events) {
-      renderer.onEvent(ev);
-      renderer.tickNow();
-    }
-    renderer.renderSummary({
-      issues: [
-        {
-          issueNumber: 504,
-          success: true,
-          phases: [
-            { name: "spec", success: true },
-            { name: "exec", success: true },
-            { name: "qa", success: true },
-          ],
-          durationSeconds: 2021,
-        },
-        {
-          issueNumber: 505,
-          success: false,
-          phases: [
-            { name: "spec", success: true },
-            { name: "exec", success: true },
-            { name: "qa", success: false },
-          ],
-          durationSeconds: 765,
-          failureReason: "qa failed",
-          qaVerdict: "AC_MET_BUT_NOT_A_PLUS",
-        },
-      ],
-      totalDurationSeconds: 2786,
-    });
-
-    const text = harness.vt.getAllText();
-
-    // AC-2 invariant #1: no Unicode replacement chars anywhere.
-    if (text.includes("�")) {
-      throw new Error(`Found U+FFFD in rendered output. Full text:\n${text}`);
-    }
-    expect(text).not.toContain("�");
-
-    // AC-2 invariant #2: every separator row (one that starts with `  ├` or
-    // contains `├`/`┼`/`┤`/`┬`/`┴`) must consist of *only* box-drawing chars
-    // and spaces — never digits or letters. A digit/letter in a separator row
-    // means a data row was rendered atop the separator row.
-    const allLines = text.split("\n");
-    const separatorWithContent = allLines.find((line) => {
-      const isSeparator = /[├┼┤┬┴]/.test(line);
-      if (!isSeparator) return false;
-      // Strip ANSI to inspect raw content (renderer emits SGR codes for dim).
-      const stripped = line.replace(/\[[0-9;]*[A-Za-z]/g, "");
-      return /[0-9A-Za-z]/.test(stripped);
-    });
-    if (separatorWithContent) {
-      throw new Error(
-        `Found separator row with digit/letter content (data row overlaid on separator):\n  ${separatorWithContent}\n\nFull text:\n${text}`,
-      );
-    }
-    expect(separatorWithContent).toBeUndefined();
-    renderer.dispose();
-  });
-
-  it("cancels the live timer before tearing down log-update (RED→GREEN call-order invariant)", () => {
-    // RED→GREEN gate for the renderSummary fix. The harness cannot model OS
-    // pipe buffering or real setInterval preemption, so the visible-output
-    // assertion in the test above passes on both old and new code. This
-    // invariant test instead captures the *underlying* mechanism: the live
-    // timer MUST be `null` by the time `logUpdateClear` runs, otherwise a
-    // pending tick (already queued in the event loop) can still fire between
-    // the log-update teardown and the summary write.
-    //
-    // Before fix: renderSummary called logUpdateClear/Done first, then
-    // clearInterval → liveTimer was still set at clear time. RED.
-    // After fix: clearInterval runs first → liveTimer is null at clear time.
-    // GREEN.
+    // **Honesty note.** The original PR claimed this prevents a tick from
+    // firing between `logUpdateClear` and the subsequent `clearInterval`.
+    // JS is single-threaded so that race cannot occur. We keep the reorder
+    // as structural cleanup (see the comment in renderSummary), and this
+    // test pins the ordering so a future reverter can't silently restore
+    // the misleading sequence.
     const { renderer } = makeHarnessRenderer({ rows: 30, cols: 100 });
 
     type RendererPrivate = {
@@ -651,6 +415,21 @@ describe("#652 Symptom B — U+FFFD and row overlap in summary table", () => {
       liveTimer: NodeJS.Timeout | null;
     };
     const r = renderer as unknown as RendererPrivate;
+
+    // Set up a real interval so the `clearInterval` branch is exercised.
+    // The harness path uses `liveTickMs: 0` which suppresses the constructor's
+    // own `startLiveTimer()`, so we manually create one to model the
+    // production case where the timer is live when renderSummary is called.
+    r.liveTimer = setInterval(() => {}, 100_000);
+
+    // Pre-condition: liveTimer must actually be non-null going into
+    // renderSummary, otherwise the test is vacuous (it would pass with
+    // the bug intact via the "liveTimer was already null" path).
+    expect(r.liveTimer).not.toBeNull();
+
+    // Spy on logUpdateClear: record whether liveTimer was still set when
+    // it ran. The fix guarantees `clearInterval` ran first → liveTimer
+    // is null at clear time.
     const observations: Array<{ op: string; liveTimerWasSet: boolean }> = [];
     const origClear = r.logUpdateClear.bind(renderer);
     const origDone = r.logUpdateDone.bind(renderer);
@@ -670,11 +449,6 @@ describe("#652 Symptom B — U+FFFD and row overlap in summary table", () => {
     };
 
     renderer.registerIssue({ issueNumber: 504 });
-    // The harness sets liveTickMs: 0 so no live timer is started by default.
-    // Force one to exist so we can observe whether renderSummary cancels it
-    // BEFORE the log-update teardown.
-    r.liveTimer = setInterval(() => {}, 100_000);
-
     renderer.renderSummary({
       issues: [
         {
@@ -687,12 +461,18 @@ describe("#652 Symptom B — U+FFFD and row overlap in summary table", () => {
       totalDurationSeconds: 30,
     });
 
-    // Invariant: liveTimer must be null at the moment logUpdateClear runs.
+    // Invariant 1: logUpdateClear was actually called (proves the
+    // `clearInterval`-then-`clear` branch was taken, not a dispose
+    // shortcut that bypasses both).
     const clearCall = observations.find((c) => c.op === "logUpdateClear");
     expect(clearCall).toBeDefined();
-    if (clearCall) {
-      expect(clearCall.liveTimerWasSet).toBe(false);
-    }
+
+    // Invariant 2: at the moment logUpdateClear ran, liveTimer was null
+    // (proves clearInterval ran first). Pre-condition above proves it
+    // started non-null, so this transition can only have happened via
+    // the renderSummary's clearInterval branch.
+    expect(clearCall?.liveTimerWasSet).toBe(false);
+
     renderer.dispose();
   });
 });


### PR DESCRIPTION
## Stacking callout (read first)

**This PR is stacked on PR #653 / `feature/647-…` (issue #647).**

- **Files actually in scope of #652 (review these):** `src/lib/cli-ui/run-renderer.ts` and `src/lib/cli-ui/scrollback-harness.test.ts`. The "Files changed" tab will show this delta correctly.
- **#647's changes are inherited, not under review here.** The "Commits" tab will show ~7 commits including #647's instrumentation, harness, and AC-3 grid-math fix. Those belong to #653.
- **Merge order:** #653 must land first. After #653 merges to main, rebase this PR onto main and merge. If #653 stalls, the escape hatch is to retarget this PR to `main` and cherry-pick `scrollback-harness.ts`/`scrollback-harness.test.ts` from #653 into this branch.
- **Squash before merge.** Use GitHub's squash-merge — the commit history here is messy (a revert-restore cycle during local debugging, plus a gap-fix commit on top of the original fix).

Closes #652.

## What this PR ships

Two defensive renderer fixes + two invariant tests.

### 1. `log-update` column binding (Symptom A)

The production `TTYRenderer` constructor previously delegated to the unbound `logUpdate` singleton, which reads `process.stdout.columns` directly. Under `npx`, that value is sometimes undefined → log-update falls back to its internal `defaultColumns` (~80) while the renderer falls back to 100 (`getColumns()`). The width disagreement makes log-update's `previousLineCount` desync from the actual terminal-row-count.

Fix: replace the singleton with `createLogUpdate(boundStream)`, where the bound stream's `columns`/`rows`/`isTTY` getters delegate to the renderer's view of the world. Renderer and log-update now share a single source of truth.

Note: `isTTY` derives from `process.stdout.isTTY` (NOT hardcoded `true`). An earlier draft of this PR hardcoded `true` — caught by code review because it would cause log-update v7 to wrap every write in synchronized-output ANSI escapes (`ESC[?2026h` … `ESC[?2026l`) under redirects/pipes.

### 2. `renderSummary` teardown order (Symptom B)

The original PR comment claimed that a `setInterval` tick could fire between `logUpdateClear` and the subsequent `clearInterval`, allowing the live frame to redraw into the summary stream. **That claim is false.** JS is single-threaded; setInterval callbacks are macrotasks and cannot preempt synchronous code. The race window doesn't exist.

The reorder (move `clearInterval` to the top of `renderSummary`) is kept as **structural cleanup**: single-statement move, guards against future `redraw()` callers re-creating the live zone after teardown, and documents intent (when rendering summary, we are *finished* with the live zone). But it is NOT a fix for Symptom B in any defensible sense.

The likely real fix for Symptom B is #647's AC-3 grid-width math correction (`-7` → `-9`), already shipped in this branch.

## Tests

Two RED→GREEN invariant tests in `scrollback-harness.test.ts`:

1. **Symptom A: `_boundStream` exists and reports the renderer's view.** Constructs a production-path renderer with `process.stdout.columns = undefined` and asserts `_boundStream.columns === 200` (the renderer's configured value, not log-update's 80-col fallback). Also asserts `_boundStream.isTTY` correctly tracks `process.stdout.isTTY` (guards against the synchronized-output ANSI regression).

2. **Symptom B: `clearInterval` runs before `logUpdateClear`.** Sets a real interval, asserts the precondition (`liveTimer !== null` before `renderSummary`), spies on `logUpdateClear`, and asserts that at the moment it ran, `liveTimer` was already null (proves `clearInterval` ran first via the renderSummary branch, not via a dispose shortcut).

**RED→GREEN verified locally** by reverting each fix:
- Symptom A: set `_boundStream = null` → test fails with "expected null not to be null"
- Symptom B: revert `clearInterval` to after `clear/done` → test fails with "expected true to be false"

## Honest gap acknowledgements

These are documented limits, not blockers. Filed as follow-ups (recommended below).

- **Symptom A's column-mismatch hypothesis is partial.** `eraseLines` clears whole lines and can't directly produce mid-string corruption (`#505 loop` → `#5loop`). That shape requires log-update's diff renderer overwriting from the first changed column, AND/OR SIGWINCH races, AND/OR subprocess stdout interleaving. The column-binding fix narrows the desync window but does not address SIGWINCH or subprocess interleaving.

- **Symptom B is likely already fixed by #647's AC-3 grid-math correction.** The U+FFFD and row-overlap are most plausibly the result of `wrap-ansi` hard-wrapping inside a multibyte box-drawing character because the rows were 2 chars wider than the terminal column count. The reorder in this PR is structural cleanup; #647 is the substantive fix.

- **Tests are property invariants, not visible-symptom regressions.** They prove the bound stream is configured correctly and the call order is correct. They do NOT prove the visible symptoms cannot occur via SIGWINCH/subprocess/etc. mechanisms.

- **No production replay performed.** Running the original `npx sequant run 504 505 -q` transcript with `SEQUANT_DEBUG_RENDERER=1` would validate (or refute) the column-mismatch hypothesis. Not done here because it requires live `claude` subprocess calls.

- **Commit history is messy.** Three commits, including a revert-restore cycle. Squash-merge at merge time will collapse to a single clean commit.

## Recommended follow-ups (not blocking)

1. **PTY-based harness** for true visible-symptom regression coverage (instead of the synchronous `VirtualTerminal` model that fundamentally can't reproduce timing-dependent symptoms).
2. **Production replay** with `SEQUANT_DEBUG_RENDERER=1` against the original transcript to empirically validate the column-mismatch hypothesis.
3. **SIGWINCH race investigation** — the column-binding fix doesn't address `process.stdout.columns` changing mid-render.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] All 91 cli-ui tests pass (`npx vitest run src/lib/cli-ui/`)
- [x] Symptom A invariant goes RED on pre-fix code (verified by setting `_boundStream = null`)
- [x] Symptom B invariant goes RED on pre-fix code (verified by reverting `clearInterval` to after `clear/done`)
- [ ] Production replay with `SEQUANT_DEBUG_RENDERER=1` (deferred — requires real `claude` subprocess; filed as follow-up)