### PR TITLE
docs: note why the two body-strip helpers must not be unified

### DIFF
--- a/src/lib/assess-collision-detect.ts
+++ b/src/lib/assess-collision-detect.ts
@@ -92,6 +92,13 @@ const THREE_DIR_SYNC_PATTERN =
  * single-backtick wrapper, so this gives us the "paths quoted as code in
  * prose count, paths inside a code block don't" behavior the AC-5 guard
  * specifies.
+ *
+ * Do NOT unify this with `chain-preflight.ts:stripCodeAndComments`, which
+ * looks nearly identical but additionally strips inline spans. The two have
+ * opposite requirements for the same syntax: there a backticked marker is a
+ * documentation example to discard, here a backticked path is the entire
+ * signal. Adding its inline-span strip to this function would delete every
+ * path PATH_REGEX is looking for and silently return an empty set.
  */
 function stripCodeBlocksAndComments(body: string): string {
   return body.replace(/```[\s\S]*?```/g, "").replace(/<!--[\s\S]*?-->/g, "");

--- a/src/lib/workflow/chain-preflight.ts
+++ b/src/lib/workflow/chain-preflight.ts
@@ -84,6 +84,12 @@ const BLOCKER_MARKER_REGEX =
  * markers inside quoted shell snippets, documentation examples, or commented-out
  * drafts don't count as real declarations. Inline spans are matched within a
  * single line so an unbalanced backtick cannot swallow the rest of the body.
+ *
+ * Deliberately diverges from `assess-collision-detect.ts:stripCodeBlocksAndComments`,
+ * which keeps inline spans: its PATH_REGEX only matches backtick-wrapped paths,
+ * so stripping them there would find nothing. Same syntax, opposite meaning —
+ * a backticked marker here is an example, a backticked path there is the target.
+ * Keep the two separate.
  */
 function stripCodeAndComments(body: string): string {
   return body


### PR DESCRIPTION
Comments only — no behavior change.

`chain-preflight.ts:stripCodeAndComments` and `assess-collision-detect.ts:stripCodeBlocksAndComments` are near-identical in name and body, differing only by an inline-code-span strip. They read as obvious DRY bait. The divergence is required: the two modules have **opposite requirements for the same syntax**.

- In the pre-flight, a backticked marker is a documentation example → strip it.
- In the collision detector, a backticked path is the entire signal — `PATH_REGEX` only matches backtick-wrapped paths → keep it.

Unifying them on the pre-flight's version silently kills path extraction:

```
current:                [ 'src/lib/foo.ts', 'bin/cli.ts' ]
with inline-span strip: []
```

The detector's 15 tests would fail on that change, so this is a signpost rather than a missing guard — it saves the next reader the round trip. Each function now cross-references the other with the reason.

Came out of asking whether anything from #762 needed consolidating; this was the one candidate that looked consolidatable and specifically must not be.

**Heads-up:** the unmerged local branch `chore/chain-suggestion-annotation` also touches `assess-collision-detect.ts` (`formatCollisionAnnotations`). Different function, so no conflict expected, but worth knowing if both land.
