### PR TITLE
feat(#684): /release pre-flight regenerates marketplace README + checks README 'What's new' freshness

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -117,18 +117,9 @@ if [ -f "docs/internal/what-weve-built.md" ]; then
     echo "Warning: docs/internal/what-weve-built.md ASCII art shows v${ascii_version}, expected v${current}"
   fi
 fi
-
-# 12. Check README.md "What's new" section mentions the version being released
-if [ -f "README.md" ]; then
-  current=$(node -p "require('./package.json').version")
-
-  # Extract the "What's new" region (from its heading to EOF; .? matches the apostrophe)
-  whats_new=$(awk "/^#+ What.?s new/{f=1} f" README.md || true)
-  if ! echo "$whats_new" | grep -qF "New in ${current}"; then
-    echo "Warning: README.md \"What's new\" section omits v${current} — add a feature group before releasing"
-  fi
-fi
 ```
+
+> **Note:** The README "What's new" freshness check lives in **Step 4.65** (after the version bump), not here — it must compare against the *new* version, which doesn't exist in `package.json` until Step 4 runs.
 
 ## Release Steps
 
@@ -330,6 +321,25 @@ fi
 ```
 
 **Ask the user to review what-weve-built.md before proceeding** if there are new features to document.
+
+### Step 4.65: Verify README "What's new" Freshness
+
+**IMPORTANT:** This runs **after** Step 4 (version bump) so `package.json` already holds the *new* version. Running it earlier (in pre-flight) would compare against the previous release, which the README already lists — so the gate would never fire for the version actually being released (root cause class of #684).
+
+Warn-only (like the what-weve-built checks): prompt the releaser to add a "What's new" feature group if the new version is absent.
+
+```bash
+# Warn if README.md "What's new" section omits the version being released
+if [ -f "README.md" ]; then
+  new_version=$(node -p "require('./package.json').version")
+
+  # Extract the "What's new" region (from its heading to EOF; .? matches the apostrophe)
+  whats_new=$(awk "/^#+ What.?s new/{f=1} f" README.md || true)
+  if ! echo "$whats_new" | grep -qF "New in ${new_version}"; then
+    echo "Warning: README.md \"What's new\" section omits v${new_version} — add a feature group before releasing"
+  fi
+fi
+```
 
 ### Step 4.7: Regenerate Marketplace Artifact
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -117,6 +117,17 @@ if [ -f "docs/internal/what-weve-built.md" ]; then
     echo "Warning: docs/internal/what-weve-built.md ASCII art shows v${ascii_version}, expected v${current}"
   fi
 fi
+
+# 12. Check README.md "What's new" section mentions the version being released
+if [ -f "README.md" ]; then
+  current=$(node -p "require('./package.json').version")
+
+  # Extract the "What's new" region (from its heading to EOF; .? matches the apostrophe)
+  whats_new=$(awk "/^#+ What.?s new/{f=1} f" README.md || true)
+  if ! echo "$whats_new" | grep -qF "New in ${current}"; then
+    echo "Warning: README.md \"What's new\" section omits v${current} — add a feature group before releasing"
+  fi
+fi
 ```
 
 ## Release Steps
@@ -319,6 +330,28 @@ fi
 ```
 
 **Ask the user to review what-weve-built.md before proceeding** if there are new features to document.
+
+### Step 4.7: Regenerate Marketplace Artifact
+
+**IMPORTANT:** The marketplace plugin artifact under `dist/marketplace/` is bundled into the published tgz via `files: ["dist", ...]` in package.json — even though `dist/` is gitignored. Regenerate it from current sources **before** packing/publishing so the bundled README always matches; otherwise a stale artifact ships (root cause of #684 — the v2.4.0 tgz carried a "Node.js 20+" README after the floor moved to 22.12).
+
+This is an action step, so it lives in Release Steps (not the read-only pre-flight checks). It MUST run before Step 5 (`npm pack`) and Step 9 (`npm publish`).
+
+```bash
+# Regenerate the marketplace plugin artifact from current sources
+npm run prepare:marketplace
+
+# Freshness sanity check: generated README's Node.js floor should match package.json engines.
+# Warn-only (regeneration above already fixes the artifact; this is a belt-and-suspenders signal).
+gen_readme="dist/marketplace/external_plugins/sequant/README.md"
+if [ -f "$gen_readme" ]; then
+  engines_floor=$(node -p "require('./package.json').engines.node.replace(/[^0-9.]/g,'')")  # e.g. 22.12.0
+  readme_floor=$(grep -oE "Node\.js [0-9]+\.[0-9]+" "$gen_readme" | head -1 | grep -oE "[0-9]+\.[0-9]+" || true)
+  if [ -n "$readme_floor" ] && [ "${engines_floor%.*}" != "$readme_floor" ]; then
+    echo "Warning: generated marketplace README shows Node.js ${readme_floor}, package.json engines floor is ${engines_floor}"
+  fi
+fi
+```
 
 ### Step 5: Verify Package Size
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/release` pre-flight hardens doc-freshness gates** — adds a marketplace-artifact regeneration step (`npm run prepare:marketplace` before pack/publish, with a warn-only Node-floor-vs-`engines` diff) and a `README.md` "What's new" freshness check that warns when the version being released is absent. Closes the two doc surfaces that shipped stale in v2.4.0 (the bundled marketplace README and the root README "What's new" section). (#684)
+
 ## [2.4.0] - 2026-05-30
 
 ### Changed


### PR DESCRIPTION
## Summary

Hardens the `/release` skill pre-flight so the two doc surfaces that shipped stale in v2.4.0 can't ship again:

- **Step 4.7 (new):** Regenerate the marketplace artifact (`npm run prepare:marketplace`) before pack/publish. The artifact under `dist/marketplace/` is bundled into the tgz via `files:["dist", ...]` even though `dist/` is gitignored — so regenerating it from source before Step 5/9 guarantees the bundled README matches current sources. Includes a warn-only freshness check comparing the generated README's Node.js floor against `package.json` `engines.node`.
- **Documentation Checks (extended):** Warn (non-blocking, mirroring the existing `what-weve-built.md` version-stamp check) when `README.md` "What's new" omits the version being released.

Root cause of the v2.4.0 misses: the `sequant-2.4.0.tgz` carried a "Node.js 20+" marketplace README after the floor moved to 22.12 (#677), and the root README "What's new" was never refreshed for 2.4.0.

## Pre-PR AC Verification

| AC | Source | Description | Status | Evidence |
|----|--------|-------------|--------|----------|
| AC-1 | Original | Pre-flight regenerates/validates marketplace README before publish | ✅ Implemented | New **Step 4.7** in `SKILL.md`, before Step 5 (pack) / Step 9 (publish) |
| AC-2 | Original | Warn when `README.md` "What's new" omits the release version | ✅ Implemented | Check #12 in Documentation Checks block |
| AC-3 | Original | Mirror SKILL.md change to other skill copies | 🔄 N/A | `find . -name SKILL.md -path '*release*'` → only `.claude/skills/release/`; no `templates/skills/` or `skills/` copy exists |

## Test plan

All snippets were run live (this is a run-the-snippet deliverable — no code paths added):

- [x] AC-2 pass path: README contains `New in 2.4.0` → no warning
- [x] AC-2 warn path: simulated missing `9.9.9` → warning fires
- [x] AC-1 regeneration: `npm run prepare:marketplace` succeeds; generated README Node line `Node.js 22.12+` matches engines `>=22.12.0` → no warning
- [x] AC-1 warn path: simulated stale `Node.js 20.0` README → warning fires
- [x] `npm run lint` (eslint src/ bin/) — clean
- [x] `npm run lint:skill-calls` — no violations

Build/test phases skipped: no TypeScript or runtime code changed (markdown + bash snippets in one SKILL.md).

Closes #684