### PR TITLE
docs: list `sequant ready` in cheat-sheet + link orphaned command-reference pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,10 @@ From GitHub issue to merge-ready PR — verified at every step.
 
 - [Cheat Sheet](reference/cheat-sheet.md) — Quick reference for all commands, flags, and workflows
 - [Run Command](reference/run-command.md) — Batch execution and CLI options
+- [Ready Command](reference/ready-command.md) — Post-resolve A+ QA gate (`sequant ready`)
+- [Merge Command](reference/merge-command.md) — Post-QA integration and merge
 - [State Command](reference/state-command.md) — Workflow state management
+- [Conventions Command](reference/conventions-command.md) — Codebase convention detection and overrides
 - [Analytics](reference/analytics.md) — Usage tracking and metrics
 - [Logging](reference/logging.md) — Log configuration
 - [Telemetry](reference/telemetry.md) — Telemetry settings

--- a/docs/reference/cheat-sheet.md
+++ b/docs/reference/cheat-sheet.md
@@ -99,6 +99,7 @@ sequant doctor              # Verify installation health
 | `sequant doctor` | Check installation health and prerequisites |
 | `sequant status [issue]` | Show version, config, workflow state |
 | `sequant run <issues...>` | Execute workflow headlessly |
+| `sequant ready <issue>` | Post-resolve A+ QA gate (drives to merge-readiness, never merges) |
 | `sequant state [init\|rebuild\|clean]` | Manage workflow state |
 | `sequant stats` | View local workflow analytics |
 | `sequant dashboard` | Launch real-time workflow dashboard |


### PR DESCRIPTION
## Summary

Pre-release doc sync for the new `sequant ready <issue>` command (#683/#686). The substantive docs (README, CHANGELOG `[Unreleased]`, dedicated `docs/reference/ready-command.md`) were already current — these are the two remaining index/listing gaps.

## Changes

- **Cheat-sheet** — add `sequant ready <issue>` to the core-commands table (was omitted).
- **docs/README.md reference index** — link `ready-command.md` (new in #683), which was orphaned (no inbound links). While there, fixed two pre-existing orphans in the same index: `conventions-command.md` and `merge-command.md`.

## Verification

`grep` orphan check confirms all three command-reference pages are now reachable from `docs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)