### PR TITLE
fix(#722): add sync --dry-run so the sync preview can't under-report the apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sequant sync --dry-run` / `-d` — a trustworthy preview for the sync surface (#722)** — `sync` previously had no preview: on a `.sequant-version` marker mismatch (e.g. an install that predates the 2.6.2 `<!-- sequant:local-override -->` overlay header from #711) it ran `copyTemplates(force:true)` and silently rewrote the whole tree (every `SKILL.md` + `AGENTS.md`) with no per-file output, so an operator or CI job had no way to see pending work before applying. The reported dry-run-vs-apply divergence traced to this gap (and/or `npx` version skew) — **not** to `update`, which already derives its summary and write-set from one `computeTemplateChanges()` call and already classifies a header-missing `SKILL.md` as `modified` (verified: `update --dry-run` reports the drift, never a false "0 modified"). `sync --dry-run` reuses that same source of truth to report the exact set the apply would write — `new` + `modified` + `local-override` (the force copy overwrites in-place customizations, so they are counted, never under-reported) — mutates nothing, and exits non-zero when work is pending so the preview can gate automation. The override classifier remains keyed on a real `.claude/.local/` twin, not the in-band marker. (#722)
+
 ## [2.6.2] - 2026-06-04
 
 ### Added

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -195,6 +195,10 @@ program
   )
   .option("-f, --force", "Sync even if versions match")
   .option("-q, --quiet", "Suppress output")
+  .option(
+    "-d, --dry-run",
+    "Show what sync would write without making changes (exits non-zero if work is pending)",
+  )
   .action(syncCommand);
 
 program

--- a/docs/reference/cheat-sheet.md
+++ b/docs/reference/cheat-sheet.md
@@ -24,6 +24,7 @@ bun add -g sequant           # bun
 sequant update              # Update skill templates to latest version (interactive)
 sequant update --yes        # Apply updates without prompting (CI/non-interactive)
 sequant sync                # Sync skills and templates (non-interactive, CI-safe)
