### PR TITLE
feat(#705): fix -q/-Q flag collision, make boxed Ink TUI the default for run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI UX: `-q`/`-Q` flag collision fixed; boxed Ink TUI is now the default for `run` (#705)** — Commander short flags are case-sensitive, so `sequant run … -q` (meaning to enable the quality loop) silently enabled **quiet mode** instead, suppressing the live renderer. Now: **`--quiet` moves to `-s`** (mnemonic: silent) and `-q` becomes a hidden alias for `-Q, --quality-loop` (both enable the quality loop; neither enables quiet). The **boxed Ink TUI is the default** on a TTY for `sequant run` — `tuiEnabled = options.tui !== false && isTTY && !quiet` — matching `sequant ready`. Opt out with **`--no-tui`** (falls back to the line-based phase-matrix renderer); non-TTY / piped output auto-degrades safely. **`--experimental-tui`** is kept as a hidden no-op alias so existing scripts keep parsing. `--quiet`/`-s` continues to suppress the renderer entirely (heartbeat-only). Flag normalization (`run-flags.ts`) is unit-tested and the CLI help surface is integration-tested. Docs updated: README TUI-default framing and `docs/features/quiet-mode-heartbeat.md` (`-q`→`-s` throughout). (#705)
+
 ## [2.5.0] - 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See the [CHANGELOG](CHANGELOG.md) for release notes, or the [migration guide](CH
 ### What's new in 2.5
 
 - **`sequant ready <issue>`** — a post-resolve A+ QA gate that drives a resolved issue through a full-weight `qa → loop → qa` pass and **stops at the human merge gate — it never merges**.
-- **Live phase-matrix TUI** — `sequant ready` and `sequant run` render the active phase and quality-loop iteration in place (boxed Ink dashboard on a TTY), so a long run is never indistinguishable from a hang.
+- **Live phase-matrix TUI** — `sequant ready` and `sequant run` render the active phase and quality-loop iteration in place (boxed Ink dashboard on a TTY by default), so a long run is never indistinguishable from a hang. Opt out with `--no-tui` (line renderer) or `-s`/`--quiet` (heartbeat-only); non-TTY output auto-degrades.
 - **Per-issue concurrency locks** — a second session on the same issue is skipped with a clear message instead of clobbering the first; `sequant locks` inspects and clears them.
 
 ## Quick Start

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -5,7 +5,7 @@
  * Sequential AI phases with quality gates for any codebase.
  */
 
-import { Command, InvalidArgumentError } from "commander";
+import { Command, InvalidArgumentError, Option } from "commander";
 import chalk from "chalk";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
@@ -236,6 +236,16 @@ program
   .option("--no-log", "Disable JSON logging for this run")
   .option("--log-path <path>", "Custom log directory path")
   .option("-Q, --quality-loop", "Enable quality loop with auto-retry")
+  // #705: `-q` is a hidden alias for the quality loop (Commander 14 allows only
+  // one short flag per Option, so it can't live on --quality-loop directly).
+  // `runCommand` ORs `qualityLoopAlias` into `qualityLoop`. `-q` no longer maps
+  // to --quiet, which moved to `-s` to end the `-q`/`-Q` collision.
+  .addOption(
+    new Option(
+      "-q, --quality-loop-alias",
+      "Alias for -Q/--quality-loop",
+    ).hideHelp(),
+  )
   .option(
     "--max-iterations <n>",
     "Max iterations for quality loop (default: 3)",
@@ -251,7 +261,10 @@ program
   .option("--no-smart-tests", "Disable smart test detection")
   .option("--testgen", "Run testgen phase after spec")
   .option("--security-review", "Run security-review phase after spec")
-  .option("-q, --quiet", "Suppress version warnings and non-essential output")
+  .option(
+    "-s, --quiet",
+    "Suppress version warnings and non-essential output (heartbeat-only)",
+  )
   .option(
     "--chain",
     "Chain issues: each branches from previous (implies --sequential)",
@@ -307,10 +320,15 @@ program
     "--agent <name>",
     'Agent driver for phase execution (default: "claude-code")',
   )
+  // #705: the boxed Ink TUI is now the default on a TTY. `--no-tui` opts out to
+  // the line-based phase-matrix renderer; non-TTY / piped output auto-degrades.
   .option(
-    "--experimental-tui",
-    "Render live multi-issue dashboard (requires TTY; falls back to linear output when piped)",
+    "--no-tui",
+    "Disable the boxed Ink dashboard; use the line-based phase-matrix renderer",
   )
+  // #705: `--experimental-tui` is now a hidden no-op alias (the TUI is the
+  // default) so existing scripts and muscle-memory keep parsing.
+  .addOption(new Option("--experimental-tui").hideHelp())
   .option(
     "--no-relay",
     "Disable interactive relay (#383); `sequant prompt` cannot reach this run",

--- a/docs/features/experimental-tui-dashboard.md
+++ b/docs/features/experimental-tui-dashboard.md
@@ -1,6 +1,8 @@
 # Live Multi-Issue TUI Dashboard
 
-A live, in-terminal dashboard that renders one box per issue while `sequant run` works through them concurrently. Use it when running multiple issues in parallel and you want to see at a glance which issue is in which phase, what each one is doing right now, and whether anything has stalled. Ships behind `--experimental-tui`; existing linear output is unchanged when the flag is omitted.
+A live, in-terminal dashboard that renders one box per issue while `sequant run` works through them concurrently. Use it when running multiple issues in parallel and you want to see at a glance which issue is in which phase, what each one is doing right now, and whether anything has stalled.
+
+> **Now the default (#705).** This boxed Ink dashboard is the default for `sequant run` on a TTY — no flag needed. Pass **`--no-tui`** to fall back to the [line phase-matrix renderer](run-renderer.md), or **`-s`/`--quiet`** to suppress both in favor of the liveness heartbeat. Non-TTY output (pipe, redirect, CI) auto-degrades to the line renderer. `--experimental-tui` is retained as a hidden no-op alias so existing scripts keep working.
 
 ## Prerequisites
 
@@ -10,20 +12,17 @@ A live, in-terminal dashboard that renders one box per issue while `sequant run`
 
 ## Setup
 
-No installation step beyond sequant itself. The TUI renderer (ink) ships in the package; nothing extra to enable.
+No installation step beyond sequant itself. The TUI renderer (ink) ships in the package, and it is the default on a TTY — nothing to enable.
 
 ```bash
-# Single issue
-npx sequant run 47 --experimental-tui
+# Single issue — boxed TUI by default on a TTY
+npx sequant run 47
 
-# Several issues, parallel
-npx sequant run 46 47 8 34 --experimental-tui
-```
+# Several issues, parallel — boxed TUI by default
+npx sequant run 46 47 8 34
 
-If you want to make it the default for your shell, alias it:
-
-```bash
-alias srun='npx sequant run --experimental-tui'
+# Opt out to the line phase-matrix renderer
+npx sequant run 46 47 8 34 --no-tui
 ```
 
 ## What You Can Do
@@ -32,7 +31,7 @@ alias srun='npx sequant run --experimental-tui'
 - **Spot stalls.** A "last activity" stamp ticks under the live `now` line — if it climbs into minutes while a phase shows the spinner, the phase is stuck.
 - **Find the right log fast.** Each box prints its `tail -f` path so you can pop a second terminal and stream the underlying log without leaving the dashboard.
 - **Ctrl+C cleanly.** The TUI unmounts and hands off to `ShutdownManager`; no terminal corruption, no orphaned spinners.
-- **Combine with `--quiet`.** `--quiet` is orthogonal: pass both, and the TUI still renders while the per-phase progress lines that `--quiet` suppresses stay suppressed in the fallback path.
+- **Suppress with `--quiet`/`-s`.** Since #705, `--quiet` (now `-s`) wins over the TUI default: the dashboard is suppressed and the liveness heartbeat becomes the only signal. Use `--no-tui` instead if you want the line renderer rather than heartbeat-only output.
 
 ## What to Expect
 
@@ -61,22 +60,24 @@ Borders rotate cyan → magenta → blue → yellow by start order. On terminal 
 
 **When the dashboard does NOT render.** If stdout is not a TTY (CI, redirect, pipe), the orchestrator silently falls back to the existing linear stream — no error, no warning.
 
-**Bundle / startup cost.** Ink and React ship with sequant; cold start is unaffected by passing the flag (modules load lazily when the flag is set).
+**Bundle / startup cost.** Ink and React ship with sequant; cold start is unaffected (the modules load lazily only when the TUI actually mounts — i.e. on a TTY without `--no-tui`/`-s`).
 
 ## Reference
 
 | Flag | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `--experimental-tui` | boolean | no | off | Render the live multi-issue dashboard instead of linear progress lines. Auto-falls back to linear output when stdout is not a TTY. |
+| `--no-tui` | boolean | no | TUI on | Opt out of the boxed dashboard and use the line phase-matrix renderer instead. |
+| `--experimental-tui` | boolean | no | (no-op) | Hidden no-op alias retained for backward compatibility (#705) — the TUI is now the default, so this flag does nothing. |
 
 Interaction with other flags:
 
 | Combined with | Behavior |
 |---------------|----------|
-| `--quiet` (`-q`) | Both apply. TUI renders; non-TUI fallback stays quiet (no liveness heartbeat lines, since the dashboard is the liveness signal). |
+| `--quiet` (`-s`) | `--quiet` wins: the TUI is suppressed and the liveness heartbeat is the only signal (#705). |
+| `--no-tui` | TUI does not mount; the line phase-matrix renderer is used instead. |
 | `--phases ...` | Phase set drives the phase progression row inside each box. |
 | `--testgen` / `--security-review` | Inserted phases appear in the progression row like any other. |
-| Output piped (`| tee`, `>file`) | TUI does not mount; linear output is used. |
+| Output piped (`| tee`, `>file`) | TUI does not mount; line renderer is used. |
 | `NO_COLOR=1` | Borders and status colors drop; box structure is preserved. |
 
 ## Troubleshooting
@@ -96,7 +97,7 @@ node -e "console.log(process.stdout.isTTY)"
 
 **Cause:** Terminal is not reporting display widths correctly for wide glyphs (CJK, some emoji). The TUI uses `string-width` for truncation, so this is unusual but possible in older terminals.
 
-**Fix:** Update to a recent terminal (iTerm2, Ghostty, modern xterm, Windows Terminal). If you cannot, drop the flag — linear output works in any terminal.
+**Fix:** Update to a recent terminal (iTerm2, Ghostty, modern xterm, Windows Terminal). If you cannot, pass `--no-tui` — linear output works in any terminal.
 
 ### Boxes overflow off-screen with many issues
 

--- a/docs/features/quiet-mode-heartbeat.md
+++ b/docs/features/quiet-mode-heartbeat.md
@@ -1,38 +1,42 @@
-# `-q` Mode Liveness Heartbeat & Stall Warning
+# Quiet (`-s`) Mode Liveness Heartbeat & Stall Warning
 
-`sequant run -q` used to go silent for the entire duration of each phase — sometimes 15+ minutes — with no way to tell "agent working" from "process hung" short of digging through `ps`, `lsof`, and `state.json`. The heartbeat fixes that with two thin signals: a TTY-only liveness line that ticks during long phases, and a one-shot warning (TTY and non-TTY) when an in-progress phase shows no activity for 5 minutes.
+> **Flag change (#705):** quiet mode is now `-s, --quiet`. `-q` is no longer
+> quiet — it is a hidden alias for `-Q, --quality-loop`. Update any scripts that
+> used `-q` for quiet to `-s`.
+
+`sequant run -s` used to go silent for the entire duration of each phase — sometimes 15+ minutes — with no way to tell "agent working" from "process hung" short of digging through `ps`, `lsof`, and `state.json`. The heartbeat fixes that with two thin signals: a TTY-only liveness line that ticks during long phases, and a one-shot warning (TTY and non-TTY) when an in-progress phase shows no activity for 5 minutes.
 
 ## Prerequisites
 
 1. **`sequant run` available** — `npx sequant run --help`
-2. **Run with `-q` (or `--quiet`)** — the heartbeat is gated to `-q`. Default verbose mode already prints per-phase progress lines, so it does nothing.
+2. **Run with `-s` (or `--quiet`)** — the heartbeat is gated to quiet mode. Quiet suppresses the renderer (and the boxed Ink TUI), so the heartbeat is the sole liveness signal. Without `-s` the default boxed TUI (or the line renderer under `--no-tui` / non-TTY) handles liveness, so the heartbeat does nothing.
 3. **`.sequant/state.json` is being written** — this happens automatically during any run; the heartbeat reads its mtime as the activity proxy.
 
 ## Setup
 
-No setup. The heartbeat is on by default whenever `sequant run -q` runs without `--experimental-tui`. There is no flag to enable or configure it.
+No setup. The heartbeat is on by default whenever `sequant run -s` runs. There is no flag to enable or configure it. Because quiet always suppresses the boxed TUI, `--no-tui` / `--experimental-tui` have no effect on the heartbeat.
 
 ```bash
 # Heartbeat active (TTY: liveness line + stall warning; non-TTY: stall warning only)
-npx sequant run 551 559 -q
+npx sequant run 551 559 -s
 
-# Heartbeat NOT active (TUI handles its own liveness)
-npx sequant run 551 559 -q --experimental-tui
-
-# Heartbeat NOT active (verbose progress lines render every phase event)
+# Heartbeat NOT active — default boxed Ink TUI owns liveness on a TTY
 npx sequant run 551 559
+
+# Heartbeat NOT active — line phase-matrix renderer owns liveness
+npx sequant run 551 559 --no-tui
 ```
 
 ## What You Can Do
 
-- **Tell "working" from "hung" in a TTY.** A long phase under `-q` rewrites a single line every 30s with elapsed time and how recently `state.json` was last touched.
+- **Tell "working" from "hung" in a TTY.** A long phase under `-s` rewrites a single line every 30s with elapsed time and how recently `state.json` was last touched.
 - **Get a written warning when something stalls.** If `state.json` mtime hasn't advanced for 5 minutes during an in-progress phase, the heartbeat emits one warning to stderr — even when stdout is piped to a file or CI log.
 - **Keep CI logs clean.** Non-TTY runs (CI, redirected output) get the stall warning only — no scroll-spam from periodic heartbeats.
 - **Trust the no-news case.** No warning fired and the rewriting line keeps ticking? The phase is genuinely making progress.
 
 ## What to Expect
 
-**TTY, in `-q`, normal phase progress.** Every 30s the active phase line is rewritten in place using `\r`:
+**TTY, in `-s`, normal phase progress.** Every 30s the active phase line is rewritten in place using `\r`:
 
 ```
   ▸ #551  exec  (12m elapsed, last log update 8s ago)
@@ -60,10 +64,10 @@ The heartbeat is automatic, not flag-driven. Behavior is determined by the matri
 
 | Mode | TTY heartbeat line | Stall warning |
 |------|--------------------|---------------|
-| `-q` (TTY) | Yes — rewrites every 30s | Yes — once per stall window |
-| `-q` (non-TTY: pipe, redirect, CI) | No | Yes — once per stall window |
-| `-q --experimental-tui` | No (TUI owns liveness) | No (TUI surfaces its own activity) |
-| Default verbose (`sequant run` without `-q`) | No (per-phase progress lines exist) | No |
+| `-s` (TTY) | Yes — rewrites every 30s | Yes — once per stall window |
+| `-s` (non-TTY: pipe, redirect, CI) | No | Yes — once per stall window |
+| Default (`sequant run` without `-s`, TTY) | No (boxed Ink TUI owns liveness) | No (TUI surfaces its own activity) |
+| `--no-tui` or non-TTY (without `-s`) | No (line phase-matrix renderer owns liveness) | No |
 
 | Constant | Default | Source |
 |----------|---------|--------|
@@ -75,18 +79,18 @@ These are not user-configurable from the CLI. They live in `src/lib/workflow/hea
 
 ## Troubleshooting
 
-### `-q` run still feels silent — no rewriting line appears
+### `-s` run still feels silent — no rewriting line appears
 
-**Cause:** Either stdout is not a TTY (running under CI, redirected to a file, piped through another command), or the run is using `--experimental-tui`. Both intentionally suppress the rewriting line.
+**Cause:** stdout is not a TTY (running under CI, redirected to a file, piped through another command). The rewriting line is TTY-only by design; non-TTY runs get the stall warning only.
 
-**Fix:** Run in an interactive terminal without `--experimental-tui`. Verify TTY with:
+**Fix:** Run in an interactive terminal. Verify TTY with:
 
 ```bash
 node -e "console.log(process.stdout.isTTY)"
 # expect: true
 ```
 
-If you need a live signal under `--experimental-tui`, the dashboard's per-issue activity stamp is the equivalent.
+If you dropped `-s` to get a live signal, the default boxed Ink TUI's per-issue activity stamp is the equivalent on a TTY.
 
 ### Heartbeat line keeps ticking but I'm sure the phase is hung
 
@@ -110,7 +114,7 @@ If you need a live signal under `--experimental-tui`, the dashboard's per-issue 
 
 **Cause:** Heartbeat noise in scripted scenarios where even the stall warning is unwanted.
 
-**Fix:** No CLI flag exists today. Either use `--experimental-tui` (suppresses the heartbeat in favor of the dashboard) or drop `-q` (verbose mode also suppresses it). Filing a flag-level opt-out is reasonable if your use case can't use either.
+**Fix:** No CLI flag exists today. Drop `-s` — the default boxed Ink TUI (or the `--no-tui` line renderer) suppresses the heartbeat in favor of its own liveness display. Filing a flag-level opt-out is reasonable if your use case can't use either.
 
 ---
 

--- a/docs/features/run-renderer.md
+++ b/docs/features/run-renderer.md
@@ -1,10 +1,10 @@
 # Run Renderer
 
-The default terminal output for `sequant run`: a live, redrawing grid on top showing per-issue state as an in-place **phase matrix**, with a compact completion log below. Use it to track concurrent issues at a glance, see which phase each is in, and pick out failures from a long run.
+The line-based terminal output for `sequant run`: a live, redrawing grid on top showing per-issue state as an in-place **phase matrix**, with a compact completion log below. Use it to track concurrent issues at a glance, see which phase each is in, and pick out failures from a long run.
 
-This is the default — nothing to enable. It replaces the older spinner + parallel-mode line output that produced duplicate and overwritten lines.
+Since #705 the boxed Ink TUI is the default on a TTY; this line renderer is what you get when you pass **`--no-tui`**, or automatically when stdout is **not a TTY** (pipe, redirect, CI). It replaces the older spinner + parallel-mode line output that produced duplicate and overwritten lines.
 
-> Looking for the experimental Ink-based dashboard with one box per issue? See [Experimental TUI Dashboard](experimental-tui-dashboard.md). The Ink TUI is opt-in via `--experimental-tui`; the renderer described here is the default.
+> Looking for the boxed Ink-based dashboard with one box per issue? See [TUI Dashboard](experimental-tui-dashboard.md). That Ink TUI is now the default on a TTY (#705); the line renderer described here is the `--no-tui` / non-TTY fallback. `--quiet`/`-s` suppresses both in favor of the liveness heartbeat.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ No setup. The renderer is wired into `sequant run` and selects a mode based on t
 
 | Environment | Mode | What you see |
 |---|---|---|
-| Interactive terminal (`process.stdout.isTTY`) | **TTY renderer** | Live grid (redrawn ~1Hz) + events log |
+| Interactive terminal (`process.stdout.isTTY`) with `--no-tui` | **TTY renderer** | Live grid (redrawn ~1Hz) + events log |
 | Pipe, redirect, CI (`!process.stdout.isTTY`) | **Non-TTY renderer** | Append-only timestamped events, 60s heartbeat |
 | MCP orchestrator (`SEQUANT_ORCHESTRATOR=1`) | **Orchestrator renderer** | Silent. Only `emitProgressLine` JSON flows. |
 
@@ -113,7 +113,7 @@ Passed rows are one-line; failed rows expand with reason, last-verdict summary, 
 
 - **Frame cadence.** The live zone redraws on phase events and at most once per second on a timer between events. Elapsed counters keep ticking even when nothing is happening, so the screen is always alive. Because the start line no longer appends to scrollback (#672), each phase transition costs one fewer `logUpdateClear`/redraw cycle — fewer redraws also means a smaller blast radius for terminal-emulator paint corruption (ties to #647/#655).
 - **Verbose streaming.** Running with `-v` / `--verbose` pauses the live zone while Claude's stream prints, then redraws below it on the next phase event. No interleaved garble.
-- **Quiet mode (`-q`).** Renderer is disabled in quiet mode (gated at `run-progress.ts:60` on `!quiet`); the liveness heartbeat replaces it — a TTY-only rewriting line every 30s plus a one-shot stall warning at 5 minutes. See [Quiet Mode Heartbeat](quiet-mode-heartbeat.md).
+- **Quiet mode (`-s`).** Renderer is disabled in quiet mode (gated at `run-progress.ts:60` on `!quiet`); the liveness heartbeat replaces it — a TTY-only rewriting line every 30s plus a one-shot stall warning at 5 minutes. (Since #705 quiet is `-s`, not `-q`.) See [Quiet Mode Heartbeat](quiet-mode-heartbeat.md).
 - **Retries get a counter.** When a quality loop retries `exec`, the second and later attempts annotate as `(attempt 2/3)`, `(attempt 3/3)` (added by #624). Since #672 dropped the `▸ start` line that used to carry this, the counter now surfaces on the live-zone status (`loop N/3`) and on the `✘ failed (attempt N/3)` completion line. QA loop iterations show `qa loop N/3` the same way.
 - **Identical failures get folded.** If `exec` fails three times with the same error, you see the full message on attempt 1 and on the final attempt. The middle attempt shows `(attempt 2/3, same failure as attempt 1)` instead of repeating the error verbatim. Divergent failures always print in full.
 - **Frame stability.** The live zone height is capped at `max(8, terminal-rows − 5)`. With more than ~10 active issues, the oldest done rows roll up to a single `✔ {n} done` line so the grid never spills past the visible terminal.
@@ -125,7 +125,7 @@ Passed rows are one-line; failed rows expand with reason, last-verdict summary, 
 
 | Env / context | Effect |
 |---|---|
-| `process.stdout.isTTY` truthy | TTY renderer (live grid + events log) |
+| `process.stdout.isTTY` truthy **+ `--no-tui`** | TTY renderer (live grid + events log). Without `--no-tui` the boxed Ink TUI mounts instead (#705). |
 | `process.stdout.isTTY` falsy | Non-TTY renderer (append-only + 60s heartbeat) |
 | `SEQUANT_ORCHESTRATOR=1` | Renderer is a no-op; only `emitProgressLine` JSON is emitted (MCP path) |
 | `NO_COLOR=1` | Colors stripped; layout preserved |
@@ -134,7 +134,7 @@ Passed rows are one-line; failed rows expand with reason, last-verdict summary, 
 | Terminal width `< 80` cols | Box-drawing replaced with indented key:value pairs |
 | Terminal rows visible | Live-zone height auto-capped to fit; excess done rows roll up |
 
-No CLI flags configure the renderer directly. Renderer behavior is driven by environment and the existing `run` flags (`-v`, `-q`, `--experimental-tui` to swap to Ink). See [Run Command](../reference/run-command.md) for run-level flags.
+This line renderer is selected by `--no-tui` (or automatically off a TTY); the boxed Ink TUI is otherwise the default (#705). Renderer behavior is further driven by environment and the existing `run` flags (`-v` verbose, `-s` quiet). See [Run Command](../reference/run-command.md) for run-level flags.
 
 ## Troubleshooting
 

--- a/docs/reference/run-command.md
+++ b/docs/reference/run-command.md
@@ -56,9 +56,10 @@ Shows what would be executed without actually running any phases. Useful for ver
 | `-d, --dry-run` | Preview without execution | `false` |
 | `-v, --verbose` | Show detailed output | `false` |
 | `--timeout <seconds>` | Timeout per phase | `1800` (30 min) |
-| `-Q, --quality-loop` | Enable auto-retry on failures | `false` |
+| `-Q, --quality-loop` | Enable auto-retry on failures (`-q` is a hidden alias — both enable it) | `false` |
 | `--max-iterations <n>` | Max iterations for quality loop | `3` |
-| `-q, --quiet` | Suppress version warnings and non-essential output | `false` |
+| `-s, --quiet` | Suppress version warnings and non-essential output (heartbeat-only liveness; `-q` no longer maps here — see #705) | `false` |
+| `--no-tui` | Disable the default boxed Ink dashboard; use the line phase-matrix renderer. Non-TTY output auto-degrades. (`--experimental-tui` is a hidden no-op alias.) | TUI on (TTY) |
 | `--testgen` | Run testgen phase after spec | `false` |
 | `--batch "<issues>"` | Group issues to run together | - |
 | `--no-mcp` | Disable MCP servers for faster/cheaper runs | `false` |

--- a/src/commands/cli.integration.test.ts
+++ b/src/commands/cli.integration.test.ts
@@ -138,10 +138,12 @@ describe.skipIf(!distExists)("CLI version (pre-built)", () => {
   });
 });
 
-// Issue #658: pin run command short-form bindings so a future option reordering
-// can't silently re-shadow them (Commander assigns -q to whichever option
-// declares it first).
-describe("run command short-form bindings (#658)", () => {
+// Issue #705: reverse the #658 binding. `-q` no longer maps to --quiet (it is
+// now a hidden alias for the quality loop); --quiet moved to `-s`. The boxed
+// Ink TUI is the default, with `--no-tui` to opt out and `--experimental-tui`
+// kept as a hidden no-op alias. These tests assert the help surface; the
+// alias-normalization and tuiEnabled behavior are unit-tested in run.test.ts.
+describe("run command flag surface (#705)", () => {
   const runHelp = (): string => {
     try {
       return execSync(`node ${cliPath} run --help`, execOptions);
@@ -159,14 +161,66 @@ describe("run command short-form bindings (#658)", () => {
     }
   };
 
-  it("-q binds to --quiet (UNIX convention)", () => {
+  it("--quiet is reachable via -s, not -q (AC-2)", () => {
     const output = runHelp();
-    expect(output).toMatch(/-q,\s*--quiet/);
-    expect(output).not.toMatch(/-q,\s*--quality-loop/);
+    expect(output).toMatch(/-s,\s*--quiet/);
+    expect(output).not.toMatch(/-q,\s*--quiet/);
   });
 
-  it("-Q binds to --quality-loop", () => {
+  it("-Q binds to --quality-loop (AC-1)", () => {
     const output = runHelp();
     expect(output).toMatch(/-Q,\s*--quality-loop/);
+  });
+
+  it("the -q quality-loop alias is hidden from help (AC-1)", () => {
+    const output = runHelp();
+    // Hidden alias Option must not surface in --help, but must still parse
+    // (covered by the parse test below).
+    expect(output).not.toMatch(/--quality-loop-alias/);
+  });
+
+  it("--no-tui is documented; --experimental-tui is hidden (AC-4, AC-5)", () => {
+    const output = runHelp();
+    expect(output).toMatch(/--no-tui/);
+    expect(output).not.toMatch(/--experimental-tui/);
+  });
+
+  // AC-1: `-q` and `-Q` both enable the quality loop and neither enables quiet.
+  // AC-5: `--experimental-tui` still parses without error. Use --dry-run so the
+  // CLI parses flags and exits without executing a real workflow.
+  const runDryRun = (flag: string): string => {
+    try {
+      return execSync(`node ${cliPath} run 1 ${flag} --dry-run`, execOptions);
+    } catch (error) {
+      const execError = error as {
+        status: number | null;
+        stdout: string;
+        stderr: string;
+      };
+      // A parse error exits non-zero with the message on stderr; surface it so
+      // the assertion fails with context rather than a generic throw.
+      throw new Error(
+        `CLI run 1 ${flag} --dry-run crashed with exit code ${execError.status}.\n` +
+          `stdout: ${execError.stdout}\n` +
+          `stderr: ${execError.stderr}`,
+      );
+    }
+  };
+
+  it("-q parses without error (hidden quality-loop alias) (AC-1)", () => {
+    // Must not throw — proves the hidden `-q` alias is accepted by Commander.
+    expect(() => runDryRun("-q")).not.toThrow();
+  });
+
+  it("-Q parses without error (AC-1)", () => {
+    expect(() => runDryRun("-Q")).not.toThrow();
+  });
+
+  it("--experimental-tui still parses as a hidden no-op alias (AC-5)", () => {
+    expect(() => runDryRun("--experimental-tui")).not.toThrow();
+  });
+
+  it("--no-tui parses without error (AC-4)", () => {
+    expect(() => runDryRun("--no-tui")).not.toThrow();
   });
 });

--- a/src/commands/run-flags.test.ts
+++ b/src/commands/run-flags.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for run flag resolvers (#705).
+ *
+ * Covers AC-1 (`-q`/`-Q` both enable the quality loop), AC-3 (boxed TUI default
+ * on a TTY), and AC-4 (`--no-tui` and non-TTY degrade to the line renderer).
+ */
+
+import { describe, it, expect } from "vitest";
+import { normalizeQualityLoop, resolveTuiEnabled } from "./run-flags.js";
+import type { RunOptions } from "../lib/workflow/types.js";
+
+describe("normalizeQualityLoop (#705 AC-1)", () => {
+  it("returns true when -Q/--quality-loop is set", () => {
+    expect(normalizeQualityLoop({ qualityLoop: true })).toBe(true);
+  });
+
+  it("returns true when the hidden -q alias is set", () => {
+    expect(normalizeQualityLoop({ qualityLoopAlias: true })).toBe(true);
+  });
+
+  it("returns true when both -q and -Q are set (identical behavior)", () => {
+    expect(
+      normalizeQualityLoop({ qualityLoop: true, qualityLoopAlias: true }),
+    ).toBe(true);
+  });
+
+  it("returns false when neither is set", () => {
+    expect(normalizeQualityLoop({})).toBe(false);
+  });
+
+  it("never reads quiet — quiet does not enable the quality loop", () => {
+    // Regression guard for the original -q/-Q collision: a quiet flag must not
+    // leak into the quality-loop decision.
+    expect(normalizeQualityLoop({ quiet: true } as RunOptions)).toBe(false);
+  });
+});
+
+describe("resolveTuiEnabled (#705 AC-3, AC-4, AC-2)", () => {
+  it("AC-3: defaults to true on a TTY (no flags)", () => {
+    expect(resolveTuiEnabled({}, true)).toBe(true);
+  });
+
+  it("AC-4: --no-tui (tui === false) opts out even on a TTY", () => {
+    expect(resolveTuiEnabled({ tui: false }, true)).toBe(false);
+  });
+
+  it("AC-4: non-TTY auto-degrades to the line renderer", () => {
+    expect(resolveTuiEnabled({}, false)).toBe(false);
+  });
+
+  it("AC-2: --quiet suppresses the TUI even on a TTY", () => {
+    expect(resolveTuiEnabled({ quiet: true }, true)).toBe(false);
+  });
+
+  it("AC-5: --experimental-tui is a no-op (does not gate rendering)", () => {
+    // The default already enables the TUI on a TTY; the alias must not be
+    // required, and its absence must not disable the default.
+    expect(resolveTuiEnabled({ experimentalTui: true }, true)).toBe(true);
+    expect(resolveTuiEnabled({ experimentalTui: undefined }, true)).toBe(true);
+  });
+
+  it("quiet beats the TUI default regardless of --no-tui (AC-2 precedence)", () => {
+    expect(resolveTuiEnabled({ quiet: true, tui: false }, true)).toBe(false);
+  });
+});

--- a/src/commands/run-flags.ts
+++ b/src/commands/run-flags.ts
@@ -1,0 +1,41 @@
+/**
+ * Run flag normalization (#705) — keeps run.ts thin (#503 AC-2: <200 LOC).
+ *
+ * Two pure resolvers for the `run` command's flag surface:
+ *   - `normalizeQualityLoop`: ORs the hidden `-q` alias into `--quality-loop`.
+ *   - `resolveTuiEnabled`: decides whether the boxed Ink TUI mounts.
+ *
+ * Extracted as pure functions so the flag behavior is unit-testable without
+ * driving the full `runCommand` side effects.
+ */
+
+import type { RunOptions } from "../lib/workflow/types.js";
+
+/**
+ * #705: `-q` is a hidden alias for the quality loop (it no longer maps to
+ * `--quiet`, which moved to `-s`). Returns the effective quality-loop flag so
+ * `-q` and `-Q` produce identical behavior. Must run before any consumer reads
+ * `options.qualityLoop`.
+ */
+export function normalizeQualityLoop(options: RunOptions): boolean {
+  return Boolean(options.qualityLoop || options.qualityLoopAlias);
+}
+
+/**
+ * #705: the boxed Ink TUI is the default on a TTY.
+ *
+ * - `--no-tui` (Commander surfaces `options.tui === false`) opts out to the
+ *   line-based phase-matrix renderer.
+ * - Non-TTY / piped output auto-degrades (`isTTY === false`), so no Ink writes
+ *   corrupt pipes.
+ * - `--quiet`/`-s` suppresses the renderer entirely (heartbeat-only),
+ *   regardless of the TUI default (AC-2).
+ * - `--experimental-tui` is a hidden no-op alias — the default already covers
+ *   it, so it is intentionally not consulted here.
+ */
+export function resolveTuiEnabled(
+  options: RunOptions,
+  isTTY: boolean,
+): boolean {
+  return options.tui !== false && isTTY && !options.quiet;
+}

--- a/src/commands/run-progress.test.ts
+++ b/src/commands/run-progress.test.ts
@@ -143,7 +143,7 @@ describe("buildProgressWiring — activity event filter (#543)", () => {
     });
   });
 
-  describe("heartbeat branch (-q mode)", () => {
+  describe("heartbeat branch (-s / quiet mode)", () => {
     it("skips heartbeat.start / .stop for activity events", () => {
       const start = vi.fn();
       const stop = vi.fn();

--- a/src/commands/run-tui.integration.test.ts
+++ b/src/commands/run-tui.integration.test.ts
@@ -1,10 +1,11 @@
 /**
- * Integration tests for `sequant run --experimental-tui` flag wiring.
+ * Integration tests for `sequant run` TUI flag wiring.
  *
- * Verifies the flag is registered at all three layers:
- *   1. bin/cli.ts option registration
- *   2. RunOptions interface (pre-merge)
- *   3. runCommand branches on TTY detection for the TUI path
+ * #705: the boxed Ink TUI is now the default on a TTY. `--experimental-tui` is
+ * retained as a hidden no-op alias (parses, but absent from --help), and
+ * `--no-tui` opts out to the line renderer. These tests assert the CLI accepts
+ * both flags without parser errors; the tuiEnabled precedence is unit-tested in
+ * run-flags.test.ts.
  */
 
 import { execSync, ExecSyncOptionsWithStringEncoding } from "child_process";
@@ -24,15 +25,20 @@ const execOptions: ExecSyncOptionsWithStringEncoding = {
   timeout: 15000,
 };
 
-describe("sequant run --experimental-tui (CLI wiring)", () => {
-  it.skipIf(!distExists)("registers --experimental-tui in run --help", () => {
-    const help = execSync(`node ${cliPath} run --help`, execOptions);
-    expect(help).toMatch(/--experimental-tui/);
-    expect(help).toMatch(/live multi-issue dashboard/i);
-  });
+describe("sequant run TUI flag wiring (#705)", () => {
+  it.skipIf(!distExists)(
+    "--experimental-tui is hidden from run --help (no-op alias)",
+    () => {
+      const help = execSync(`node ${cliPath} run --help`, execOptions);
+      // #705: the TUI is the default, so the alias is hidden. `--no-tui` is the
+      // documented opt-out and must appear instead.
+      expect(help).not.toMatch(/--experimental-tui/);
+      expect(help).toMatch(/--no-tui/);
+    },
+  );
 
   it.skipIf(!distExists)(
-    "accepts --experimental-tui without TTY and does not error out (auto-fallback)",
+    "accepts --experimental-tui without TTY and does not error out (hidden no-op alias)",
     () => {
       // Piping through execSync guarantees stdout is not a TTY.
       // Combined with --dry-run, the run should produce linear output

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,6 +10,7 @@ import { parseBatches } from "../lib/workflow/batch-executor.js";
 import { RunOrchestrator } from "../lib/workflow/run-orchestrator.js";
 import { displayConfig, displaySummary } from "./run-display.js";
 import { buildProgressWiring } from "./run-progress.js";
+import { normalizeQualityLoop, resolveTuiEnabled } from "./run-flags.js";
 
 // Re-export public API for backwards compatibility
 export * from "./run-compat.js";
@@ -19,6 +20,11 @@ export async function runCommand(
   issues: string[],
   options: RunOptions,
 ): Promise<void> {
+  // #705: `-q` is a hidden alias for the quality loop (it no longer maps to
+  // --quiet, which moved to `-s`). Normalize before any consumer reads
+  // `qualityLoop` so `-q` and `-Q` produce identical behavior.
+  options.qualityLoop = normalizeQualityLoop(options);
+
   console.log(ui.headerBox("SEQUANT WORKFLOW"));
 
   if (!options.quiet) {
@@ -99,8 +105,10 @@ export async function runCommand(
   const resolved = RunOrchestrator.resolveConfig(init, issues, batches);
   displayConfig(resolved);
 
-  const tuiEnabled =
-    Boolean(options.experimentalTui) && Boolean(process.stdout.isTTY);
+  // #705: the boxed Ink TUI is the default on a TTY; `--no-tui` opts out,
+  // non-TTY auto-degrades, and `--quiet`/`-s` suppresses it (heartbeat-only).
+  // See resolveTuiEnabled for the full precedence.
+  const tuiEnabled = resolveTuiEnabled(options, Boolean(process.stdout.isTTY));
 
   // RunRenderer (#618) + LivenessHeartbeat (#574) wiring lives in
   // run-progress.ts to keep this adapter under the 200-LOC cap (#503 AC-2).

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -20,9 +20,8 @@ export async function runCommand(
   issues: string[],
   options: RunOptions,
 ): Promise<void> {
-  // #705: `-q` is a hidden alias for the quality loop (it no longer maps to
-  // --quiet, which moved to `-s`). Normalize before any consumer reads
-  // `qualityLoop` so `-q` and `-Q` produce identical behavior.
+  // #705: fold the hidden `-q` alias into qualityLoop before any consumer reads
+  // it (`-q` no longer maps to --quiet, which moved to `-s`). See run-flags.ts.
   options.qualityLoop = normalizeQualityLoop(options);
 
   console.log(ui.headerBox("SEQUANT WORKFLOW"));
@@ -105,9 +104,8 @@ export async function runCommand(
   const resolved = RunOrchestrator.resolveConfig(init, issues, batches);
   displayConfig(resolved);
 
-  // #705: the boxed Ink TUI is the default on a TTY; `--no-tui` opts out,
-  // non-TTY auto-degrades, and `--quiet`/`-s` suppresses it (heartbeat-only).
-  // See resolveTuiEnabled for the full precedence.
+  // #705: boxed Ink TUI is the default on a TTY; resolveTuiEnabled owns the
+  // --no-tui / non-TTY / --quiet precedence (see run-flags.ts).
   const tuiEnabled = resolveTuiEnabled(options, Boolean(process.stdout.isTTY));
 
   // RunRenderer (#618) + LivenessHeartbeat (#574) wiring lives in

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -266,6 +266,13 @@ export interface RunOptions {
   noLog?: boolean;
   logPath?: string;
   qualityLoop?: boolean;
+  /**
+   * #705: hidden `-q` alias for the quality loop. Commander 14 allows only one
+   * short flag per Option, so `-q` lives on its own `--quality-loop-alias`
+   * Option and `runCommand` ORs it into `qualityLoop` before any consumer reads
+   * it. `-q` no longer maps to `--quiet` (which moved to `-s`).
+   */
+  qualityLoopAlias?: boolean;
   maxIterations?: number;
   batch?: string[];
   smartTests?: boolean;
@@ -355,9 +362,17 @@ export interface RunOptions {
    */
   isolateParallel?: boolean;
   /**
-   * Render a live multi-issue dashboard during the run.
-   * Requires a TTY; auto-falls back to linear output when stdout is piped.
-   * Experimental — surface and behavior may change.
+   * #705: the boxed Ink dashboard is the default on a TTY. Set via `--no-tui`,
+   * which Commander surfaces as `options.tui === false` to opt out to the
+   * line-based phase-matrix renderer. Non-TTY / piped output auto-degrades, and
+   * `--quiet`/`-s` suppresses the renderer entirely regardless of this flag.
+   * Resolution: `tuiEnabled = options.tui !== false && isTTY && !quiet`.
+   */
+  tui?: boolean;
+  /**
+   * #705: now a hidden no-op alias — the boxed Ink TUI is the default, so
+   * `--experimental-tui` only parses for backward compatibility and no longer
+   * gates rendering. Kept so existing scripts/muscle-memory don't break.
    */
   experimentalTui?: boolean;
   /**


### PR DESCRIPTION
## Summary

- **Frees `-q` from quiet.** `--quiet` moves to `-s` (mnemonic: silent). `-q` is now a hidden alias for `-Q, --quality-loop`, ORed into `qualityLoop` at the top of `runCommand` — both `-q` and `-Q` enable the quality loop; neither enables quiet. Ends the footgun where `run … -q` silently enabled quiet mode instead of the quality loop.
- **Boxed Ink TUI is the default for `run`** on a TTY: `tuiEnabled = options.tui !== false && isTTY && !quiet`. `--no-tui` opts out to the line phase-matrix renderer; non-TTY / piped output auto-degrades; `--quiet`/`-s` suppresses the renderer entirely (heartbeat-only).
- **`--experimental-tui`** kept as a hidden no-op alias for backward compatibility.
- **`ready` parity (AC-6):** both `run` and `ready` mount the identical `renderTui(provider)` (same `App`, same full box) — confirmed structurally identical, no gap to close.

Flag resolution extracted to `src/commands/run-flags.ts` (`normalizeQualityLoop`, `resolveTuiEnabled`) as pure functions, making the flag behavior directly unit-testable and keeping `run.ts` under its 200-LOC cap (matches the existing `run-progress.ts` extraction pattern).

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | `-q` and `-Q` both enable the quality loop; neither enables quiet | ✅ | `run-flags.ts` `normalizeQualityLoop` + unit tests; `bin/cli.ts` hidden `-q` alias; CLI parse tests in `cli.integration.test.ts` |
| AC-2 | `--quiet` reachable via `-s`; suppresses the renderer | ✅ | `bin/cli.ts:-s, --quiet`; `resolveTuiEnabled` `!quiet` term + unit test; help-surface test |
| AC-3 | `sequant run` shows boxed Ink TUI by default on a TTY | ✅ | `resolveTuiEnabled({}, true) === true` unit test; `run.ts` wiring |
| AC-4 | `--no-tui` opts out; non-TTY auto-degrades | ✅ | `--no-tui` registered; `resolveTuiEnabled` unit tests (`tui:false`, non-TTY) |
| AC-5 | `--experimental-tui` still parses (hidden no-op) | ✅ | `addOption(new Option("--experimental-tui").hideHelp())`; parse + hidden-from-help tests in `run-tui.integration.test.ts` |
| AC-6 | `ready` renders the same full boxed TUI as `run` | ✅ | Both mount `renderTui` from `ui/tui/index.ts` (`run.ts:140`, `ready.ts:182`) — structurally identical; confirmed, no code change needed |
| AC-7 | Help text + docs/README updated | ✅ | README, `run-command.md`, `quiet-mode-heartbeat.md`, `run-renderer.md`, `experimental-tui-dashboard.md`, CHANGELOG |

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npx vitest run` on all affected files (run-flags, cli.integration, run-tui.integration, run-progress, ready, heartbeat) — 69 passed
- [x] Manual: `run --help` shows `-Q`, `-s, --quiet`, `--no-tui`; hides `-q` alias + `--experimental-tui`
- [x] Manual: `-q`, `-Q`, `-s`, `--no-tui`, `--experimental-tui` all parse without "unknown option"

### Known unrelated failure
`src/commands/__tests__/prompt-wait.test.ts` has one pre-existing flaky failure (a timer/filesystem race reading the relay `inbox.jsonl`). It fails identically on the clean base and touches the `sequant prompt --wait` relay system — none of which this PR modifies.

Closes #705