### PR TITLE
docs(#674): correct resume cwd-mismatch comment (recoverable error, not exit-1 crash)

### DIFF
--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -649,10 +649,14 @@ async function executePhase(
 
   // Safety: never resume a session when worktree isolation is active.
   // Even if THIS phase doesn't use the worktree, a previous phase may have
-  // created the session there. Resuming from a different cwd crashes the SDK
-  // (exit code 1). The registry's `requiresWorktree` field prevents this by
-  // design, but this guard catches edge cases (e.g. a new phase registered
-  // without setting `requiresWorktree: true`).
+  // created the session there. Claude Code namespaces session storage by cwd
+  // (~/.claude/projects/<encoded-cwd>/<session-id>.jsonl), so resuming from a
+  // different cwd can't locate the session — the SDK returns a recoverable
+  // `error_during_execution` ("No conversation found with session ID"), failing
+  // the phase (verified against claude-agent-sdk@0.3.142; see #674). The
+  // registry's `requiresWorktree` field prevents this by design, but this guard
+  // catches edge cases (e.g. a new phase registered without `requiresWorktree:
+  // true`). #674 tracks moving this into a driver-owned, cwd-keyed resume check.
   const canResume = sessionId && !worktreePath;
 
   // Build AgentExecutionConfig for the driver


### PR DESCRIPTION
## What

Corrects the inline comment at `phase-executor.ts:650` describing what happens when a Claude Code session is resumed from a different cwd. The old comment claimed it **"crashes the SDK (exit code 1)."**

## Why

Empirically verified against `@anthropic-ai/claude-agent-sdk@0.3.142` (probe details in #674): a cwd-mismatched resume does **not** crash. Claude Code namespaces session storage by encoded cwd —
`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` — so resuming from a different directory can't locate the session and the SDK returns a **recoverable** `error_during_execution` ("No conversation found with session ID"). The phase still fails, so the guard's behavior is unchanged; only the explanation was wrong.

## Scope

Comment-only — no behavior change. `tsc --noEmit` clean.

The deeper refactor (driver-owned, cwd-keyed `canResume` that falls back to a fresh session instead of failing) is tracked in #674. This PR just stops the comment from misleading the next reader.

Refs #674, #497.
