### PR TITLE
docs(#655): AC-D1 negative result — synthetic harness does not reproduce

### DIFF
--- a/docs/incidents/655/negative-result.md
+++ b/docs/incidents/655/negative-result.md
@@ -27,16 +27,16 @@ Auditing every `process.stdout.write` and `console.log` call reachable from `npx
 
 | Writer | File:line | Reachable in `-q`? |
 |---|---|---|
-| `TTYRenderer.stdoutWrite` (renderer's sole own writer) | `src/lib/cli-ui/run-renderer.ts:131-132` | Yes — sole intended writer |
-| `log-update` instance (via renderer's `logUpdateImpl`) | `src/lib/cli-ui/run-renderer.ts:664-676` | Yes — sole intended writer |
+| `TTYRenderer.stdoutWrite` (renderer's sole own writer) | `src/lib/cli-ui/run-renderer.ts:131-132` | **No in `-q`** — not wired (see `run-progress.ts:59-60`); sole writer in default mode and emits all `✔`/`✘`/`▸` event-line glyphs |
+| `log-update` instance (via renderer's `logUpdateImpl`) | `src/lib/cli-ui/run-renderer.ts:664-676` | Same as above — gated on `!quiet && !tuiEnabled` |
 | `process.stdout.write(chalk.gray(text))` (verbose subprocess streaming) | `src/lib/workflow/phase-executor.ts:675` | **No** — gated on `if (config.verbose)` |
 | `process.stderr.write(chalk.red(data))` (verbose subprocess stderr) | `src/lib/workflow/phase-executor.ts:686` | No — stderr, also gated on verbose |
-| `LivenessHeartbeat.stdoutWrite` | `src/lib/workflow/heartbeat.ts:100` | No — heartbeat is NonTTY-mode only |
+| `LivenessHeartbeat.stdoutWrite` | `src/lib/workflow/heartbeat.ts:100, :226` | **Yes** — sole stdout writer in `-q` mode (see `run-progress.ts:46-49`); mutually exclusive with renderer; writes only `▸ #N phase (elapsed, …)` heartbeat lines, **never `✔`/`✘`** |
 | `batch-executor.ts:153, :165` | n/a | No — stderr only |
 | Renderer's `stderrWrite` (`SEQUANT_DEBUG_RENDERER` traces) | `src/lib/cli-ui/run-renderer.ts:605` | Yes — stderr only |
 | `console.log` callsites in `src/commands/sync.ts`, `src/commands/update.ts`, etc. | various | No — not reachable from `run` |
 
-There is **no second stdout writer** in non-verbose mode. The renderer owns stdout end-to-end.
+There is **no second stdout writer** in either mode: in default mode the renderer owns stdout end-to-end; in `-q` mode the heartbeat owns it (and writes only `▸` lines). No code path produces a `✔` glyph alongside the heartbeat, and no code path produces a `▸` heartbeat alongside the renderer. The `complete[0:8] + failed[col 9+]` overlay cannot be assembled from any combination of these writers in a single run mode.
 
 ### 3. Re-confirmation of ruled-out hypotheses
 
@@ -54,13 +54,15 @@ All three require evidence from a real corrupted run. `SEQUANT_DEBUG_RENDERER=1`
 
 ## How to capture AC-1
 
-1. Identify a scenario known to produce Symptom A. The motivating transcript was `npx sequant run 504 505 -q` (parallel mode, 2 issues, ~12 events including a `loop` retry that fails) in a real terminal.
-2. Run with the instrumentation enabled and capture both streams:
+> **Mode discrepancy — read before running the capture.** The issue body states the motivating transcript was `-q` (quiet) mode, but the visible glyph in the corrupted line (`✔`) is **only** produced by `TTYRenderer`, which is not wired in `-q` mode (see `run-progress.ts:59-60`). The heartbeat path that IS wired in `-q` writes only `▸` (see static-analysis table above). One of three things must be true: (a) the original transcript was actually default mode, not `-q`; (b) the renderer wiring changed since the transcript was captured; or (c) the original transcript's mode label is wrong. Re-confirm the mode from any available evidence before running the capture. The example below uses default mode (no `-q`) because that is the only mode in which the renderer — and therefore Symptom A's `✔` glyph — can fire.
+
+1. Identify a scenario known to produce Symptom A. The motivating transcript referenced `npx sequant run 504 505` (parallel mode, 2 issues, ~12 events including a `loop` retry that fails) in a real terminal.
+2. Run with the instrumentation enabled and capture both streams (default mode, **no** `-q`):
 
    ```bash
    SEQUANT_DEBUG_RENDERER=1 \
      script -q artifact/terminal.typescript \
-     npx sequant run 504 505 -q \
+     npx sequant run 504 505 \
      2> artifact/debug.jsonl
    ```
 

--- a/docs/incidents/655/negative-result.md
+++ b/docs/incidents/655/negative-result.md
@@ -7,7 +7,7 @@
 ## TL;DR
 
 - Synthetic reproduction does **not** trigger the `complete[0:8 bytes] + failed[col 9+]` overlay pattern. The scrollback harness from #647 covers the only mechanism reachable in our virtual-terminal model (width misreporting / scroll), and adding the explicit complete→failed event-line sequence at multiple widths + pause/resume states keeps that result.
-- Static analysis of every `process.stdout.write` / `console.log` reachable under `npx sequant run … -q` confirms the renderer is the sole stdout writer in non-verbose mode. There is no second-writer mechanism in the source tree.
+- Static analysis of every `process.stdout.write` / `console.log` reachable from `npx sequant run …` (both default mode and `-q`) confirms there is no second stdout writer in either mode: the renderer owns stdout in default mode, the heartbeat owns it in `-q` mode, and they are mutually exclusive (see `run-progress.ts:46-49` and `run-progress.ts:59-60`). There is no second-writer mechanism in the source tree.
 - The forensic byte math (`complete[0:8] + failed[9:]`) therefore implies one of: (a) a mechanism on the terminal-emulator side, (b) an interleave the static reading missed, or (c) a measurement artifact in the original transcript. Discriminating between these requires a real-run trace.
 - AC-1 instrumentation (`SEQUANT_DEBUG_RENDERER=1`, emitted from `src/lib/cli-ui/run-renderer.ts:557-606`) is already shipped. The next productive step is a live capture against a scenario known to corrupt — see "How to capture AC-1" below.
 
@@ -21,9 +21,9 @@ For #655 specifically, this PR adds one further scenario (see `scrollback-harnes
 
 **Result:** assertion passes. No overlay row produced in any synthetic variant tried.
 
-### 2. Static analysis of stdout writers in `-q` mode (spec phase 2)
+### 2. Static analysis of stdout writers in both run modes (spec phase 2)
 
-Auditing every `process.stdout.write` and `console.log` call reachable from `npx sequant run … -q`:
+Auditing every `process.stdout.write` and `console.log` call reachable from `npx sequant run …` (both default mode and `-q`). The audit covers both modes because the corrected gating analysis below establishes that they have *different* sole writers — restricting the audit to one mode would miss the mode-discrepancy callout in §"How to capture AC-1":
 
 | Writer | File:line | Reachable in `-q`? |
 |---|---|---|

--- a/docs/incidents/655/negative-result.md
+++ b/docs/incidents/655/negative-result.md
@@ -1,0 +1,86 @@
+# #655 — Renderer corruption (Symptom A): negative result
+
+**Status:** AC-D1 (no reproduction; instrumentation in place for next real-run capture).
+
+**Scope of this document:** What `/exec 655` could and could not establish without a real-terminal trace, and how to capture the trace required to advance to AC-1..4.
+
+## TL;DR
+
+- Synthetic reproduction does **not** trigger the `complete[0:8 bytes] + failed[col 9+]` overlay pattern. The scrollback harness from #647 covers the only mechanism reachable in our virtual-terminal model (width misreporting / scroll), and adding the explicit complete→failed event-line sequence at multiple widths + pause/resume states keeps that result.
+- Static analysis of every `process.stdout.write` / `console.log` reachable under `npx sequant run … -q` confirms the renderer is the sole stdout writer in non-verbose mode. There is no second-writer mechanism in the source tree.
+- The forensic byte math (`complete[0:8] + failed[9:]`) therefore implies one of: (a) a mechanism on the terminal-emulator side, (b) an interleave the static reading missed, or (c) a measurement artifact in the original transcript. Discriminating between these requires a real-run trace.
+- AC-1 instrumentation (`SEQUANT_DEBUG_RENDERER=1`, emitted from `src/lib/cli-ui/run-renderer.ts:557-606`) is already shipped. The next productive step is a live capture against a scenario known to corrupt — see "How to capture AC-1" below.
+
+## What was tried
+
+### 1. Synthetic reproduction (spec phase 1)
+
+The #647 scrollback harness (`src/lib/cli-ui/scrollback-harness.ts` + `…test.ts`) drives a real `createLogUpdate(stream)` instance through a `VirtualTerminal` that models cursor positioning, eraseLine variants, and scrollback. Existing scenarios pass green; the duplicate-header / width-misreport case from #647 is locked in.
+
+For #655 specifically, this PR adds one further scenario (see `scrollback-harness.test.ts`'s `#655 negative-result lock-in` block): the motivating issue's exact event sequence (complete `loop` event followed by a failed `loop` event for the same issue) at a 100-col stream + 80-col physical width + pause/resume between events. The VT inspects every row of `(visible + scrollback)` and asserts no row matches the overlay regex `/✔ #\d+(?!.*\d).*Claude/` (a green checkmark on the same row as the error string would indicate the production corruption).
+
+**Result:** assertion passes. No overlay row produced in any synthetic variant tried.
+
+### 2. Static analysis of stdout writers in `-q` mode (spec phase 2)
+
+Auditing every `process.stdout.write` and `console.log` call reachable from `npx sequant run … -q`:
+
+| Writer | File:line | Reachable in `-q`? |
+|---|---|---|
+| `TTYRenderer.stdoutWrite` (renderer's sole own writer) | `src/lib/cli-ui/run-renderer.ts:131-132` | Yes — sole intended writer |
+| `log-update` instance (via renderer's `logUpdateImpl`) | `src/lib/cli-ui/run-renderer.ts:664-676` | Yes — sole intended writer |
+| `process.stdout.write(chalk.gray(text))` (verbose subprocess streaming) | `src/lib/workflow/phase-executor.ts:675` | **No** — gated on `if (config.verbose)` |
+| `process.stderr.write(chalk.red(data))` (verbose subprocess stderr) | `src/lib/workflow/phase-executor.ts:686` | No — stderr, also gated on verbose |
+| `LivenessHeartbeat.stdoutWrite` | `src/lib/workflow/heartbeat.ts:100` | No — heartbeat is NonTTY-mode only |
+| `batch-executor.ts:153, :165` | n/a | No — stderr only |
+| Renderer's `stderrWrite` (`SEQUANT_DEBUG_RENDERER` traces) | `src/lib/cli-ui/run-renderer.ts:605` | Yes — stderr only |
+| `console.log` callsites in `src/commands/sync.ts`, `src/commands/update.ts`, etc. | various | No — not reachable from `run` |
+
+There is **no second stdout writer** in non-verbose mode. The renderer owns stdout end-to-end.
+
+### 3. Re-confirmation of ruled-out hypotheses
+
+Each of the six ruled-out hypotheses from the issue body was re-examined against the source as of `7412850` (post-#647). No new evidence challenges the prior refutations. Nothing in this audit warrants relitigating them.
+
+## What could not be established without a real-run trace
+
+The forensic byte pattern (`complete[0:8 bytes] + failed[col 9+]` on the same row) is a load-bearing claim. If accurate, **some** mechanism wrote those bytes onto a row that already contained the prefix of the complete-event line. Possible sources, ordered by feasibility:
+
+1. **Terminal-emulator-side rendering bug.** The VT we model in the harness is faithful to the ANSI vocabulary log-update emits, but a specific terminal emulator could implement cursor/erase semantics differently and produce an overlay where the model says none exists. This is testable only against a real terminal that has been observed to corrupt.
+2. **A stdout writer we missed in static analysis.** Possible but unlikely given the audit above; the renderer-owned-stdout invariant is structural.
+3. **Measurement artifact.** The original transcript was captured via shell redirection / scrollback copy. If the corruption is purely a rendering issue (i.e., bytes on the wire are correct, but the emulator drew the wrong glyphs at the wrong cells), the transcript could mislead the byte-math analysis.
+
+All three require evidence from a real corrupted run. `SEQUANT_DEBUG_RENDERER=1` emits one JSON line per `log-update` callsite to stderr, including frame counter, columns/rows from both the renderer and `process.stdout`, logical line count, and wrap-aware wrapped line count. Diffing the trace against the visible terminal corruption is what AC-2 calls for.
+
+## How to capture AC-1
+
+1. Identify a scenario known to produce Symptom A. The motivating transcript was `npx sequant run 504 505 -q` (parallel mode, 2 issues, ~12 events including a `loop` retry that fails) in a real terminal.
+2. Run with the instrumentation enabled and capture both streams:
+
+   ```bash
+   SEQUANT_DEBUG_RENDERER=1 \
+     script -q artifact/terminal.typescript \
+     npx sequant run 504 505 -q \
+     2> artifact/debug.jsonl
+   ```
+
+   `script -q` records the literal bytes sent to the terminal (including all ANSI sequences) into `artifact/terminal.typescript`. `2>` separates the JSON trace.
+
+3. When Symptom A reproduces, commit both artifacts under `docs/incidents/655/captures/<date>/`. If using `npx sequant run` against real production issues isn't viable, a smaller fixture (any two-issue parallel run where the `loop` phase fails for one issue) should suffice.
+4. With both artifacts in hand, the next iteration can:
+   - Read `debug.jsonl` to determine the renderer's view at every frame.
+   - Read `terminal.typescript` (or replay via `cat`) to determine what the terminal actually drew.
+   - Reconcile: does the renderer's wire output already contain the overlay, or does the emulator render an overlay despite a wire output that wouldn't produce one in our VT?
+
+Outcome (1) puts the bug in the renderer / log-update path; outcome (2) puts the bug in the terminal emulator and is out of scope for a sequant patch (though we may want a workaround).
+
+## Open follow-ups (not blocking this PR)
+
+- The PTY-based test harness option from the issue body (`node-pty` or `script`-FIFO) becomes worth building only if the AC-1 capture reveals timing-dependence — i.e., the wire bytes are deterministic but the emulator's response is not. Defer until evidence motivates the cost.
+- The pause/resume dead-code bug (`batch-executor` never passes `spinner` to `executePhaseWithRetry`) is filed separately per the issue body; no movement here.
+
+## Artifacts shipped in this PR
+
+- `docs/incidents/655/negative-result.md` — this file
+- `src/lib/cli-ui/scrollback-harness.test.ts` — added one negative-result lock-in test asserting the complete→failed event sequence does not produce an overlay row in the synthetic harness
+- No changes to `src/lib/cli-ui/run-renderer.ts`; instrumentation from #647 (`SEQUANT_DEBUG_RENDERER=1`) is unchanged and ready for the next capture

--- a/src/lib/cli-ui/scrollback-harness.test.ts
+++ b/src/lib/cli-ui/scrollback-harness.test.ts
@@ -290,6 +290,81 @@ describe("#647 scrollback harness — duplicate-header regression", () => {
     renderer.dispose();
   });
 
+  // #655 negative-result lock-in: drive the motivating issue's exact event
+  // sequence (complete `loop` followed by failed `loop` for the same issue)
+  // through the harness at a width that exercises both the renderer's
+  // `min(cols, 78)` cap AND a pause/resume cycle between the two events. The
+  // issue body's forensic byte math (`complete[0:8] + failed[col 9+]` on the
+  // same row) would manifest here as a row containing both the green ✔ marker
+  // and the error string. Assert that no such row exists.
+  //
+  // This test is expected to PASS today (synthetic harness does not reproduce
+  // Symptom A). Its purpose is to lock in the negative result: if a future
+  // change to the renderer or log-update ever introduces an overlay reachable
+  // synthetically, this test will catch it without needing a real-terminal
+  // capture. See `docs/incidents/655/negative-result.md`.
+  it("#655 negative-result lock-in: complete→failed event sequence does not produce an overlay row", () => {
+    const { renderer, harness } = makeHarnessRenderer({
+      rows: 24,
+      cols: 80,
+      streamColumns: 100,
+      rendererColumns: 100,
+    });
+
+    renderer.registerIssue({ issueNumber: 505 });
+    // Drive enough phase activity to push the live frame around in the
+    // viewport before the loop pair fires.
+    renderer.onEvent({ issue: 505, phase: "spec", event: "start" });
+    renderer.onEvent({
+      issue: 505,
+      phase: "spec",
+      event: "complete",
+      durationSeconds: 232,
+    });
+    renderer.onEvent({ issue: 505, phase: "exec", event: "start" });
+    renderer.onEvent({
+      issue: 505,
+      phase: "exec",
+      event: "complete",
+      durationSeconds: 820,
+    });
+    // The motivating pair: complete loop then failed loop for the same issue,
+    // separated by a pause/resume that mimics verbose subprocess streaming
+    // toggling. Pause/resume cycling exercises the `logUpdateClear()` →
+    // `redraw()` path between the two event-line writes.
+    renderer.onEvent({
+      issue: 505,
+      phase: "loop",
+      event: "complete",
+      durationSeconds: 60,
+    });
+    renderer.pause();
+    harness.stdoutWrite("  [verbose] streamed line between events\n");
+    renderer.resume();
+    renderer.onEvent({
+      issue: 505,
+      phase: "loop",
+      event: "failed",
+      error: "Claude Code returned an error result: ETIMEDOUT",
+    });
+
+    // Overlay detector: any single row that contains BOTH the green ✔ marker
+    // (only present on `complete` event lines) and the error string (only
+    // present on `failed` event lines) is the Symptom A signature. The two
+    // event types cannot legitimately co-occur on a single row.
+    const allRows = [...harness.vt.scrollback, ...harness.vt.getVisibleLines()];
+    const overlay = allRows.find(
+      (row) => row.includes("✔") && row.includes("Claude Code returned"),
+    );
+    if (overlay) {
+      throw new Error(
+        `Symptom A overlay row produced synthetically (unexpected). Row:\n  ${overlay}`,
+      );
+    }
+    expect(overlay).toBeUndefined();
+    renderer.dispose();
+  });
+
   // AC-3 derived: lock the grid-width arithmetic so future drift (changing
   // colW, padding, or the cap) can't silently reintroduce the overflow that
   // started this whole regression. Asserts on the actual rendered string


### PR DESCRIPTION
## Summary

Diagnose-first investigation for #655 (Symptom A renderer corruption, column-mismatch hypothesis refuted in #654, real cause unknown). `/exec` cannot drive AC-1 autonomously — real-run capture is HITL. This PR parks the work with the AC-D1 deliverable (negative result + reproduction instructions) so the next iteration can pick up from a real-run trace instead of relitigating the static analysis.

- **Static analysis** (spec phase 2): audited every `process.stdout.write` / `console.log` reachable from `npx sequant run …` (both default mode and `-q`). There is no second stdout writer in either mode — the renderer owns stdout in default mode (gated on `!quiet && !tuiEnabled`, `run-progress.ts:59-60`), the heartbeat owns it in `-q` mode (gated on `quiet && !tuiEnabled`, `run-progress.ts:46-49`), and they are mutually exclusive. `phase-executor.ts:675` is gated on `config.verbose`, so it does not write in non-verbose runs. **No second-writer mechanism in the source tree, in either mode.** The corrected static-analysis table also surfaces a contradiction with the issue body's "`-q` mode" claim: the `✔` glyph in the corrupted line is produced only by the renderer, which is not wired in `-q`. See `docs/incidents/655/negative-result.md` §"How to capture AC-1" for the mode-discrepancy callout.
- **Synthetic reproduction** (spec phase 1): the #647 scrollback harness already exists. This PR adds one further lock-in test driving the motivating issue's exact event sequence (complete `loop` → failed `loop` for the same issue) at a 100-col stream + 80-col physical width + pause/resume between events. The overlay detector (single row containing both `✔` and `Claude Code returned`) asserts no Symptom A row is produced. **Passes today** — purpose is to catch any future regression that makes Symptom A reachable synthetically.
- **No production code changes.** AC-1..4 remain unmet, deferred until a real trace lands. `SEQUANT_DEBUG_RENDERER=1` instrumentation (`run-renderer.ts:557-606`) is unchanged and ready; capture instructions are in `docs/incidents/655/negative-result.md`.

## AC coverage

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | 🔄 Deferred | Requires HITL real-run capture; `SEQUANT_DEBUG_RENDERER=1` instrumentation in place |
| AC-2 | 🔄 Deferred | Requires AC-1 evidence |
| AC-3 | 🔄 Deferred | Requires AC-2 mechanism to know which harness to write |
| AC-4 | 🔄 Deferred | Requires AC-2 mechanism |
| AC-D1 | ✅ Implemented | `docs/incidents/655/negative-result.md` + lock-in test in `scrollback-harness.test.ts` |
| AC-D2 | ⏭️ N/A | Conditional on AC-2 implicating `logUpdateClear`; not reached |

## Test plan

- [x] `npm test -- --run src/lib/cli-ui/` — 92 passed, 1 skipped (the deferred mechanism #1 scaffold from #647)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [ ] Human: run `SEQUANT_DEBUG_RENDERER=1 script -q artifact/terminal.typescript npx sequant run … 2> artifact/debug.jsonl` against a scenario known to produce Symptom A (default mode — **no** `-q`, since the renderer that emits the `✔` glyph is not wired in `-q`); commit captures under `docs/incidents/655/captures/<date>/`

Closes only AC-D1. Issue #655 remains open for AC-1..4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
