### PR TITLE
feat(tui): brand-color the run dashboard's active phase and success states

### DIFF
--- a/src/ui/tui/IssueBox.tsx
+++ b/src/ui/tui/IssueBox.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import { Box, Text } from "ink";
 import type { IssueRuntimeState } from "../../lib/workflow/run-state.js";
 import {
+  ACTIVE_PHASE_COLOR,
   DIVIDER_COLOR,
   PHASE_GLYPHS,
   borderColorForIssue,
@@ -73,7 +74,10 @@ export function IssueBox({
           <Text color={DIVIDER_COLOR}>branch </Text>
           <Text>{truncateToWidth(state.branch, innerWidth - 8)}</Text>
         </Box>
-        <PhaseProgression phases={state.phases} borderColor={border} />
+        <PhaseProgression
+          phases={state.phases}
+          activeColor={ACTIVE_PHASE_COLOR}
+        />
         {state.currentPhase?.logPath ? (
           <Box>
             <Text color={DIVIDER_COLOR}>log </Text>
@@ -92,7 +96,7 @@ export function IssueBox({
           <>
             <Box>
               <Text color={DIVIDER_COLOR}>now </Text>
-              <Spinner color={border} />
+              <Spinner color={ACTIVE_PHASE_COLOR} />
               <Text>
                 {"  "}
                 {truncateToWidth(state.currentPhase.nowLine, innerWidth - 12)}
@@ -132,10 +136,10 @@ function Divider({ width }: { width: number }): JSX.Element {
 
 function PhaseProgression({
   phases,
-  borderColor,
+  activeColor,
 }: {
   phases: IssueRuntimeState["phases"];
-  borderColor: string;
+  activeColor: string;
 }): JSX.Element {
   return (
     <Box flexWrap="wrap">
@@ -147,7 +151,7 @@ function PhaseProgression({
             <PhaseGlyph
               status={p.status}
               label={p.name}
-              activeColor={borderColor}
+              activeColor={activeColor}
               elapsedMs={p.elapsedMs}
             />
             {!isLast ? (

--- a/src/ui/tui/theme.test.ts
+++ b/src/ui/tui/theme.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   BORDER_ROTATION,
+  BRAND_GREEN,
   borderColorForIssue,
   phaseStatusColor,
 } from "./theme.js";
@@ -18,7 +19,7 @@ describe("borderColorForIssue", () => {
   it("status overrides rotation for failed and passed", () => {
     expect(borderColorForIssue("failed", 0)).toBe("red");
     expect(borderColorForIssue("failed", 7)).toBe("red");
-    expect(borderColorForIssue("passed", 2)).toBe("green");
+    expect(borderColorForIssue("passed", 2)).toBe(BRAND_GREEN);
   });
 
   it("running state uses rotation", () => {
@@ -27,8 +28,8 @@ describe("borderColorForIssue", () => {
 });
 
 describe("phaseStatusColor", () => {
-  it("green for done, red for failed, gray otherwise", () => {
-    expect(phaseStatusColor("done")).toBe("green");
+  it("brand green for done, red for failed, gray otherwise", () => {
+    expect(phaseStatusColor("done")).toBe(BRAND_GREEN);
     expect(phaseStatusColor("failed")).toBe("red");
     expect(phaseStatusColor("pending")).toBe("gray");
     expect(phaseStatusColor("running")).toBe("gray");

--- a/src/ui/tui/theme.ts
+++ b/src/ui/tui/theme.ts
@@ -8,21 +8,42 @@
 
 import type { IssueStatus, PhaseStatus } from "../../lib/workflow/run-state.js";
 
+/**
+ * Sequant brand accents, sourced from sequant-landing `src/styles/tokens.css`:
+ *   - `BRAND_ORANGE` is the primary brand color (`--color-primary` dark mode).
+ *   - `BRAND_GREEN` is the accent/success green (`--color-accent`).
+ *
+ * Used to brand the two color signals that matter most at a glance — the
+ * live/active phase and success — while issue-distinction (border rotation),
+ * failure (red), and dividers (gray) stay on robust named ANSI colors.
+ *
+ * Ink/chalk auto-downsamples hex to the nearest ANSI color on terminals
+ * without truecolor, and `NO_COLOR` still strips all color, so these degrade
+ * gracefully without a manual capability check.
+ */
+export const BRAND_ORANGE = "#FF8012" as const;
+export const BRAND_GREEN = "#10b981" as const;
+
 /** Border-color palette rotated by issue start order. */
 export const BORDER_ROTATION = ["cyan", "magenta", "blue", "yellow"] as const;
 
 export type BorderColor =
   | (typeof BORDER_ROTATION)[number]
-  | "green"
+  | typeof BRAND_GREEN
+  | typeof BRAND_ORANGE
   | "red"
   | "gray";
 
 /** Gray used for horizontal dividers inside each box. */
 export const DIVIDER_COLOR = "gray" as const;
 
-/** Green used for the rolled-up `✔ N done` summary line (#699, parity with the
+/** Brand orange for the live/active phase spinner — the one element the eye
+ *  tracks. Border rotation still distinguishes concurrent issues. */
+export const ACTIVE_PHASE_COLOR = BRAND_ORANGE;
+
+/** Brand green for the rolled-up `✔ N done` summary line (#699, parity with the
  *  plain renderer's #624 rollup). */
-export const ROLLUP_COLOR = "green" as const;
+export const ROLLUP_COLOR = BRAND_GREEN;
 
 /**
  * Pick the border color for an issue.
@@ -33,7 +54,7 @@ export function borderColorForIssue(
   slot: number,
 ): BorderColor {
   if (status === "failed") return "red";
-  if (status === "passed") return "green";
+  if (status === "passed") return BRAND_GREEN;
   const idx =
     ((slot % BORDER_ROTATION.length) + BORDER_ROTATION.length) %
     BORDER_ROTATION.length;
@@ -64,7 +85,7 @@ export const SPINNER_FRAMES = [
 
 /** Color for a phase glyph based on its status. Active phase uses border color. */
 export function phaseStatusColor(status: PhaseStatus): BorderColor {
-  if (status === "done") return "green";
+  if (status === "done") return BRAND_GREEN;
   if (status === "failed") return "red";
   return "gray";
 }


### PR DESCRIPTION
## What

Apply Sequant brand accents (sourced from `sequant-landing/src/styles/tokens.css`) to the two highest-signal colors in the boxed run TUI:

- **Active/live phase spinners** now use **brand orange** `#FF8012` (`--color-primary` dark) instead of the issue's rotation color — the running phase now pops on-brand across every box.
- **Success states** (done glyphs, passed borders, the `✔ N done` rollup) use **brand green** `#10b981` (`--color-accent`) instead of generic ANSI green.

## Why

The run UI had no brand identity. These two states are the ones the eye tracks most ("what's running" and "what passed"), so branding them gives the biggest recognition win for the smallest change.

## Scope / deliberately unchanged

- **Issue distinction** — the per-box border rotation (cyan/magenta/blue/yellow) is untouched, so concurrent issues stay distinguishable.
- **Failure** stays `red`; **dividers/labels** stay `gray`.
- No new pastels were introduced — only the two saturated brand accents, which read reliably as terminal text.

## Graceful degradation

Ink/chalk auto-downsamples the hex to the nearest ANSI color on non-truecolor terminals, and `NO_COLOR` still strips all color, so no manual capability check was needed.

## Notes

- Renamed the now-misleading `PhaseProgression` `borderColor` prop → `activeColor`.
- Updated `theme.test.ts` assertions to the brand constants.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `vitest run src/ui/tui/` — 12/12 pass
- [ ] Visual: run `sequant run` against 2+ issues and confirm orange active spinner + green success