### PR TITLE
docs(#762): explain the chain content pre-flight

### DIFF
--- a/docs/reference/run-command.md
+++ b/docs/reference/run-command.md
@@ -255,6 +255,52 @@ gh pr merge 3 --squash
 Option B: Single combined review
 - Review the final branch which contains all changes
 
+### Chain Pre-flight
+
+Every `--chain` run of 2+ issues starts with a content pre-flight. It reads each
+issue once and points out cheap, high-cost-to-miss problems **before the first
+worktree is provisioned** — an unready or mis-ordered chain is much cheaper to
+fix at the front door than after three worktrees exist.
+
+It warns on four things:
+
+| Warning | Fires when |
+|---------|------------|
+| Missing AC | An issue has no Acceptance Criteria section, or the section has no checklist items |
+| Dependency order | An issue declares `Blocked by #N` / `Depends on: #N` and #N runs *after* it in your CLI order |
+| File-overlap order | Two issues are predicted to modify the same file, and your CLI order contradicts the ascending land order (the same prediction `/assess` shows) |
+| Closed issue | An issue is already CLOSED on GitHub |
+
+**Warnings never block by default.** They are advice, not a gate — a warning
+usually means "look at this", not "you are wrong". Order that looks odd to the
+pre-flight is often deliberate.
+
+```text
+  ⚠ #39 declares it is blocked by / depends on #38, but #38 runs AFTER #39 in
+    the chain order — reorder so #38 comes first.
+```
+
+The checks run against the order **you typed**, not the dependency-sorted order,
+so `sequant run 39 38 --chain` still warns even though the sorter would have
+reordered it anyway. The point is to tell you the declared order and your order
+disagree.
+
+Only line-leading markers count as declarations, so prose that merely mentions
+`blocked by #N` mid-sentence — or shows it inside a code fence — is ignored.
+
+**Making warnings fatal:**
+
+Add `--strict-preflight` to turn any warning into a hard stop, exiting `1`
+before provisioning anything. Useful in CI, where an unready chain should fail
+loudly rather than burn a runner:
+
+```bash
+npx sequant run 38 39 40 --chain --strict-preflight
+```
+
+If `gh` cannot fetch an issue, that issue's checks are skipped with a note — the
+pre-flight never fails a run on its own.
+
 ### Stacked PRs
 
 `--stacked` builds on `--chain` and changes only one thing: each non-first PR


### PR DESCRIPTION
Follow-up to #762 / PR #764.

PR #764 added `--strict-preflight` to the two flag tables, which documented the *switch* but not the *behavior*. The pre-flight prints up to four distinct warning classes at chain start, and a user seeing one had nowhere to look up what triggered it or whether to act on it.

This adds a **Chain Pre-flight** section to `run-command.md`, placed between Chain Mode and Stacked PRs. It follows how `--qa-gate` is already documented — flag row plus a narrative section — which is the closest comparable chain flag.

Covers:
- the four warning classes and what fires each
- warn-by-default framing (advice, not a gate — odd-looking order is often deliberate)
- why checks run against the **typed** order, not the dep-sorted one
- the line-leading marker rule (prose mentions and in-fence examples are ignored)
- `--strict-preflight` for CI, with the sample warning quoted verbatim from the code

**Verified against shipped code**, not from memory: the `chain && issueNumbers.length > 1` gate, `exitCode: 1`, all four `kind:` values, the fetch-degrade note, and the example warning text matching the message template character-for-character.

**On style:** table and line-length match the file's existing tables. `markdownlint` is not wired to CI, and this file already carries 46 MD060 and 37 MD013 violations of the same kind — conforming only this section would make it the one table formatted differently.

Docs-only; no code paths touched.
