### PR TITLE
fix(#720): resolve corrupt package-lock.json (9 stash-conflict blocks)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2659,10 +2659,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2684,10 +2680,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3271,10 +3263,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4047,10 +4035,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "ISC"
     },
     "node_modules/jose": {
@@ -4600,10 +4584,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -4876,10 +4856,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5278,10 +5254,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5294,10 +5266,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5954,10 +5922,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-<<<<<<< Updated upstream
-=======
-      "dev": true,
->>>>>>> Stashed changes
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"


### PR DESCRIPTION
Closes #720.

## Problem

`main`'s `package-lock.json` has been **invalid JSON** since PR #716 (`512840f`): a `git stash pop` left **9 unresolved conflict blocks** (27 marker lines) that were committed. `npm ci` from a fresh clone fails.

Found during `/release` prep for v2.6.2 — the release's pre-flight "clean working tree" check passes because the corruption is *committed*, not staged, so `git status` looks clean and the bad file sits at HEAD.

## Why it went unnoticed

- The lockfile isn't published to the npm tarball → npm consumers unaffected.
- `npm install` / `tsc` / `vitest` tolerate the existing `node_modules`; only a strict `npm ci` (fresh clone) parses the lockfile and fails.

## Fix

Regenerated via `npm install --package-lock-only`. npm recomputes the dependency tree deterministically and drops the spurious `"dev": true` flags on production-reachable transitive deps (`cross-spawn`, `debug`, `fast-deep-equal`, `isexe`, `ms`, `path-key`, `shebang-command`, +2). Net change: `36 deletions` — purely the conflict markers and the stashed-side `dev` lines.

## Verification

- `grep -cE '^(<<<<<<<|=======|>>>>>>>)' package-lock.json` → `0`
- `node -e "JSON.parse(...)"` → valid JSON
- `npm ci --dry-run` → parses clean (strict; would fail instantly on markers)
- `npm audit` → 0 vulnerabilities

## Follow-up (not in this PR)

Add an `npm ci`-on-fresh-checkout CI gate (or a lockfile-conflict-marker lint) so a corrupt lockfile can't reach `main` again. Noted in #720.