### PR TITLE
feat(driver): surface structured rate-limit/credits errors from SDK message stream (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Surface structured rate-limit / credits errors from the SDK message stream (#732)** — the Claude Agent SDK already emits structured `rate_limit_event` (`SDKRateLimitInfo`) and assistant `error` signals, but sequant dropped them on the floor and guessed rate limits via regex-on-stderr. The `ClaudeCodeDriver` stream loop now reads these signals and constructs a typed `RateLimitError` (retryable) or `BillingError` (non-retryable) — both new subclasses of `SequantError` carrying `resetsAt`, `overageDisabledReason`, and (on SDK ≥0.3.181) `canUserPurchaseCredits` / `hasChargeableSavedPaymentMethod`. The typed cause propagates through `AgentPhaseResult` → `PhaseResult` so a failed phase now names the real cause ("Out of credits — purchasable", "Rate limited — resets at HH:MM") instead of the generic, misleading `Phase failed with MCP enabled, retrying without MCP...` fallback noise (#592). A billing/credits failure also **skips** the pointless no-MCP retry — a retry cannot refill credits. The existing stderr-regex classifier is retained as the fallback for the subprocess path (`run.ts`), so non-SDK error classification is unchanged. (#732)
+
 ## [2.7.0] - 2026-06-10
 
 ### Added

--- a/__tests__/rate-limit-errors.test.ts
+++ b/__tests__/rate-limit-errors.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for structured rate-limit / billing errors (Issue #732).
+ *
+ * Covers AC-2 (RateLimitError/BillingError types + isRetryable), AC-3
+ * (user-facing message names the real cause), and AC-7 (≥0.3.181 enrichment
+ * with graceful gating).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  SequantError,
+  RateLimitError,
+  BillingError,
+  createRateLimitError,
+  formatRateLimitMessage,
+  isBillingFailure,
+  isRateLimitFailureInfo,
+  type RateLimitInfoLike,
+} from "../src/lib/errors.js";
+
+// === AC-2: error types, metadata, isRetryable ===
+
+describe("AC-2: RateLimitError / BillingError", () => {
+  it("RateLimitError extends SequantError and is retryable", () => {
+    const err = new RateLimitError("Rate limited", {
+      resetsAt: 1_700_000_000,
+      rateLimitType: "five_hour",
+    });
+    expect(err).toBeInstanceOf(SequantError);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.name).toBe("RateLimitError");
+    expect(err.isRetryable).toBe(true);
+    expect(err.metadata.resetsAt).toBe(1_700_000_000);
+    expect(err.metadata.rateLimitType).toBe("five_hour");
+  });
+
+  it("BillingError extends SequantError and is NOT retryable", () => {
+    const err = new BillingError("Out of credits", {
+      overageDisabledReason: "out_of_credits",
+    });
+    expect(err).toBeInstanceOf(SequantError);
+    expect(err).toBeInstanceOf(BillingError);
+    expect(err.name).toBe("BillingError");
+    expect(err.isRetryable).toBe(false);
+    expect(err.metadata.overageDisabledReason).toBe("out_of_credits");
+  });
+
+  it("serializes name + metadata through toJSON", () => {
+    const err = new BillingError("Out of credits — purchasable", {
+      overageDisabledReason: "out_of_credits",
+      canUserPurchaseCredits: true,
+    });
+    const json = JSON.parse(JSON.stringify(err.toJSON()));
+    expect(json.name).toBe("BillingError");
+    expect(json.isRetryable).toBe(false);
+    expect(json.metadata.canUserPurchaseCredits).toBe(true);
+  });
+});
+
+// === isBillingFailure / isRateLimitFailureInfo predicates ===
+
+describe("rate-limit failure predicates", () => {
+  it("isBillingFailure true for out_of_credits", () => {
+    expect(isBillingFailure({ overageDisabledReason: "out_of_credits" })).toBe(
+      true,
+    );
+  });
+
+  it("isBillingFailure true for credits_required errorCode", () => {
+    expect(isBillingFailure({ errorCode: "credits_required" })).toBe(true);
+  });
+
+  it("isBillingFailure false for a plain throttle", () => {
+    expect(isBillingFailure({ status: "rejected" })).toBe(false);
+  });
+
+  it("isRateLimitFailureInfo true for rejected status", () => {
+    expect(isRateLimitFailureInfo({ status: "rejected" })).toBe(true);
+  });
+
+  it("isRateLimitFailureInfo false for allowed_warning", () => {
+    expect(isRateLimitFailureInfo({ status: "allowed_warning" })).toBe(false);
+  });
+
+  it("isRateLimitFailureInfo true for billing even when status allowed", () => {
+    expect(
+      isRateLimitFailureInfo({
+        status: "allowed",
+        overageDisabledReason: "out_of_credits",
+      }),
+    ).toBe(true);
+  });
+});
+
+// === AC-3: user-facing message names the real cause ===
+
+describe("AC-3: formatRateLimitMessage", () => {
+  it("names a rate limit with reset time (HH:MM)", () => {
+    const info: RateLimitInfoLike = {
+      status: "rejected",
+      resetsAt: 1_700_000_000, // seconds
+      rateLimitType: "five_hour",
+    };
+    const msg = formatRateLimitMessage(info);
+    expect(msg).toMatch(/^Rate limited — resets at \d{2}:\d{2}$/);
+  });
+
+  it("falls back to plain 'Rate limited' when resetsAt is absent", () => {
+    expect(formatRateLimitMessage({ status: "rejected" })).toBe("Rate limited");
+  });
+
+  it("names out-of-credits for billing failures", () => {
+    expect(
+      formatRateLimitMessage({ overageDisabledReason: "out_of_credits" }),
+    ).toBe("Out of credits");
+  });
+
+  it("treats epoch-ms resetsAt the same as epoch-seconds", () => {
+    const seconds = 1_700_000_000;
+    const secMsg = formatRateLimitMessage({
+      status: "rejected",
+      resetsAt: seconds,
+    });
+    const msMsg = formatRateLimitMessage({
+      status: "rejected",
+      resetsAt: seconds * 1000,
+    });
+    expect(secMsg).toBe(msMsg);
+  });
+});
+
+// === AC-7: ≥0.3.181 enrichment + graceful gating ===
+
+describe("AC-7: createRateLimitError + 0.3.181 enrichment", () => {
+  it("builds BillingError for out_of_credits and enriches as purchasable", () => {
+    const err = createRateLimitError({
+      status: "rejected",
+      overageDisabledReason: "out_of_credits",
+      canUserPurchaseCredits: true,
+      hasChargeableSavedPaymentMethod: false,
+    });
+    expect(err).toBeInstanceOf(BillingError);
+    expect(err.isRetryable).toBe(false);
+    expect(err.message).toBe("Out of credits — purchasable");
+    expect(err.metadata.canUserPurchaseCredits).toBe(true);
+    expect(err.metadata.hasChargeableSavedPaymentMethod).toBe(false);
+  });
+
+  it("distinguishes a hard limit when purchasing is disallowed", () => {
+    const err = createRateLimitError({
+      status: "rejected",
+      errorCode: "credits_required",
+      canUserPurchaseCredits: false,
+    });
+    expect(err).toBeInstanceOf(BillingError);
+    expect(err.message).toBe("Out of credits — hard limit");
+  });
+
+  it("gates gracefully when 0.3.181 fields are absent (generic message)", () => {
+    const err = createRateLimitError({
+      status: "rejected",
+      overageDisabledReason: "out_of_credits",
+    });
+    expect(err).toBeInstanceOf(BillingError);
+    expect(err.message).toBe("Out of credits");
+    expect(err.metadata.canUserPurchaseCredits).toBeUndefined();
+  });
+
+  it("builds a retryable RateLimitError for transient throttles", () => {
+    const err = createRateLimitError({
+      status: "rejected",
+      resetsAt: 1_700_000_000,
+      rateLimitType: "five_hour",
+    });
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.isRetryable).toBe(true);
+    expect(err.message).toMatch(/^Rate limited — resets at \d{2}:\d{2}$/);
+  });
+});

