### PR TITLE
fix(cli-ui): single-issue live frame renders boxless indented labels

### DIFF
--- a/src/lib/cli-ui/run-renderer-624.test.ts
+++ b/src/lib/cli-ui/run-renderer-624.test.ts
@@ -1050,8 +1050,12 @@ describe("Derived AC-D3: box-char assertions use the Box Drawing codepoint range
     // block). Codepoint-range matching is platform-agnostic (Linux/macOS/
     // Windows all encode these chars identically), so the Windows-safety
     // requirement is satisfied without needing a Windows CI runner.
+    // Use a multi-issue frame: single-issue switched to a boxless indented
+    // layout (#647/#655), but the multi-issue grid still draws box chars, which
+    // is what this Windows-safe detection regex needs to exercise.
     const { r } = makeTTY({ columns: 100 });
     r.registerIssue({ issueNumber: 614 });
+    r.registerIssue({ issueNumber: 615 });
     r.onEvent({ issue: 614, phase: "exec", event: "start" });
     const frame = r.renderLiveFrame(100);
     expect(/[─-╿]/u.test(frame)).toBe(true);

--- a/src/lib/cli-ui/run-renderer.test.ts
+++ b/src/lib/cli-ui/run-renderer.test.ts
@@ -447,7 +447,7 @@ describe("TTYRenderer", () => {
     expect(completionLines).toHaveLength(3);
   });
 
-  it("AC-11: single-issue frame uses key:value layout with Issue/Worktree/Branch/Status", () => {
+  it("AC-11: single-issue frame uses indented key:value layout with Issue/Worktree/Branch/Status", () => {
     const { r } = makeTTY({ columns: 100 });
     r.registerIssue({
       issueNumber: 614,
@@ -461,9 +461,10 @@ describe("TTYRenderer", () => {
     expect(frame).toContain("Worktree");
     expect(frame).toContain("Branch");
     expect(frame).toContain("Status");
-    // Box drawing present.
-    expect(frame).toContain("┌");
-    expect(frame).toContain("└");
+    // Indented labels, no box drawing (the grid stranded in scrollback —
+    // #647/#655).
+    expect(frame).not.toContain("┌");
+    expect(frame).not.toContain("│");
     r.dispose();
   });
 
@@ -563,9 +564,9 @@ describe("TTYRenderer", () => {
     for (const cols of [60, 80, 120]) {
       const frame = stripAnsi(r.renderLiveFrame(cols));
       expect(frame.length).toBeGreaterThan(0);
-      // 80+ col uses box drawing; 60 col does not.
-      if (cols >= 80) expect(frame).toContain("┌");
-      else expect(frame).not.toContain("┌");
+      // Single-issue is boxless at every width now (indented labels).
+      expect(frame).not.toContain("┌");
+      expect(frame).toContain("#614");
     }
     r.dispose();
   });

--- a/src/lib/cli-ui/run-renderer.ts
+++ b/src/lib/cli-ui/run-renderer.ts
@@ -1055,22 +1055,26 @@ export class TTYRenderer extends BaseRenderer {
   }
 
   private renderSingleIssueFrame(cols: number): string {
-    // AC-11: Single-issue runs use a key:value full-grid table.
+    // AC-11: single-issue runs render as indented `label  value` lines — not a
+    // box-drawing grid.
+    //
+    // The grid was the dominant source of `log-update` `eraseLines` stranding
+    // (#647 / #655): a multi-line bordered frame whose top survives in
+    // scrollback when the erase undershoots, leaving a frozen first paint (the
+    // classic "0s elapsed" ghost with no bottom border). Indented labels keep
+    // the same information at a shorter, border-free height that clears
+    // cleanly, and match the repo's move away from box-drawing in human output
+    // (see feedback_llm_hostile_formatting). Multi-issue still uses the grid.
     const state = [...this.issues.values()][0];
     const c = colorize(this.noColor);
     const header = `SEQUANT WORKFLOW · #${state.issueNumber} · ${formatElapsedTime((this.now() - this.runStartedAt) / 1000)} elapsed`;
 
-    // #647 AC-3: cap at 78 (not 110) so the rendered grid stays narrower than
-    // any standard 80-col terminal even when the reported `cols` is wider than
-    // the actual terminal (e.g. cached `process.stdout.columns`, TTY emulation
-    // layers, `npx` piped stdout). Total drawn width is
-    // `labelWidth + valueWidth + 9` (2 leading spaces + 3 box-drawing
-    // intersection chars + 4 cell-padding spaces); the prior `- 7` formula
-    // additionally produced rows 2 chars wider than `cols`, compounding the
-    // wrap. Both errors removed.
-    const labelWidth = 10;
-    const innerWidth = Math.max(40, Math.min(cols, 78) - labelWidth - 9);
-    const valueWidth = innerWidth;
+    // Label column fits the widest label ("Worktree"); value column is the
+    // remaining width after the 2-space indent + 2-space gap. Capped the same
+    // way the grid was so wide / misreported terminals can't push values past a
+    // standard 80-col reader.
+    const labelWidth = 8;
+    const valueWidth = Math.max(40, Math.min(cols, 100) - labelWidth - 4);
 
     const rows: Array<[string, string[]]> = [];
     const titleSuffix = state.title ? ` — ${state.title}` : "";
@@ -1088,7 +1092,7 @@ export class TTYRenderer extends BaseRenderer {
 
     const lines: string[] = [c.bold(header), ""];
     if (this.banner) lines.push(c.yellow(this.banner), "");
-    lines.push(this.drawKeyValueTable(rows, labelWidth, valueWidth));
+    lines.push(this.drawKeyValueLines(rows, labelWidth));
     return lines.join("\n");
   }
 
@@ -1352,37 +1356,25 @@ export class TTYRenderer extends BaseRenderer {
 
   // ---------------- Box drawing ----------------
 
-  private drawKeyValueTable(
+  /**
+   * Single-issue layout: indented `label  value` lines, no box drawing. The
+   * label is cyan and padded to `labelW`; continuation lines (multi-line
+   * status cells) align under the value column with a blank label. See
+   * `renderSingleIssueFrame` for why the bordered grid was dropped.
+   */
+  private drawKeyValueLines(
     rows: Array<[string, string[]]>,
     labelW: number,
-    valueW: number,
   ): string {
     const c = colorize(this.noColor);
-    const dim = c.dim;
-    const total = labelW + valueW + 3;
-    const top = dim(
-      "  ┌" + "─".repeat(labelW + 2) + "┬" + "─".repeat(valueW + 2) + "┐",
-    );
-    const sep = dim(
-      "  ├" + "─".repeat(labelW + 2) + "┼" + "─".repeat(valueW + 2) + "┤",
-    );
-    const bottom = dim(
-      "  └" + "─".repeat(labelW + 2) + "┴" + "─".repeat(valueW + 2) + "┘",
-    );
-    const out: string[] = [top];
-    rows.forEach(([label, lines], i) => {
+    const out: string[] = [];
+    for (const [label, lines] of rows) {
       const labelPadded = padEndVisible(label, labelW);
       lines.forEach((line, idx) => {
         const labelCell = idx === 0 ? c.cyan(labelPadded) : " ".repeat(labelW);
-        const valuePadded = padEndVisible(line, valueW);
-        out.push(
-          `  ${dim("│")} ${labelCell} ${dim("│")} ${valuePadded} ${dim("│")}`,
-        );
+        out.push(`  ${labelCell}  ${line}`);
       });
-      if (i < rows.length - 1) out.push(sep);
-    });
-    out.push(bottom);
-    void total;
+    }
     return out.join("\n");
   }
 


### PR DESCRIPTION
## Problem

The single-issue `sequant run` live frame used a `┌┬┐` key/value grid. That bordered, multi-line frame is the dominant source of `log-update` `eraseLines` stranding (#647 / #655): when the erase undershoots, the frame **top** survives in scrollback as a frozen first paint — the classic `0s elapsed` ghost with **no bottom border**.

Observed in a real run:

```
SEQUANT WORKFLOW · #687 · 0s elapsed

  ┌────────────┬─────────────────────────────────────┐
  │ Issue      │ #687                                │
  ├────────────┼─────────────────────────────────────┤
  │ Status     │ · queued                            │
  │            │ exec –  →  qa –                     │
  ✔ #687 exec  3m 6s          ← event lines bleed in, box never closes
  ✘ #687 qa  QA completed without a parseable verdict
```

The elapsed *logic* was always correct — you were seeing a stranded first paint, not a dead timer.

## Change

Replace the single-issue grid with indented `label  value` lines (Issue / Worktree / Branch / Status). Shorter, border-free height clears cleanly and dodges the stranding. Aligns with the repo's move away from box-drawing in human-facing output.

```
SEQUANT WORKFLOW · #687 · 3m 6s elapsed

  Issue     #687 — relocate version-stamp check
  Worktree  ../worktrees/feature/687-relocate-version-stamp-check
  Branch    feature/687-relocate-version-stamp-check
  Status    ⠋ qa · 0s
            exec ✔ 3m 6s  →  qa running
```

- `renderSingleIssueFrame`: indented layout, no box; drop the 78-col grid cap.
- `drawKeyValueTable` → `drawKeyValueLines` (cyan label + value, aligned continuation lines for multi-line status cells).
- **Multi-issue runs keep the grid** (`renderMultiIssueFrame`) — same stranding could recur there; out of scope here.

## Tests

- AC-11 / AC-32 now assert **no** box chars for single-issue.
- The Windows-safe box-char detection meta-test repointed to a multi-issue frame (which still draws box chars).
- All `src/lib/cli-ui/` tests pass (121 + 1 expected-fail); `tsc --noEmit` clean.

## Out of scope

- `QA completed without a parseable verdict` is a separate functional bug (verdict parser not matching qa output).