+sequant sync --dry-run      # Preview what sync would write (exits non-zero if work pending)
 sequant doctor              # Verify installation health
 ```
 

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -553,6 +553,152 @@ describe("sync command", () => {
       expect(mockWriteFile).toHaveBeenCalled();
     });
 
+    // #722: `sync` previously had no preview surface — on a version mismatch it
+    // force-rewrote the whole tree silently, so an operator/CI had no trustworthy
+    // way to see pending work before applying. `--dry-run` reuses the same
+    // `computeTemplateChanges` source of truth the apply consults, so the preview
+    // can never under-report the write-set.
+    describe("--dry-run (#722)", () => {
+      it("previews the write-set on a version mismatch without mutating (AC-1)", async () => {
+        mockGetManifest.mockResolvedValue({
+          version: "1.0.0",
+          stack: "nextjs",
+          installedAt: "2024-01-01",
+          files: {},
+        });
+        mockFileExists.mockResolvedValue(true);
+        mockReadFile.mockResolvedValue("1.0.0"); // marker < package → mismatch
+        mockGetPackageVersion.mockReturnValue("1.1.0");
+        mockGetConfig.mockResolvedValue(null);
+        mockComputeTemplateChanges.mockResolvedValue([
+          {
+            path: ".claude/skills/qa/SKILL.md",
+            templatePath: "templates/skills/qa/SKILL.md",
+            status: "modified",
+            rendered: "new",
+            diff: "diff",
+          },
+          {
+            path: ".claude/skills/new/SKILL.md",
+            templatePath: "templates/skills/new/SKILL.md",
+            status: "new",
+            rendered: "new",
+          },
+        ]);
+
+        const logSpy = vi.spyOn(console, "log");
+        await syncCommand({ dryRun: true });
+
+        const output = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+        // Reports the real write-set, not a false "0 modified" / "up to date".
+        expect(output).toContain("Modified: 1");
+        expect(output).toContain("New files: 1");
+        expect(output).toContain(".claude/skills/qa/SKILL.md");
+        expect(output).not.toContain("already up to date");
+        // Mutates nothing: no copy, no version-marker/manifest writes.
+        expect(mockCopyTemplates).not.toHaveBeenCalled();
+        expect(mockWriteFile).not.toHaveBeenCalled();
+        // Pending work → non-zero exit so the preview can gate CI.
+        expect(process.exitCode).toBe(1);
+      });
+
+      it("counts local-overrides in the write-set (never under-reports, AC-1)", async () => {
+        // `sync`'s apply is `copyTemplates(force:true)`, which overwrites in-place
+        // customizations (it does NOT protect them the way `update` does). The
+        // preview must therefore include local-overrides, or it would under-report
+        // exactly the way #722 describes.
+        mockGetManifest.mockResolvedValue({
+          version: "1.0.0",
+          stack: "nextjs",
+          installedAt: "2024-01-01",
+          files: {},
+        });
+        mockFileExists.mockResolvedValue(true);
+        mockReadFile.mockResolvedValue("1.0.0");
+        mockGetPackageVersion.mockReturnValue("1.1.0");
+        mockGetConfig.mockResolvedValue(null);
+        mockComputeTemplateChanges.mockResolvedValue([
+          {
+            path: ".claude/memory/constitution.md",
+            templatePath: "templates/memory/constitution.md",
+            status: "local-override",
+            rendered: "template",
+          },
+        ]);
+
+        const logSpy = vi.spyOn(console, "log");
+        await syncCommand({ dryRun: true });
+
+        const output = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+        expect(output).toContain("Local overrides (overwritten by sync): 1");
+        expect(output).toContain(".claude/memory/constitution.md");
+        expect(output).not.toContain("already up to date");
+        expect(mockCopyTemplates).not.toHaveBeenCalled();
+        // A pending overwrite still counts as work for the CI gate.
+        expect(process.exitCode).toBe(1);
+      });
+
+      it("previews under --force at a matching version without mutating (AC-1)", async () => {
+        mockGetManifest.mockResolvedValue({
+          version: "1.1.0",
+          stack: "nextjs",
+          installedAt: "2024-01-01",
+          files: {},
+        });
+        mockFileExists.mockResolvedValue(true);
+        mockReadFile.mockResolvedValue("1.1.0"); // versions match
+        mockGetPackageVersion.mockReturnValue("1.1.0");
+        mockGetConfig.mockResolvedValue(null);
+        mockComputeTemplateChanges.mockResolvedValue([
+          {
+            path: ".claude/skills/qa/SKILL.md",
+            templatePath: "templates/skills/qa/SKILL.md",
+            status: "modified",
+            rendered: "new",
+            diff: "diff",
+          },
+        ]);
+
+        const logSpy = vi.spyOn(console, "log");
+        await syncCommand({ dryRun: true, force: true });
+
+        const output = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+        expect(output).toContain("Modified: 1");
+        expect(mockCopyTemplates).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+      });
+
+      it("reports up to date and exits 0 when there is nothing to write", async () => {
+        mockGetManifest.mockResolvedValue({
+          version: "1.1.0",
+          stack: "nextjs",
+          installedAt: "2024-01-01",
+          files: {},
+        });
+        mockFileExists.mockResolvedValue(true);
+        mockReadFile.mockResolvedValue("1.1.0");
+        mockGetPackageVersion.mockReturnValue("1.1.0");
+        mockGetConfig.mockResolvedValue(null);
+        mockComputeTemplateChanges.mockResolvedValue([
+          {
+            path: ".claude/skills/qa/SKILL.md",
+            templatePath: "templates/skills/qa/SKILL.md",
+            status: "unchanged",
+            rendered: "same",
+          },
+        ]);
+
+        const logSpy = vi.spyOn(console, "log");
+        // --force reaches the dry-run preview even at a matching version.
+        await syncCommand({ dryRun: true, force: true });
+
+        const output = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+        expect(output).toContain("already up to date");
+        expect(mockCopyTemplates).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(0);
+      });
+    });
+
     it("syncs when force is set even if versions match", async () => {
       mockGetManifest.mockResolvedValue({
         version: "1.1.0",

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -43,6 +43,7 @@ const MANIFEST_FILE_PATH = ".sequant-manifest.json";
 interface SyncOptions {
   force?: boolean;
   quiet?: boolean;
+  dryRun?: boolean;
 }
 
 interface DriftCache {
@@ -248,7 +249,7 @@ async function updateSkillsVersion(): Promise<void> {
 }
 
 export async function syncCommand(options: SyncOptions = {}): Promise<void> {
-  const { force = false, quiet = false } = options;
+  const { force = false, quiet = false, dryRun = false } = options;
 
   if (!quiet) {
     console.log(chalk.blue("\nSyncing templates...\n"));
@@ -316,6 +317,71 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     // non-interactive / CI path we recommend can't treat a drifted tree as
     // success — the original failure mode in #708.
     process.exitCode = 1;
+    return;
+  }
+
+  // Preview path: report exactly what the apply would write, then stop without
+  // mutating (#722). This branch is only reached when `force` is set or the
+  // version marker mismatches — i.e. the path that runs `copyTemplates(force:
+  // true)` and rewrites the whole tree. (A matching-version, non-force dry-run
+  // already returned at the report-only short-circuit above, which never
+  // mutates.) `copyTemplates` does NOT protect in-place customizations the way
+  // `update` does — the force copy overwrites them — so the preview counts
+  // `local-override` files alongside `new`/`modified`. Reporting only
+  // new+modified would under-report the write-set, the exact divergence #722
+  // is about.
+  if (dryRun) {
+    const changes = await computeTemplateChanges(manifest.stack, tokens);
+    const newFiles = changes.filter((c) => c.status === "new");
+    const modifiedFiles = changes.filter((c) => c.status === "modified");
+    const localOverrides = changes.filter((c) => c.status === "local-override");
+    const toWrite = [...newFiles, ...modifiedFiles, ...localOverrides];
+
+    if (!quiet) {
+      console.log(chalk.bold("Summary (dry-run):"));
+      console.log(chalk.green(`  New files: ${newFiles.length}`));
+      console.log(chalk.yellow(`  Modified: ${modifiedFiles.length}`));
+      console.log(
+        chalk.blue(
+          `  Local overrides (overwritten by sync): ${localOverrides.length}`,
+        ),
+      );
+
+      if (modifiedFiles.length > 0) {
+        console.log(chalk.bold("\nModified files:"));
+        for (const file of modifiedFiles) {
+          console.log(chalk.yellow(`  ${file.path}`));
+        }
+      }
+      if (newFiles.length > 0) {
+        console.log(chalk.bold("\nNew files:"));
+        for (const file of newFiles) {
+          console.log(chalk.green(`  ${file.path}`));
+        }
+      }
+      if (localOverrides.length > 0) {
+        console.log(
+          chalk.bold("\nLocal overrides (will be overwritten by sync):"),
+        );
+        for (const file of localOverrides) {
+          console.log(chalk.blue(`  ${file.path}`));
+        }
+      }
+
+      if (toWrite.length === 0) {
+        console.log(chalk.green("\n✔ Skills are already up to date!"));
+      } else {
+        console.log(chalk.gray("\n(dry-run mode - no changes made)"));
+      }
+    }
+
+    // Non-zero exit when work is pending so the documented preview surface can
+    // gate CI/automation (the #709 intent): a dry-run reporting nothing must
+    // mean nothing to do. The matching-version short-circuit signals drift the
+    // same way.
+    if (toWrite.length > 0) {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/src/lib/templates.test.ts
+++ b/src/lib/templates.test.ts
@@ -297,5 +297,51 @@ describe("templates", () => {
 
       expect(skill?.status).toBe("new");
     });
+
+    // #722 regression: a SKILL.md installed before the `<!-- sequant:local-override
+    // -->` overlay header shipped (#711 / 2.6.2) must surface as `modified` in the
+    // preview — never silently `unchanged` — so `update --dry-run` / `sync --dry-run`
+    // can't report "0 modified" while the apply rewrites it.
+    it("classifies a header-missing SKILL.md vs a header-bearing template as modified (AC-3)", async () => {
+      const OVERRIDE_HEADER =
+        "<!-- sequant:local-override -->\n" +
+        "> **Local overrides (read this first).** See `.claude/.local/skills/exec/overrides.md`.\n\n";
+      // Template ships the overlay header; installed copy predates it.
+      await fsWriteFile(
+        join(templatesDir, "skills", "exec", "SKILL.md"),
+        OVERRIDE_HEADER + "exec skill v{{PROJECT_NAME}}\n",
+      );
+      await seedLocal(SKILL_LOCAL, "exec skill vmy-project\n");
+
+      const changes = await computeTemplateChanges("generic");
+      const skill = changes.find((c) => c.path === SKILL_LOCAL);
+
+      expect(skill?.status).toBe("modified");
+      expect(skill?.diff).toBeDefined();
+    });
+
+    // #722 AC-2: the override classifier must key on a real `.claude/.local/`
+    // twin (the supported customization mechanism), NOT on the in-band marker
+    // embedded in the managed SKILL.md template. Locks the invariant so a future
+    // change can't re-introduce the marker coupling the issue warns against.
+    it("classifies a drifted SKILL.md as modified with no .local twin, local-override with one (AC-2)", async () => {
+      await seedLocal(SKILL_LOCAL, "locally edited skill\n");
+
+      // No `.claude/.local/skills/exec/SKILL.md` twin → modified.
+      const before = await computeTemplateChanges("generic");
+      expect(before.find((c) => c.path === SKILL_LOCAL)?.status).toBe(
+        "modified",
+      );
+
+      // Add the real `.local` twin → now protected as a local-override.
+      await seedLocal(
+        ".claude/.local/skills/exec/SKILL.md",
+        "my local override\n",
+      );
+      const after = await computeTemplateChanges("generic");
+      expect(after.find((c) => c.path === SKILL_LOCAL)?.status).toBe(
+        "local-override",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Reproduction (gate) first:** the literal `update --dry-run` "0 modified" vs apply-rewrites-everything divergence **does not reproduce** on `update`. It derives its summary and write-set from a single `computeTemplateChanges()` call, which already classifies a header-missing `SKILL.md` as `modified`. Verified against a pre-2.6.2-marker fixture: `update --dry-run` reports **17 modified**, never `0`.
- **Real gap = `sync`:** on a `.sequant-version` mismatch (e.g. an install predating the #711 / 2.6.2 `<!-- sequant:local-override -->` overlay header) `sync` runs `copyTemplates(force:true)` and silently rewrites the whole tree (+`AGENTS.md`) with **no preview and no `--dry-run`** — the untrustworthy-preview surface the issue is really about (the reporter's apply was `sync`, and/or `npx` version skew).
- **Fix:** add `sequant sync --dry-run` / `-d`. It reuses the same source of truth to report the exact set the apply would write — `new` + `modified` + `local-override` (the force copy overwrites in-place customizations, so they are counted, **never under-reported**), mutates nothing, and exits non-zero when work is pending so the preview can gate CI/automation. The override classifier stays keyed on a real `.claude/.local/` twin, not the in-band marker.

Scope respected the spec non-goals: no change to `update`, to `computeTemplateChanges`, or to the apply write-set itself.

## Pre-PR AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Preview never under-reports the apply write-set | ✅ | Live verify: `sync --dry-run` preview = 18 files, real apply changed 18. Tests in `sync.test.ts`. |
| AC-2 | Override classification keyed on real `.claude/.local/` twin, not the marker | ✅ | Existing `templates.ts:231-234` (unchanged); locked by new test in `templates.test.ts`. |
| AC-3 | Header-missing installed vs header-bearing template → `Modified` in preview | ✅ | New test in `templates.test.ts`; reproduced live (17 modified). |

## Files changed

- `src/commands/sync.ts` — `dryRun` option + preview guard before `copyTemplates`
- `bin/cli.ts` — register `-d, --dry-run` on `sync`
- `src/commands/sync.test.ts` — AC-1 dry-run tests
- `src/lib/templates.test.ts` — AC-2 / AC-3 regression tests
- `CHANGELOG.md`, `docs/reference/cheat-sheet.md` — document the flag

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npx vitest run` on sync/templates/update-integration/doctor/cli-integration — **102 passed**
- [x] Live fixture verify: `sync --dry-run` reports the full write-set, mutates nothing, exits 1; preview count equals real apply count

Closes #722