--- a/__tests__/rate-limit-errors.test.ts
+++ b/__tests__/rate-limit-errors.test.ts
@@ -95,14 +95,27 @@ describe("rate-limit failure predicates", () => {
 // === AC-3: user-facing message names the real cause ===
 
 describe("AC-3: formatRateLimitMessage", () => {
-  it("names a rate limit with reset time (HH:MM)", () => {
+  it("date-qualifies a reset on a different day (MM-DD HH:MM)", () => {
+    // 1_700_000_000 (Nov 2023) is never "today", so the message must carry a
+    // date — bare HH:MM would misread a multi-day (seven_day) window as today.
     const info: RateLimitInfoLike = {
       status: "rejected",
-      resetsAt: 1_700_000_000, // seconds
-      rateLimitType: "five_hour",
+      resetsAt: 1_700_000_000, // seconds, far in the past
+      rateLimitType: "seven_day",
     };
     const msg = formatRateLimitMessage(info);
-    expect(msg).toMatch(/^Rate limited — resets at \d{2}:\d{2}$/);
+    expect(msg).toMatch(/^Rate limited — resets at \d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+
+  it("shows bare HH:MM for a same-day reset", () => {
+    // A reset later today is unambiguous without a date.
+    const today = new Date();
+    today.setHours(14, 30, 0, 0);
+    const msg = formatRateLimitMessage({
+      status: "rejected",
+      resetsAt: today.getTime(), // ms, today
+    });
+    expect(msg).toBe("Rate limited — resets at 14:30");
   });
 
   it("falls back to plain 'Rate limited' when resetsAt is absent", () => {
@@ -174,6 +187,9 @@ describe("AC-7: createRateLimitError + 0.3.181 enrichment", () => {
     });
     expect(err).toBeInstanceOf(RateLimitError);
     expect(err.isRetryable).toBe(true);
-    expect(err.message).toMatch(/^Rate limited — resets at \d{2}:\d{2}$/);
+    // Past timestamp → date-qualified.
+    expect(err.message).toMatch(
+      /^Rate limited — resets at \d{2}-\d{2} \d{2}:\d{2}$/,
+    );
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -173,6 +173,162 @@ export class SubprocessError extends SequantError {
   }
 }
 
+// ─── Rate-limit / billing errors (#732) ─────────────────────────────────────
+
+/**
+ * Metadata carried by {@link RateLimitError} / {@link BillingError}.
+ *
+ * Fields mirror the structured signals the Claude Agent SDK emits via
+ * `rate_limit_event` (`SDKRateLimitInfo`). The `canUserPurchaseCredits` /
+ * `hasChargeableSavedPaymentMethod` fields arrived in SDK 0.3.181 and are
+ * optional so older streams (or absent fields) degrade gracefully.
+ */
+export interface RateLimitMetadata {
+  [key: string]: unknown;
+  /** Unix timestamp (seconds or ms) at which the limit resets. */
+  resetsAt?: number;
+  /** Which limit window was hit (five_hour, seven_day, overage, …). */
+  rateLimitType?: string;
+  /** Why overage/billing was disabled (e.g. `out_of_credits`). */
+  overageDisabledReason?: string;
+  /** SDK error code; `credits_required` indicates a billing failure. */
+  errorCode?: string;
+  /** Whether the user can self-serve purchase credits (≥0.3.181). */
+  canUserPurchaseCredits?: boolean;
+  /** Whether a chargeable payment method is on file (≥0.3.181). */
+  hasChargeableSavedPaymentMethod?: boolean;
+}
+
+/**
+ * Transient rate-limit error (HTTP 429-style throttle, overloaded API).
+ *
+ * Retryable: waiting and re-running can succeed once the limit window resets.
+ */
+export class RateLimitError extends SequantError {
+  declare readonly metadata: RateLimitMetadata;
+
+  constructor(
+    message: string,
+    metadata: RateLimitMetadata = {},
+    cause?: Error,
+  ) {
+    super(message, { isRetryable: true, metadata, cause });
+    this.name = "RateLimitError";
+  }
+}
+
+/**
+ * Billing / out-of-credits error.
+ *
+ * NOT retryable: a no-MCP retry (or any retry) cannot refill credits, so the
+ * executor must surface the real cause instead of looping. Drives the #592
+ * fallback-noise skip in phase-executor.
+ */
+export class BillingError extends SequantError {
+  declare readonly metadata: RateLimitMetadata;
+
+  constructor(
+    message: string,
+    metadata: RateLimitMetadata = {},
+    cause?: Error,
+  ) {
+    super(message, { isRetryable: false, metadata, cause });
+    this.name = "BillingError";
+  }
+}
+
+/**
+ * Structural subset of the SDK's `SDKRateLimitInfo` consumed when building a
+ * rate-limit error. Declared here (not imported from the SDK) so `errors.ts`
+ * stays SDK-free — only the driver owns the `@anthropic-ai/claude-agent-sdk`
+ * import.
+ */
+export interface RateLimitInfoLike {
+  status?: string;
+  resetsAt?: number;
+  rateLimitType?: string;
+  overageDisabledReason?: string;
+  errorCode?: string;
+  canUserPurchaseCredits?: boolean;
+  hasChargeableSavedPaymentMethod?: boolean;
+}
+
+/**
+ * True when the rate-limit info represents a billing/credits failure (which a
+ * retry cannot fix), rather than a transient throttle.
+ */
+export function isBillingFailure(info: RateLimitInfoLike): boolean {
+  return (
+    info.errorCode === "credits_required" ||
+    info.overageDisabledReason === "out_of_credits"
+  );
+}
+
+/**
+ * True when the rate-limit info represents an actual failure (rejection or
+ * billing), as opposed to an informational `allowed` / `allowed_warning`
+ * event. The driver uses this to avoid mis-attributing a stale warning event
+ * to an unrelated phase failure.
+ */
+export function isRateLimitFailureInfo(info: RateLimitInfoLike): boolean {
+  return info.status === "rejected" || isBillingFailure(info);
+}
+
+/** Format a Unix timestamp (seconds or ms) as a local `HH:MM` string. */
+function formatResetTime(resetsAt: number): string {
+  // Heuristic: values below ~1e12 are seconds, otherwise milliseconds.
+  const ms = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+/**
+ * Build a user-facing message from rate-limit info, naming the real cause:
+ * - billing/credits → "Out of credits" (enriched with purchasable vs hard
+ *   limit when the ≥0.3.181 `canUserPurchaseCredits` field is present)
+ * - transient throttle → "Rate limited — resets at HH:MM" (reset time omitted
+ *   when `resetsAt` is absent)
+ */
+export function formatRateLimitMessage(info: RateLimitInfoLike): string {
+  if (isBillingFailure(info)) {
+    if (info.canUserPurchaseCredits === true) {
+      return "Out of credits — purchasable";
+    }
+    if (info.canUserPurchaseCredits === false) {
+      return "Out of credits — hard limit";
+    }
+    return "Out of credits";
+  }
+  if (info.resetsAt !== undefined) {
+    return `Rate limited — resets at ${formatResetTime(info.resetsAt)}`;
+  }
+  return "Rate limited";
+}
+
+/**
+ * Construct the appropriate typed error from structured rate-limit info.
+ * Billing/credits failures become a non-retryable {@link BillingError};
+ * transient throttles become a retryable {@link RateLimitError}.
+ */
+export function createRateLimitError(
+  info: RateLimitInfoLike,
+): RateLimitError | BillingError {
+  const message = formatRateLimitMessage(info);
+  const metadata: RateLimitMetadata = {
+    resetsAt: info.resetsAt,
+    rateLimitType: info.rateLimitType,
+    overageDisabledReason: info.overageDisabledReason,
+    errorCode: info.errorCode,
+    canUserPurchaseCredits: info.canUserPurchaseCredits,
+    hasChargeableSavedPaymentMethod: info.hasChargeableSavedPaymentMethod,
+  };
+  return isBillingFailure(info)
+    ? new BillingError(message, metadata)
+    : new RateLimitError(message, metadata);
+}
+
 /**
  * Map of error type names to their constructors.
  * Used for deserialization from logs.
@@ -192,4 +348,6 @@ export const ERROR_TYPE_MAP: Record<
   BuildError: BuildError as never,
   TimeoutError: TimeoutError as never,
   SubprocessError: SubprocessError as never,
+  RateLimitError: RateLimitError as never,
+  BillingError: BillingError as never,
 };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -274,22 +274,41 @@ export function isRateLimitFailureInfo(info: RateLimitInfoLike): boolean {
   return info.status === "rejected" || isBillingFailure(info);
 }
 
-/** Format a Unix timestamp (seconds or ms) as a local `HH:MM` string. */
+/**
+ * Format a Unix timestamp (seconds or ms) as a local time string.
+ *
+ * Bare `HH:MM` when the reset falls on the current local calendar day;
+ * date-qualified `MM-DD HH:MM` otherwise. Multi-day windows
+ * (`rateLimitType: seven_day*`) can reset days out — a bare `HH:MM` there reads
+ * as "later today" and misleads the user (#732 QA follow-up), so the date is
+ * included whenever the reset is not today.
+ */
 function formatResetTime(resetsAt: number): string {
   // Heuristic: values below ~1e12 are seconds, otherwise milliseconds.
   const ms = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
   const d = new Date(ms);
   const hh = String(d.getHours()).padStart(2, "0");
   const mm = String(d.getMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameDay) {
+    return `${hh}:${mm}`;
+  }
+  const mon = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${mon}-${day} ${hh}:${mm}`;
 }
 
 /**
  * Build a user-facing message from rate-limit info, naming the real cause:
  * - billing/credits → "Out of credits" (enriched with purchasable vs hard
  *   limit when the ≥0.3.181 `canUserPurchaseCredits` field is present)
- * - transient throttle → "Rate limited — resets at HH:MM" (reset time omitted
- *   when `resetsAt` is absent)
+ * - transient throttle → "Rate limited — resets at HH:MM" (date-qualified as
+ *   "MM-DD HH:MM" when the reset is not today; reset time omitted entirely when
+ *   `resetsAt` is absent)
  */
 export function formatRateLimitMessage(info: RateLimitInfoLike): string {
   if (isBillingFailure(info)) {

--- a/src/lib/workflow/drivers/agent-driver.ts
+++ b/src/lib/workflow/drivers/agent-driver.ts
@@ -6,6 +6,8 @@
  * interface without touching orchestration logic.
  */
 
+import type { SequantError } from "../../errors.js";
+
 /**
  * Resume handle for a previous agent session.
  *
@@ -67,6 +69,15 @@ export interface AgentPhaseResult {
   /** Driver-tagged resume handle for cwd-safe cross-phase resume (#674). */
   resumeHandle?: ResumeHandle;
   error?: string;
+  /**
+   * Typed error carrying structured cause data (#732). Set by drivers that can
+   * observe structured failure signals (e.g. ClaudeCodeDriver reading the SDK's
+   * `rate_limit_event` / assistant `error`). The executor prefers this over
+   * stderr-regex classification and uses its type to gate retry behavior (e.g.
+   * skipping the MCP fallback for non-retryable billing failures). Left
+   * undefined by drivers without structured signals (aider, subprocess paths).
+   */
+  structuredError?: SequantError;
   /** Last N lines of stderr captured via RingBuffer (#447) */
   stderrTail?: string[];
   /** Last N lines of stdout captured via RingBuffer (#447) */

--- a/src/lib/workflow/drivers/claude-code.test.ts
+++ b/src/lib/workflow/drivers/claude-code.test.ts
@@ -200,6 +200,60 @@ describe("ClaudeCodeDriver", () => {
       expect(result.error).toBe("generic failure");
     });
 
+    it("attaches structuredError when the stream throws after a rejected rate_limit_event (#732)", async () => {
+      // SDK surfaces a billing rejection, then the stream throws mid-iteration.
+      queryMock.mockReturnValue({
+        async *[Symbol.asyncIterator]() {
+          yield INIT;
+          yield {
+            type: "rate_limit_event",
+            rate_limit_info: {
+              status: "rejected",
+              overageDisabledReason: "out_of_credits",
+            },
+            uuid: "u1",
+            session_id: "sess-1",
+          };
+          throw new Error("stream connection reset");
+        },
+      });
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.success).toBe(false);
+      expect(result.structuredError).toBeInstanceOf(BillingError);
+      // Real cause preferred over the raw thrown message.
+      expect(result.error).toBe("Out of credits");
+    });
+
+    it("does NOT mask a genuine timeout/abort with a prior rate-limit signal (#732)", async () => {
+      // A rejected event was seen, but the throw is an abort → timeout wins.
+      queryMock.mockReturnValue({
+        async *[Symbol.asyncIterator]() {
+          yield INIT;
+          yield {
+            type: "rate_limit_event",
+            rate_limit_info: {
+              status: "rejected",
+              overageDisabledReason: "out_of_credits",
+            },
+            uuid: "u1",
+            session_id: "sess-1",
+          };
+          throw new Error("AbortError: operation aborted");
+        },
+      });
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.success).toBe(false);
+      // Abort path returns first — no structuredError, timeout message intact.
+      expect(result.structuredError).toBeUndefined();
+      expect(result.error).toMatch(/^Timeout after \d+s$/);
+    });
+
     it("leaves structuredError undefined on success", async () => {
       queryMock.mockReturnValue(
         mockStream([

--- a/src/lib/workflow/drivers/claude-code.test.ts
+++ b/src/lib/workflow/drivers/claude-code.test.ts
@@ -132,7 +132,44 @@ describe("ClaudeCodeDriver", () => {
       const err = result.structuredError as SequantError;
       expect(err).toBeInstanceOf(RateLimitError);
       expect(err.isRetryable).toBe(true);
-      expect(err.message).toMatch(/^Rate limited — resets at \d{2}:\d{2}$/);
+      // Past timestamp → date-qualified reset.
+      expect(err.message).toMatch(
+        /^Rate limited — resets at \d{2}-\d{2} \d{2}:\d{2}$/,
+      );
+    });
+
+    it("prefers billing over a transient rate_limit_event when the assistant reports billing_error (#732)", async () => {
+      // A transient (non-billing) throttle event AND a separate billing_error:
+      // the non-retryable billing cause must win so the MCP fallback is skipped.
+      queryMock.mockReturnValue(
+        mockStream([
+          INIT,
+          {
+            type: "rate_limit_event",
+            rate_limit_info: {
+              status: "rejected",
+              resetsAt: 1_700_000_000,
+              rateLimitType: "five_hour",
+            },
+            uuid: "u1",
+            session_id: "sess-1",
+          },
+          {
+            type: "assistant",
+            message: { content: [] },
+            error: "billing_error",
+          },
+          RESULT_ERROR,
+        ]),
+      );
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      const err = result.structuredError as SequantError;
+      expect(err).toBeInstanceOf(BillingError);
+      expect(err.isRetryable).toBe(false);
+      expect(result.error).toBe("Billing error");
     });
 
     it("falls back to the assistant error field when no rate_limit_event is present (AC-1, AC-6)", async () => {

--- a/src/lib/workflow/drivers/claude-code.test.ts
+++ b/src/lib/workflow/drivers/claude-code.test.ts
@@ -1,7 +1,55 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
 import { ClaudeCodeDriver } from "./claude-code.js";
+import {
+  RateLimitError,
+  BillingError,
+  type SequantError,
+} from "../../errors.js";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type { AgentExecutionConfig } from "./agent-driver.js";
+
+// Mock the SDK so we can drive arbitrary message streams through the driver
+// loop (#732). Only `query` is exercised by executePhase().
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+const queryMock = query as unknown as Mock;
+
+/** Build an async iterable that yields the given messages, like the SDK does. */
+function mockStream(messages: unknown[]): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const m of messages) {
+        yield m;
+      }
+    },
+  };
+}
+
+function baseConfig(): AgentExecutionConfig {
+  return {
+    cwd: "/tmp/wt",
+    env: {},
+    phaseTimeout: 60,
+    verbose: false,
+    mcp: false,
+  };
+}
+
+const INIT = { type: "system", subtype: "init", session_id: "sess-1" };
+const RESULT_ERROR = {
+  type: "result",
+  subtype: "error_during_execution",
+  errors: ["generic failure"],
+};
 
 describe("ClaudeCodeDriver", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
   it("has name 'claude-code'", () => {
     const driver = new ClaudeCodeDriver();
     expect(driver.name).toBe("claude-code");
@@ -18,5 +66,158 @@ describe("ClaudeCodeDriver", () => {
     expect(typeof driver.executePhase).toBe("function");
     expect(typeof driver.isAvailable).toBe("function");
     expect(typeof driver.name).toBe("string");
+  });
+
+  // === AC-1 / AC-6: stream loop reads rate_limit_event + assistant error ===
+
+  describe("structured rate-limit / billing capture (#732)", () => {
+    it("captures a billing rate_limit_event into a BillingError (AC-1, AC-6, AC-7)", async () => {
+      queryMock.mockReturnValue(
+        mockStream([
+          INIT,
+          {
+            type: "rate_limit_event",
+            rate_limit_info: {
+              status: "rejected",
+              overageDisabledReason: "out_of_credits",
+              errorCode: "credits_required",
+              canUserPurchaseCredits: true,
+            },
+            uuid: "u1",
+            session_id: "sess-1",
+          },
+          {
+            type: "assistant",
+            message: { content: [] },
+            error: "billing_error",
+          },
+          RESULT_ERROR,
+        ]),
+      );
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.success).toBe(false);
+      const err = result.structuredError as SequantError;
+      expect(err).toBeInstanceOf(BillingError);
+      expect(err.isRetryable).toBe(false);
+      // Real cause surfaced in both the typed error and the result.error string.
+      expect(err.message).toBe("Out of credits — purchasable");
+      expect(result.error).toBe("Out of credits — purchasable");
+    });
+
+    it("captures a transient rate_limit_event into a retryable RateLimitError (AC-6, AC-7)", async () => {
+      queryMock.mockReturnValue(
+        mockStream([
+          INIT,
+          {
+            type: "rate_limit_event",
+            rate_limit_info: {
+              status: "rejected",
+              resetsAt: 1_700_000_000,
+              rateLimitType: "five_hour",
+            },
+            uuid: "u1",
+            session_id: "sess-1",
+          },
+          RESULT_ERROR,
+        ]),
+      );
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.success).toBe(false);
+      const err = result.structuredError as SequantError;
+      expect(err).toBeInstanceOf(RateLimitError);
+      expect(err.isRetryable).toBe(true);
+      expect(err.message).toMatch(/^Rate limited — resets at \d{2}:\d{2}$/);
+    });
+
+    it("falls back to the assistant error field when no rate_limit_event is present (AC-1, AC-6)", async () => {
+      queryMock.mockReturnValue(
+        mockStream([
+          INIT,
+          { type: "assistant", message: { content: [] }, error: "rate_limit" },
+          RESULT_ERROR,
+        ]),
+      );
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.structuredError).toBeInstanceOf(RateLimitError);
+      expect(result.error).toBe("Rate limited");
+    });
+
+    it("captures api_retry diagnostics as a fallback signal (AC-6, optional)", async () => {
+      queryMock.mockReturnValue(
+        mockStream([
+          INIT,
+          {
+            type: "system",
+            subtype: "api_retry",
+            attempt: 1,
+            max_retries: 3,
+            retry_delay_ms: 500,
+            error_status: 429,
+            error: "overloaded",
+            uuid: "u1",
+            session_id: "sess-1",
+          },
+          RESULT_ERROR,
+        ]),
+      );
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.structuredError).toBeInstanceOf(RateLimitError);
+      expect(result.error).toBe("API overloaded");
+    });
+
+    it("does NOT attach a structured error for an informational allowed_warning event", async () => {
+      queryMock.mockReturnValue(
+        mockStream([
+          INIT,
+          {
+            type: "rate_limit_event",
+            rate_limit_info: { status: "allowed_warning", utilization: 0.8 },
+            uuid: "u1",
+            session_id: "sess-1",
+          },
+          RESULT_ERROR,
+        ]),
+      );
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.success).toBe(false);
+      expect(result.structuredError).toBeUndefined();
+      // Generic subtype text preserved when no structured cause exists.
+      expect(result.error).toBe("generic failure");
+    });
+
+    it("leaves structuredError undefined on success", async () => {
+      queryMock.mockReturnValue(
+        mockStream([
+          INIT,
+          {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "done" }] },
+          },
+          { type: "result", subtype: "success" },
+        ]),
+      );
+
+      const driver = new ClaudeCodeDriver();
+      const result = await driver.executePhase("prompt", baseConfig());
+
+      expect(result.success).toBe(true);
+      expect(result.structuredError).toBeUndefined();
+      expect(result.output).toBe("done");
+    });
   });
 });

--- a/src/lib/workflow/drivers/claude-code.ts
+++ b/src/lib/workflow/drivers/claude-code.ts
@@ -308,6 +308,14 @@ export class ClaudeCodeDriver implements AgentDriver {
    * otherwise the assistant-level `error`; otherwise the last `api_retry`
    * error. Returns undefined when no rate-limit/billing signal was seen, so
    * the executor falls back to stderr-regex classification.
+   *
+   * Exception: a non-retryable billing failure must never be downgraded to a
+   * retryable {@link RateLimitError}. If the `rate_limit_event` was only a
+   * transient throttle but the assistant separately reported `billing_error`,
+   * the billing cause wins — a retry cannot refill credits, and a
+   * RateLimitError would wrongly re-enable the retry / MCP-fallback path. When
+   * the `rate_limit_event` is itself a billing failure its richer metadata
+   * (`canUserPurchaseCredits`, etc.) is preserved.
    */
   private buildStructuredError(
     rateLimitInfo: SDKRateLimitInfo | undefined,
@@ -315,7 +323,11 @@ export class ClaudeCodeDriver implements AgentDriver {
     apiRetryError: SDKAssistantMessageError | undefined,
   ): SequantError | undefined {
     if (rateLimitInfo) {
-      return createRateLimitError(rateLimitInfo);
+      const err = createRateLimitError(rateLimitInfo);
+      if (err instanceof RateLimitError && assistantError === "billing_error") {
+        return new BillingError("Billing error");
+      }
+      return err;
     }
     return (
       this.errorFromAssistantError(assistantError) ??

--- a/src/lib/workflow/drivers/claude-code.ts
+++ b/src/lib/workflow/drivers/claude-code.ts
@@ -274,6 +274,17 @@ export class ClaudeCodeDriver implements AgentDriver {
         };
       }
 
+      // If the stream surfaced a failure-grade rate-limit/billing signal before
+      // throwing, prefer that typed cause (#732) over the raw thrown message — a
+      // mid-stream throw after a *rejected* rate_limit_event is very likely the
+      // proximate cause. Abort/timeout is handled above first, so a genuine
+      // timeout is never masked by a stale rate-limit signal.
+      const structuredError = this.buildStructuredError(
+        rateLimitInfo,
+        assistantError,
+        apiRetryError,
+      );
+
       const stderrSuffix = capturedStderr
         ? `\nStderr: ${capturedStderr.slice(0, 500)}`
         : "";
@@ -283,7 +294,8 @@ export class ClaudeCodeDriver implements AgentDriver {
         output: capturedOutput,
         sessionId: resultSessionId,
         resumeHandle: this.buildResumeHandle(resultSessionId, config.cwd),
-        error: error + stderrSuffix,
+        error: structuredError?.message ?? error + stderrSuffix,
+        structuredError,
         stderrTail: stderrBuffer.getLines(),
         stdoutTail: stdoutBuffer.getLines(),
       };

--- a/src/lib/workflow/drivers/claude-code.ts
+++ b/src/lib/workflow/drivers/claude-code.ts
@@ -6,8 +6,19 @@
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  SDKResultMessage,
+  SDKRateLimitInfo,
+  SDKAssistantMessageError,
+} from "@anthropic-ai/claude-agent-sdk";
 import { getMcpServersConfig } from "../../system.js";
+import {
+  type SequantError,
+  RateLimitError,
+  BillingError,
+  createRateLimitError,
+  isRateLimitFailureInfo,
+} from "../../errors.js";
 import { RingBuffer } from "../ring-buffer.js";
 import type {
   AgentDriver,
@@ -66,6 +77,17 @@ export class ClaudeCodeDriver implements AgentDriver {
     let resultMessage: SDKResultMessage | undefined;
     let capturedOutput = "";
     let capturedStderr = "";
+
+    // Structured rate-limit / billing signals captured from the SDK stream
+    // (#732). The SDK emits these but sequant previously dropped them on the
+    // floor, falling back to regex-on-stderr classification. We keep only the
+    // latest *failure-grade* rate-limit info (rejection or billing) so an
+    // informational `allowed_warning` event isn't mis-attributed to an
+    // unrelated phase failure.
+    let rateLimitInfo: SDKRateLimitInfo | undefined;
+    let assistantError: SDKAssistantMessageError | undefined;
+    // Last api_retry signal, captured opportunistically for diagnostics.
+    let apiRetryError: SDKAssistantMessageError | undefined;
     const stderrBuffer = new RingBuffer(50);
     const stdoutBuffer = new RingBuffer(50);
 
@@ -124,7 +146,31 @@ export class ClaudeCodeDriver implements AgentDriver {
           resultSessionId = message.session_id;
         }
 
+        // Capture structured rate-limit info (#732). Only retain
+        // failure-grade events (rejection / billing) so a benign warning
+        // doesn't poison the failure path.
+        if (
+          message.type === "rate_limit_event" &&
+          isRateLimitFailureInfo(message.rate_limit_info)
+        ) {
+          rateLimitInfo = message.rate_limit_info;
+        }
+
+        // Capture api_retry diagnostics (#732, optional). These are transient
+        // retries the SDK performs internally; recorded for the structured
+        // error fallback when no rate_limit_event/assistant error is present.
+        if (message.type === "system" && message.subtype === "api_retry") {
+          apiRetryError = message.error;
+        }
+
         if (message.type === "assistant") {
+          // Capture the assistant-level error field (#732) — `rate_limit`,
+          // `billing_error`, `overloaded`, etc. Previously discarded by the
+          // text-only content filter below.
+          if (message.error) {
+            assistantError = message.error;
+          }
+
           const content = message.message.content as Array<{
             type: string;
             text?: string;
@@ -156,6 +202,15 @@ export class ClaudeCodeDriver implements AgentDriver {
       // upgraded callers can still drive resume off the deprecated field.
       const resumeHandle = this.buildResumeHandle(resultSessionId, config.cwd);
 
+      // Build a typed error from structured SDK signals (#732). Present only
+      // when the stream surfaced a rate-limit/billing failure; otherwise
+      // undefined and the executor falls back to stderr-regex classification.
+      const structuredError = this.buildStructuredError(
+        rateLimitInfo,
+        assistantError,
+        apiRetryError,
+      );
+
       if (resultMessage) {
         if (resultMessage.subtype === "success") {
           return {
@@ -186,7 +241,10 @@ export class ClaudeCodeDriver implements AgentDriver {
           output: capturedOutput,
           sessionId: resultSessionId,
           resumeHandle,
-          error,
+          // Prefer the structured cause (e.g. "Out of credits") over the
+          // generic subtype text when available (#732).
+          error: structuredError?.message ?? error,
+          structuredError,
           stderrTail: stderrBuffer.getLines(),
           stdoutTail: stdoutBuffer.getLines(),
         };
@@ -197,7 +255,8 @@ export class ClaudeCodeDriver implements AgentDriver {
         output: capturedOutput,
         sessionId: resultSessionId,
         resumeHandle,
-        error: "No result received from Claude",
+        error: structuredError?.message ?? "No result received from Claude",
+        structuredError,
         stderrTail: stderrBuffer.getLines(),
         stdoutTail: stdoutBuffer.getLines(),
       };
@@ -228,6 +287,47 @@ export class ClaudeCodeDriver implements AgentDriver {
         stderrTail: stderrBuffer.getLines(),
         stdoutTail: stdoutBuffer.getLines(),
       };
+    }
+  }
+
+  /**
+   * Derive a typed {@link SequantError} from structured SDK failure signals
+   * (#732). Precedence: a captured `rate_limit_event` (richest signal) wins;
+   * otherwise the assistant-level `error`; otherwise the last `api_retry`
+   * error. Returns undefined when no rate-limit/billing signal was seen, so
+   * the executor falls back to stderr-regex classification.
+   */
+  private buildStructuredError(
+    rateLimitInfo: SDKRateLimitInfo | undefined,
+    assistantError: SDKAssistantMessageError | undefined,
+    apiRetryError: SDKAssistantMessageError | undefined,
+  ): SequantError | undefined {
+    if (rateLimitInfo) {
+      return createRateLimitError(rateLimitInfo);
+    }
+    return (
+      this.errorFromAssistantError(assistantError) ??
+      this.errorFromAssistantError(apiRetryError)
+    );
+  }
+
+  /**
+   * Map the SDK's assistant/api-retry error enum to a typed error. Only
+   * rate-limit / billing variants are mapped; other variants (auth, etc.)
+   * return undefined and defer to the existing classification path.
+   */
+  private errorFromAssistantError(
+    error: SDKAssistantMessageError | undefined,
+  ): SequantError | undefined {
+    switch (error) {
+      case "billing_error":
+        return new BillingError("Billing error");
+      case "rate_limit":
+        return new RateLimitError("Rate limited");
+      case "overloaded":
+        return new RateLimitError("API overloaded");
+      default:
+        return undefined;
     }
   }
 

--- a/src/lib/workflow/phase-executor.test.ts
+++ b/src/lib/workflow/phase-executor.test.ts
@@ -22,6 +22,7 @@ import {
 import type { ExecutionConfig, PhaseResult } from "./types.js";
 import type { AgentPhaseResult } from "./drivers/index.js";
 import { ShutdownManager } from "../shutdown.js";
+import { BillingError, RateLimitError } from "../errors.js";
 
 // Mock agents-md module
 vi.mock("../agents-md.js", () => ({
@@ -641,6 +642,110 @@ describe("executePhaseWithRetry", () => {
     expect(result.success).toBe(false);
     // Only 3 calls (no MCP fallback since mcp was already false)
     expect(executePhaseFn).toHaveBeenCalledTimes(3);
+  });
+
+  // === #732: structured rate-limit / billing errors ===
+
+  it("surfaces the structured cause and skips MCP fallback for a billing failure (AC-3, AC-4)", async () => {
+    // Genuine failure (>= 60s) carrying a non-retryable BillingError.
+    const executePhaseFn = vi.fn().mockResolvedValue(
+      makeResult({
+        durationSeconds: 120,
+        error: "Out of credits",
+        structuredError: new BillingError("Out of credits", {
+          overageDisabledReason: "out_of_credits",
+        }),
+      }),
+    );
+
+    const result = await executePhaseWithRetry(
+      1,
+      "exec",
+      baseConfig, // mcp: true
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      executePhaseFn,
+    );
+
+    expect(result.success).toBe(false);
+    // AC-3: real cause surfaced, not generic #592 fallback noise.
+    expect(result.error).toBe("Out of credits");
+    // AC-4: billing failure must NOT trigger the no-MCP retry — single call,
+    // and no call was ever made with mcp disabled.
+    expect(executePhaseFn).toHaveBeenCalledTimes(1);
+    const mcpDisabledCall = executePhaseFn.mock.calls.find(
+      (call) => (call[2] as ExecutionConfig).mcp === false,
+    );
+    expect(mcpDisabledCall).toBeUndefined();
+  });
+
+  it("skips MCP fallback for a cold-start-range billing failure (AC-4)", async () => {
+    // Billing failure that lands in the cold-start window: cold-start retries
+    // run, but the MCP fallback after them must still be skipped.
+    const billing = () =>
+      makeResult({
+        durationSeconds: 5,
+        error: "Out of credits",
+        structuredError: new BillingError("Out of credits", {
+          overageDisabledReason: "out_of_credits",
+        }),
+      });
+    const executePhaseFn = vi
+      .fn()
+      .mockResolvedValueOnce(billing())
+      .mockResolvedValueOnce(billing())
+      .mockResolvedValueOnce(billing());
+
+    const result = await executePhaseWithRetry(
+      1,
+      "exec",
+      baseConfig, // mcp: true
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      executePhaseFn,
+    );
+
+    expect(result.success).toBe(false);
+    // 3 cold-start attempts, NO 4th mcp-disabled fallback call.
+    expect(executePhaseFn).toHaveBeenCalledTimes(3);
+    const mcpDisabledCall = executePhaseFn.mock.calls.find(
+      (call) => (call[2] as ExecutionConfig).mcp === false,
+    );
+    expect(mcpDisabledCall).toBeUndefined();
+  });
+
+  it("still retries a transient rate-limit failure (RateLimitError is retryable)", async () => {
+    // Genuine-duration failure with a retryable RateLimitError → one more
+    // attempt is allowed, unlike the non-retryable billing case.
+    const executePhaseFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResult({
+          durationSeconds: 120,
+          structuredError: new RateLimitError("Rate limited — resets at 14:30"),
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResult({ success: true, durationSeconds: 130 }),
+      );
+
+    const result = await executePhaseWithRetry(
+      1,
+      "exec",
+      baseConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      executePhaseFn,
+    );
+
+    expect(result.success).toBe(true);
+    expect(executePhaseFn).toHaveBeenCalledTimes(2);
   });
 
   it("returns original error when MCP fallback also fails", async () => {

--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -28,7 +28,7 @@ import type {
   ResumeHandle,
 } from "./drivers/index.js";
 import { classifyError } from "./error-classifier.js";
-import { ApiError } from "../errors.js";
+import { ApiError, BillingError } from "../errors.js";
 import { phaseRegistry } from "./phase-registry.js";
 import { bracketedConsoleLog } from "./notice.js";
 
@@ -756,6 +756,9 @@ async function executePhase(
     success: false,
     durationSeconds,
     error: agentResult.error,
+    // Propagate the driver's typed cause (#732) so the retry logic can prefer
+    // it over stderr-regex classification and gate the MCP fallback.
+    structuredError: agentResult.structuredError,
     sessionId: agentResult.sessionId,
     resumeHandle: agentResult.resumeHandle,
     stderrTail: agentResult.stderrTail,
@@ -860,10 +863,12 @@ export async function executePhaseWithRetry(
       // Use error classification (AC-9): if the error is retryable (e.g., API
       // rate limit, transient 503), allow one more attempt even for genuine failures.
       if (duration >= COLD_START_THRESHOLD_SECONDS) {
-        const typedError = classifyError(
-          lastResult.stderrTail ?? [],
-          lastResult.exitCode,
-        );
+        // Prefer the driver's structured cause (#732) — it reflects the real
+        // SDK rate-limit/billing signal — over stderr-regex classification,
+        // which only sees text and never the structured data.
+        const typedError =
+          lastResult.structuredError ??
+          classifyError(lastResult.stderrTail ?? [], lastResult.exitCode);
         if (typedError.isRetryable && attempt < COLD_START_MAX_RETRIES) {
           if (config.verbose) {
             const label =
@@ -905,7 +910,18 @@ export async function executePhaseWithRetry(
   // Phase 2: MCP fallback - if MCP is enabled and we're still failing, try without MCP
   // This handles npx-based MCP servers that fail on first run due to cold-cache issues.
   // Skip for `loop` phase — MCP is never the cause of loop failures (#488).
-  if (config.mcp && !lastResult!.success && !skipColdStartRetry) {
+  //
+  // Also skip when the failure is a billing/credits error (#732): a no-MCP
+  // retry cannot refill credits, so the misleading "retrying without MCP"
+  // noise (#592) would only mask the real cause. The accurate structured
+  // message (e.g. "Out of credits") is surfaced instead.
+  const isBillingFailure = lastResult!.structuredError instanceof BillingError;
+  if (
+    config.mcp &&
+    !lastResult!.success &&
+    !skipColdStartRetry &&
+    !isBillingFailure
+  ) {
     bracketedConsoleLog(
       spinner,
       chalk.yellow(

--- a/src/lib/workflow/phase-executor.ts
+++ b/src/lib/workflow/phase-executor.ts
@@ -915,12 +915,12 @@ export async function executePhaseWithRetry(
   // retry cannot refill credits, so the misleading "retrying without MCP"
   // noise (#592) would only mask the real cause. The accurate structured
   // message (e.g. "Out of credits") is surfaced instead.
-  const isBillingFailure = lastResult!.structuredError instanceof BillingError;
+  const failureIsBilling = lastResult!.structuredError instanceof BillingError;
   if (
     config.mcp &&
     !lastResult!.success &&
     !skipColdStartRetry &&
-    !isBillingFailure
+    !failureIsBilling
   ) {
     bracketedConsoleLog(
       spinner,

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -8,6 +8,7 @@ import type { LogWriter } from "./log-writer.js";
 import type { StateManager } from "./state-manager.js";
 import type { ShutdownManager } from "../shutdown.js";
 import type { WorktreeInfo } from "./worktree-manager.js";
+import type { SequantError } from "../errors.js";
 
 // Importing the registry triggers its side-effect registrations (built-ins
 // live at the bottom of phase-registry.ts), guaranteeing the registry is
@@ -210,6 +211,13 @@ export interface PhaseResult {
   success: boolean;
   durationSeconds?: number;
   error?: string;
+  /**
+   * Typed error with structured cause data, propagated from the driver's
+   * `AgentPhaseResult.structuredError` (#732). When present, the retry logic
+   * prefers it over stderr-regex classification and uses its type to gate the
+   * MCP fallback (a `BillingError` skips the misleading retry — #592).
+   */
+  structuredError?: SequantError;
   /** Captured output from the phase (used for parsing spec recommendations) */
   output?: string;
   /** Parsed QA verdict (only for qa phase) */


### PR DESCRIPTION
## Summary

- The Claude Agent SDK already emits structured `rate_limit_event` (`SDKRateLimitInfo`) and assistant `error` signals, but sequant dropped them at the `ClaudeCodeDriver` stream chokepoint and guessed rate limits via regex-on-stderr. The driver now reads these signals and constructs a typed `RateLimitError` (retryable) or `BillingError` (non-retryable).
- The typed cause propagates through `AgentPhaseResult.structuredError` → `PhaseResult.structuredError`, so a failed phase names the real cause ("Out of credits — purchasable", "Rate limited — resets at HH:MM") instead of the generic, misleading `Phase failed with MCP enabled, retrying without MCP...` noise (#592).
- A billing/credits failure now **skips** the no-MCP retry — a retry cannot refill credits. The stderr-regex classifier is retained as the subprocess (`run.ts`) fallback, so non-SDK classification is unchanged.

## Pre-PR AC Verification

| AC | Source | Description | Status | Evidence |
|----|--------|-------------|--------|----------|
| AC-1 | Original | Stream loop reads `rate_limit_event` + assistant `error` instead of discarding | ✅ | `claude-code.ts` capture vars + `claude-code.test.ts` |
| AC-2 | Original | `RateLimitError`/`BillingError` extend `SequantError`, carry `resetsAt`+`overageDisabledReason`, correct `isRetryable` | ✅ | `errors.ts`; `rate-limit-errors.test.ts` |
| AC-3 | Original | User-facing message names the real cause | ✅ | driver sets `error: structuredError.message`; `phase-executor.test.ts` |
| AC-4 | Original | Billing/credits failure does NOT trigger "retrying without MCP" (#592) | ✅ | `BillingError` guard at MCP fallback; `phase-executor.test.ts` (2 tests) |
| AC-5 | Original | Stderr-regex classifier still works for subprocess path — no regression | ✅ | `error-types.test.ts` + `error-capture.test.ts` unchanged & green |
| AC-6 | Original | Unit coverage drives new message types through the loop | ✅ | `claude-code.test.ts` (rate_limit_event, assistant.error, api_retry) |
| AC-7 | Original | ≥0.3.181 enrichment (`canUserPurchaseCredits`/`hasChargeableSavedPaymentMethod`) with graceful gating | ✅ | `formatRateLimitMessage`; `rate-limit-errors.test.ts` |
| AC-8 | Part 3 | Working tree synced to origin/main, SDK 0.3.181 installed | ✅ | Precondition — already met (SDK `sdk.d.ts` exposes the 0.3.181 fields) |

## Test plan

- [x] `npm run build` — passes (tsc clean)
- [x] `npm run lint` — passes (0 warnings)
- [x] Targeted tests: `rate-limit-errors`, `claude-code`, `phase-executor`, `error-types`, `error-capture` — 218 passed
- [x] Workflow-layer sweep — 41 files, 1003 passed / 2 skipped

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)