### PR TITLE
fix(tui): stop perf-buffer leak and react to terminal resize

### DIFF
--- a/src/commands/ready.ts
+++ b/src/commands/ready.ts
@@ -178,7 +178,7 @@ export async function readyCommand(
       listWorktrees().find((w) => w.issue === issueNumber)?.branch ?? "";
     adapter = new ReadySnapshotAdapter({ issueNumber, title, branch });
     onProgress = adapter.onProgress;
-    const { renderTui } = await import("../ui/tui/index.js");
+    const { renderTui } = await (await import("../ui/tui/load.js")).loadTui();
     tuiHandle = renderTui(adapter);
   } else if (!options.json) {
     // Stream phases as they fire (no `basePhases`): the ready pipeline length

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -125,7 +125,7 @@ export async function runCommand(
   });
 
   if (tuiEnabled) {
-    const { renderTui } = await import("../ui/tui/index.js");
+    const { renderTui } = await (await import("../ui/tui/load.js")).loadTui();
     let tuiHandle: { done: Promise<void>; unmount: () => void } | null = null;
     // Unmount the TUI before ShutdownManager writes its shutdown banner so
     // the two don't race on stdout / leave the terminal in alt-screen buffer.

--- a/src/ui/tui/App.resize.test.ts
+++ b/src/ui/tui/App.resize.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import { createElement } from "react";
+import { render } from "ink";
+import stringWidth from "string-width";
+import { App } from "./App.js";
+import type { RunSnapshot } from "../../lib/workflow/run-state.js";
+
+/**
+ * Width-reactivity regression test for the duplicate/garbled-frame bug.
+ *
+ * The corruption was a *width* failure: after the terminal shrank, ink kept
+ * repainting boxes at the stale (now too-wide) width, so box lines wrapped and
+ * the borders misaligned. `App` now tracks `columns` from the stdout `resize`
+ * event, so this asserts the rendered box width follows a width decrease.
+ */
+// Mirrors ink-testing-library's fake stdout (non-interactive: ink writes full
+// measurable frames) but with a *mutable* `columns` so we can simulate resize.
+class FakeStdout extends EventEmitter {
+  columns: number;
+  rows = 40;
+  frames: string[] = [];
+  constructor(columns: number) {
+    super();
+    this.columns = columns;
+  }
+  write = (frame: string): void => {
+    this.frames.push(frame);
+  };
+}
+
+function snapshot(): RunSnapshot {
+  return {
+    config: { concurrency: 1, baseBranch: "main", qualityLoop: true },
+    issues: [
+      {
+        number: 707,
+        title: "a representative issue title that is reasonably long",
+        branch: "feature/707-some-branch",
+        status: "running",
+        phases: [
+          { name: "spec", status: "done", elapsedMs: 1000 },
+          { name: "exec", status: "running" },
+          { name: "qa", status: "pending" },
+        ],
+        currentPhase: {
+          name: "exec",
+          startedAt: new Date(0),
+          lastActivityAt: new Date(0),
+          nowLine: "running exec",
+        },
+        startedAt: new Date(0),
+      },
+    ],
+    done: false,
+    capturedAt: new Date(0),
+  };
+}
+
+/** Max printable width across all lines of the most recent frame. */
+function maxLineWidth(stdout: FakeStdout): number {
+  const frame = stdout.frames.at(-1) ?? "";
+  return Math.max(0, ...frame.split("\n").map((l) => stringWidth(l)));
+}
+
+/** Wait until ink has flushed at least one new frame (or time out). */
+async function waitForFrame(stdout: FakeStdout): Promise<void> {
+  const start = Date.now();
+  const before = stdout.frames.length;
+  while (stdout.frames.length === before && Date.now() - start < 2000) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe("App width reactivity", () => {
+  it("shrinks box width to fit after the terminal narrows", async () => {
+    const stdout = new FakeStdout(120);
+    const instance = render(
+      createElement(App, { getSnapshot: () => snapshot() }),
+      // `debug: true` makes ink write each frame synchronously as plain text
+      // (no throttle / cursor codes) — the same mode ink-testing-library uses.
+      { stdout: stdout as never, patchConsole: false, debug: true },
+    );
+    try {
+      await waitForFrame(stdout);
+      const wide = maxLineWidth(stdout);
+      // Box is capped at 100 cols; at 120 columns it renders near that cap.
+      expect(wide).toBeGreaterThan(80);
+      expect(wide).toBeLessThanOrEqual(120);
+
+      // Shrink the terminal and fire the resize the same way a real tty does.
+      // Wait only briefly — under the 100 ms snapshot poll — so this asserts
+      // the *resize event* drove the re-layout, not the periodic poll.
+      stdout.columns = 60;
+      stdout.emit("resize");
+      await new Promise((r) => setTimeout(r, 60));
+
+      const narrow = maxLineWidth(stdout);
+      // The box must re-lay-out to fit the new width — never wider than the
+      // terminal (the wrap that caused border misalignment).
+      expect(narrow).toBeLessThanOrEqual(60);
+      expect(narrow).toBeLessThan(wide);
+    } finally {
+      instance.unmount();
+    }
+  });
+});

--- a/src/ui/tui/App.tsx
+++ b/src/ui/tui/App.tsx
@@ -27,6 +27,7 @@ export function App({
   const [now, setNow] = useState(() => Date.now());
   const doneFired = useRef(false);
   const { stdout } = useStdout();
+  const [columns, setColumns] = useState(() => stdout?.columns ?? 80);
 
   // Snapshot poller (drives all state transitions).
   useEffect(() => {
@@ -48,8 +49,29 @@ export function App({
     return () => clearInterval(id);
   }, []);
 
-  const columns = stdout?.columns ?? 80;
-  const boxWidth = Math.min(columns - 2, 100);
+  // Track the terminal width reactively. ink's own resize handler re-renders
+  // the existing React tree but does NOT re-run this component, so a width read
+  // imperatively in render goes stale until the next poll. In that window ink
+  // repaints boxes at the old (now too-wide) width and the lines wrap, which
+  // misaligns the box borders into the duplicate/garbled frames. Updating
+  // `columns` from the resize event forces an immediate re-layout at the new
+  // width. A 1 Hz fallback poll covers terminals that don't emit `resize`.
+  useEffect(() => {
+    if (!stdout) return;
+    const sync = (): void => setColumns(stdout.columns ?? 80);
+    stdout.on("resize", sync);
+    sync();
+    const id = setInterval(sync, 1000);
+    return () => {
+      stdout.off("resize", sync);
+      clearInterval(id);
+    };
+  }, [stdout]);
+
+  // Clamp each box to the current terminal width (minus a 2-col safety margin)
+  // so a box line can never equal or exceed the terminal width and wrap.
+  const safeColumns = columns > 0 ? columns : 80;
+  const boxWidth = Math.max(20, Math.min(safeColumns - 2, 100));
 
   // #699 AC-4: clamp the number of boxes to the terminal height so a large
   // batch on a short terminal can't overflow the frame (parity with the plain

--- a/src/ui/tui/load.test.ts
+++ b/src/ui/tui/load.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { loadTui } from "./load.js";
+
+/**
+ * Guards the leak fix in `load.ts`. The dangerous regression is NOT "fails to
+ * load" (TypeScript catches that) — it's `loadTui()` leaving
+ * `NODE_ENV=production` set after it returns, which spawned phase children
+ * would then inherit (making, e.g., `npm install` skip devDependencies). These
+ * tests pin the restore behavior for every prior `NODE_ENV` state.
+ */
+describe("loadTui", () => {
+  const original = process.env.NODE_ENV;
+  afterEach(() => {
+    if (original === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = original;
+  });
+
+  it("returns the TUI module with renderTui", async () => {
+    const mod = await loadTui();
+    expect(typeof mod.renderTui).toBe("function");
+  });
+
+  it("restores an unset NODE_ENV (children must not inherit production)", async () => {
+    delete process.env.NODE_ENV;
+    await loadTui();
+    expect("NODE_ENV" in process.env).toBe(false);
+  });
+
+  it("preserves an explicit NODE_ENV (test/development is respected)", async () => {
+    process.env.NODE_ENV = "test";
+    await loadTui();
+    expect(process.env.NODE_ENV).toBe("test");
+  });
+});

--- a/src/ui/tui/load.ts
+++ b/src/ui/tui/load.ts
@@ -1,0 +1,37 @@
+/**
+ * Loader for the Ink TUI module that forces React into its production build.
+ *
+ * `react-reconciler` (pulled in by `ink`) selects its dev-vs-prod bundle from
+ * `process.env.NODE_ENV` **at module-evaluation time**. The development bundle
+ * emits a `performance.measure()` per component render and never calls
+ * `performance.clearMeasures()`. Driven by the TUI's 10 Hz poll over a long
+ * `sequant run`, those entries accumulate in Node's global performance buffer
+ * until it overflows its ~1,000,000-entry cap and prints
+ * `MaxPerformanceEntryBufferExceededWarning` to stderr — a memory leak that
+ * also corrupts the dashboard's in-place redraw (the stderr write scrolls the
+ * terminal between log-update frames; see #647/#664).
+ *
+ * The TUI module is the *only* importer of `react`/`ink`/`react-reconciler`,
+ * and it is always reached through a dynamic `import()`, so bracketing that one
+ * import with `NODE_ENV=production` caches the production reconciler (which has
+ * zero `performance.measure` calls). We restore `NODE_ENV` immediately after so
+ * spawned child processes (claude phases, `npm install`, build steps) do NOT
+ * inherit `NODE_ENV=production` — which would, e.g., make `npm install` skip
+ * devDependencies.
+ *
+ * Only overrides when `NODE_ENV` is unset/empty: an explicit `development` or
+ * `test` (the test runner) is respected so dev warnings remain available there.
+ */
+export async function loadTui(): Promise<typeof import("./index.js")> {
+  const prev = process.env.NODE_ENV;
+  const override = prev === undefined || prev === "";
+  if (override) process.env.NODE_ENV = "production";
+  try {
+    return await import("./index.js");
+  } finally {
+    if (override) {
+      if (prev === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prev;
+    }
+  }
+}


### PR DESCRIPTION
Two fixes for the `sequant run` dashboard.

## 1. perf_hooks leak (`MaxPerformanceEntryBufferExceededWarning`)

ink pulls in `react-reconciler`, which loads its **development** bundle whenever `NODE_ENV !== "production"` (the normal dogfooding case). That bundle emits an uncleared `performance.measure()` per component render; driven by the TUI's 10 Hz poll it overflows Node's ~1,000,000-entry global perf buffer and writes a raw warning to **stderr** — which also corrupts the in-place redraw (stderr scrolls the terminal between frames, so the erase undershoots and frames stack).

**Fix:** new `src/ui/tui/load.ts` — `loadTui()` brackets the TUI's single dynamic `import()` with `NODE_ENV=production` (only when unset), caching the production reconciler (zero `performance.measure` calls), then **restores** `NODE_ENV` so spawned phase children don't inherit it (e.g. `npm install` skipping devDependencies). Both call sites (`run.ts`, `ready.ts`) now go through it.

**Verified:** same render workload went from **206 → 0** `measure` entries; `NODE_ENV` confirmed restored afterward.

## 2. Width corruption on resize (duplicate / garbled frames)

ink's resize handler re-renders the existing React tree but does **not** re-run `App`, and `App` read `stdout.columns` imperatively — so after a resize it repainted boxes at the stale, too-wide width until the next 100 ms poll. Those over-wide lines wrapped while short lines didn't, misaligning the box borders into the garbled/duplicate frames.

**Fix (`App.tsx`):** track `columns` in state, updated from the stdout `resize` event (plus a 1 Hz fallback for terminals that don't emit it), and clamp `boxWidth` to the live width.

## Tests
- `load.test.ts` — pins the `NODE_ENV` restore behavior for every prior state.
- `App.resize.test.ts` — renders a real ink tree, shrinks 120 → 60, and asserts the box width follows within one frame (under the poll). Confirmed it **fails on the un-fixed code** and passes with the fix.

typecheck clean; 224 tests pass in the touched areas.