### PR TITLE
chore(#687): relocate /release what-weve-built version-stamp check post-bump

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -100,26 +100,11 @@ gh auth status || { echo "Not logged in - run: gh auth login"; exit 1; }
 
 ### Documentation Checks
 
-```bash
-# 11. Check docs/internal/what-weve-built.md is up to date
-if [ -f "docs/internal/what-weve-built.md" ]; then
-  current=$(node -p "require('./package.json').version")
-
-  # Check title version
-  title_version=$(grep -oE "Sequant v[0-9]+\.[0-9]+\.[0-9]+" docs/internal/what-weve-built.md | head -1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" || true)
-  if [ "$title_version" != "$current" ]; then
-    echo "Warning: docs/internal/what-weve-built.md title shows v${title_version}, expected v${current}"
-  fi
-
-  # Check ASCII art version
-  ascii_version=$(grep -E "SEQUANT v[0-9]+\.[0-9]+\.[0-9]+" docs/internal/what-weve-built.md | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" || true)
-  if [ "$ascii_version" != "$current" ]; then
-    echo "Warning: docs/internal/what-weve-built.md ASCII art shows v${ascii_version}, expected v${current}"
-  fi
-fi
-```
-
-> **Note:** The README "What's new" freshness check lives in **Step 4.65** (after the version bump), not here — it must compare against the *new* version, which doesn't exist in `package.json` until Step 4 runs.
+> **Note:** Documentation freshness checks that compare against the version *being released* run **after** Step 4 (the version bump), not here in pre-flight:
+> - `docs/internal/what-weve-built.md` title + ASCII version stamps → **Step 4.63**
+> - README "What's new" section → **Step 4.65**
+>
+> They must compare against the *new* version, which doesn't exist in `package.json` until Step 4 runs. Running them in pre-flight would compare against the *previous* release — which the docs already reflect — so the gate would never fire for the release in progress (root cause class of #684 / #687).
 
 ## Release Steps
 
@@ -321,6 +306,31 @@ fi
 ```
 
 **Ask the user to review what-weve-built.md before proceeding** if there are new features to document.
+
+### Step 4.63: Verify what-weve-built.md Version Stamps
+
+**IMPORTANT:** This runs **after** Step 4 (version bump) and Step 4.6 (which updates the stamps), so `package.json` already holds the *new* version. Running it earlier (in pre-flight) would compare against the previous release — which the file already reflects — so the gate would never fire for the version actually being released (root cause class of #684 / #687, the same ordering bug fixed for the README check in #685).
+
+Warn-only (like the README "What's new" check): prompt the releaser if the title or ASCII-art version stamp omits/mismatches the version being released.
+
+```bash
+# Warn if docs/internal/what-weve-built.md version stamps don't match the version being released
+if [ -f "docs/internal/what-weve-built.md" ]; then
+  new_version=$(node -p "require('./package.json').version")
+
+  # Check title version
+  title_version=$(grep -oE "Sequant v[0-9]+\.[0-9]+\.[0-9]+" docs/internal/what-weve-built.md | head -1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" || true)
+  if [ "$title_version" != "$new_version" ]; then
+    echo "Warning: docs/internal/what-weve-built.md title shows v${title_version}, expected v${new_version}"
+  fi
+
+  # Check ASCII art version
+  ascii_version=$(grep -E "SEQUANT v[0-9]+\.[0-9]+\.[0-9]+" docs/internal/what-weve-built.md | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" || true)
+  if [ "$ascii_version" != "$new_version" ]; then
+    echo "Warning: docs/internal/what-weve-built.md ASCII art shows v${ascii_version}, expected v${new_version}"
+  fi
+fi
+```
 
 ### Step 4.65: Verify README "What's new" Freshness
 


### PR DESCRIPTION
## Summary

- Pre-flight **Check #11** read `package.json` *before* the Step 4 version bump, so it compared `docs/internal/what-weve-built.md` stamps against the **previous** release — a no-op for the version actually being released (same ordering bug fixed for the README check in #685).
- Relocated the title + ASCII version-stamp comparison to a new post-bump **Step 4.63** (just after Step 4.6, which updates the stamps), comparing against `new_version`.
- Left a pointer note at the former pre-flight location. Warn-only semantics unchanged. Single skill copy — no mirror sync.

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Stamp checks run **after** Step 4 bump, compare against new version | ✅ Implemented | New Step 4.63 reads `new_version` from `package.json` post-bump |
| AC-2 | Warns when stamps omit/mismatch the version being released | ✅ Verified | Simulated stale stamp (release 2.5.0 vs stamp 2.4.0) → 2 warnings; matching → none |
| AC-3 | Pointer note left at former pre-flight location | ✅ Implemented | Documentation Checks block now points to Step 4.63 / Step 4.65 |
| AC-4 | Single skill copy — no mirror sync | ✅ Verified | Only `.claude/skills/release/SKILL.md` exists; no `templates/skills` or `skills/` copy |

## Test plan

- [x] `npm run lint:skill-calls` → No violations
- [x] Simulated check against real `what-weve-built.md`: matching version → no warnings; stale stamp → warns on both title and ASCII art
- [ ] Reviewer: confirm Step 4.63 ordering reads correctly relative to Step 4.6 / 4.65

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)