### PR TITLE
docs(reflect): localize the skill; drop the CLAUDE.md line target

### DIFF
--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -120,21 +120,35 @@ For each proposal, specify:
 
 ### **Documentation Health Check**
 
-Review CLAUDE.md size and relevance:
-- Current line count (target: 700-800)
-- Sections that feel bloated
-- Sections that are missing
-- Redundancy check
-- Extract candidates (sections >50 lines)
-- Recommendation: [Prune | Expand | Restructure | Extract | Good as-is]
+**CLAUDE.md is an index, not a knowledge store.** Durable knowledge belongs in
+auto-memory, `docs/`, or the relevant skill; CLAUDE.md holds only what must be
+loaded into *every* session (commit rules, hook gotchas, skill-invocation
+rules). A short CLAUDE.md is a sign the other tiers are doing their job — do
+**not** recommend padding it toward some line count. There is no target length.
+
+Review CLAUDE.md relevance:
+- Does every line still apply, and is it still accurate?
+- Anything that only matters in one workflow → move to that skill or `docs/`
+- Anything that is durable session-to-session context → auto-memory
+- Redundancy check (same rule stated here and in a skill)
+- Extract candidates (sections >50 lines — CLAUDE.md should rarely have any)
+- Recommendation: [Prune | Restructure | Extract | Good as-is]
+
+Also check the **memory** tier, which carries most of this repo's knowledge:
+- Entries citing script flags, CLI behavior, or `file:line` **rot silently** —
+  spot-check any entry you relied on this session against current code and fix
+  it. A wrong memory is worse than a missing one.
+- Index (`MEMORY.md`) one-liners still accurate?
 
 ### **Action Items**
 
-Generate a checklist:
-- [ ] Add section to CLAUDE.md: [topic]
-- [ ] Update slash command: [command name]
-- [ ] Move to docs/archive/: [file name]
-- [ ] Create new command: [command name]
+Generate a checklist. Prefer concrete targets — a file, a memory entry, a
+command — over intentions:
+- [ ] Correct/remove a stale memory entry: [name] (verify against current code first)
+- [ ] Add a memory entry for: [durable lesson]
+- [ ] Update skill: [name] — remember all three skill dirs
+- [ ] Update docs: [path] (check main README + marketplace README + docs/)
+- [ ] Add a pointer to CLAUDE.md: [one line + link] — only if needed most sessions
 - [ ] Remove outdated content: [location]
 
 ## Workflow Analytics
@@ -172,7 +186,7 @@ At the end of reflection, ask:
 - [ ] **Session Summary** - What was accomplished, what went well, friction points
 - [ ] **Effectiveness Analysis** - Token efficiency, context gathering, pattern reuse
 - [ ] **Proposed Changes** - Specific changes with target files and rationale
-- [ ] **Documentation Health** - Line count, bloat assessment, recommendations
+- [ ] **Documentation Health** - CLAUDE.md relevance/accuracy (not length) + memory-tier rot check
 - [ ] **Action Items** - Checklist of concrete next steps
 
 **DO NOT respond until all items are verified.**

--- a/.claude/skills/reflect/references/documentation-tiers.md
+++ b/.claude/skills/reflect/references/documentation-tiers.md
@@ -1,70 +1,82 @@
 # Documentation Tiers
 
-Organize information by access frequency:
+Where knowledge lives in this repo, by how often it's needed and how long it stays true.
 
-## Tier 1: Hot Path (CLAUDE.md)
+**There are no line-count targets.** Judge a tier by whether the right reader
+finds the right thing, not by size. A short CLAUDE.md means the other tiers are
+working, not that it needs filling.
 
-- Used in 50%+ of sessions
-- Core architecture decisions
-- Most common commands and patterns
-- **Target: 700-800 lines** (check with `wc -l CLAUDE.md`)
-- Quick summaries with links to detailed docs
-- Review monthly
+## Tier 1: CLAUDE.md — the always-loaded index
 
-**Keep in CLAUDE.md:**
-- ✅ Core architecture patterns (database, routing, components)
-- ✅ Most common commands (development, discovery, enrichment)
-- ✅ Critical patterns (validation, audit logging, state management)
-- ✅ Quick reference information needed in 50%+ of sessions
+Loaded into **every** session, so everything here is a tax on every session.
 
-## Tier 2: Reference (docs/ folder)
+**Keep only:**
+- ✅ Rules with no natural home in a skill or doc (commit conventions, hook gotchas)
+- ✅ Pointers — a one-line "here's the trap, here's the link"
+- ✅ Things that are wrong to learn late (e.g. skill-invocation namespacing)
 
-- Used in 10-50% of sessions
-- Detailed specs, schemas, guides
-- Can be 1000+ lines per doc
-- Review quarterly
+**Move out:**
+- ❌ Anything that matters in one workflow → that skill
+- ❌ Anything explanatory or >~10 lines → `docs/` and link to it
+- ❌ Session-to-session context about *this developer's* work → auto-memory
 
-**Current specialized docs:**
-- `ARCHITECTURE.md` - System architecture overview
-- `DATA_PIPELINE.md` - Data processing workflows
-- `TESTING.md` - Testing patterns and strategies
-- `ADMIN_CMS_ARCHITECTURE.md` - Full CMS architecture
+## Tier 2: Auto-memory — the main knowledge store
 
-## Tier 3: Archive (docs/archive/)
+`~/.claude/projects/<project>/memory/`, indexed by `MEMORY.md`. This is where
+most of this repo's hard-won knowledge actually lives (100+ entries): pitfalls,
+feedback, architecture decisions, roadmap state.
 
-- Used in <10% of sessions
-- Historical context, deprecated patterns
-- Move here after 6 months of non-use
-- Keep for searchability, not active use
+- One fact per file; `MEMORY.md` carries a one-line pointer.
+- Best tier for "I learned this the hard way and would re-learn it otherwise".
 
-## Tier 4: Code Comments
+**Its failure mode is rot, not bloat.** Entries citing script flags, CLI
+behavior, or `file:line` go stale silently, and a *wrong* memory is worse than a
+missing one — it gets trusted. Verify before asserting; fix on sight.
 
-- Implementation-specific details
-- Edge case handling
-- Why certain approaches were chosen
-- Lives with the code, not in docs
+## Tier 3: docs/ — reference for humans
 
-## When to Extract to Separate Docs
+Real structure: `concepts/`, `features/`, `guides/`, `reference/`,
+`getting-started/`, `examples/`, `internal/`, `incidents/`, `investigations/`.
 
-Move from CLAUDE.md to docs/ when:
-- ✅ Section exceeds 50 lines
-- ✅ Contains detailed workflow steps (>3 steps)
-- ✅ Has extensive examples or command variations
-- ✅ Used occasionally but not in every session
-- ✅ Could evolve independently
+- Detailed specs, architecture, runbooks. Length is fine here.
+- User-facing behavior changes must land here, and often in **more than one
+  place** — check the main README, the marketplace README, and `docs/`.
+- Review when the behavior it describes changes, not on a calendar.
 
-## Documentation Health Metrics
+## Tier 4: Skills — workflow instructions
 
-**CLAUDE.md Health Check:**
-- Current line count vs target (700-800)
-- Lines added in last month
-- Sections that feel bloated
-- Sections that are missing
-- Redundancy between CLAUDE.md and docs/
+`skills/`, `templates/skills/`, `.claude/skills/` — **three real copies**;
+fix all three or `sequant init`/`update` regenerates the bug (CI enforces this
+via `npm run lint:skill-sync`).
 
-**Recommendations:**
-- **Prune:** >900 lines, multiple bloated sections
-- **Expand:** <600 lines, missing critical patterns
-- **Restructure:** Hard to find information
-- **Extract:** Multiple sections >50 lines
-- **Good as-is:** 700-800 lines, balanced content
+- Procedure a skill must follow belongs in its `SKILL.md`.
+- Detail a skill needs only sometimes → its `references/`, linked from `SKILL.md`.
+- **When editing a SKILL.md, grep its `references/` for the same claim.** Prose
+  specs of a rule drift out of sync with the rule itself.
+
+## Tier 5: Code comments
+
+Constraints the code can't show — why this approach, what breaks otherwise.
+Not what the next line does, and not where it came from.
+
+## When to extract from CLAUDE.md
+
+- ✅ It's explanatory rather than a pointer
+- ✅ It only applies to one workflow or one command
+- ✅ It has examples, steps, or rationale
+- ✅ It could evolve independently of the rest
+
+## Health check
+
+**CLAUDE.md:** is every line still true, still needed in *most* sessions, and
+not duplicated in a skill? Recommend `Prune | Restructure | Extract | Good as-is`
+— never "Expand".
+
+**Memory:** spot-check entries relied on this session against current code.
+Are `MEMORY.md` one-liners still accurate? Any entry superseded by shipped work?
+
+**docs/:** does anything contradict what shipped? Behavior changes are the usual
+source of drift.
+
+**Skills:** are the three copies in sync, and does each `SKILL.md` agree with its
+own `references/`?

--- a/.claude/skills/reflect/references/phase-reflection.md
+++ b/.claude/skills/reflect/references/phase-reflection.md
@@ -70,26 +70,42 @@ Focus on QA/review effectiveness after `/qa`:
 
 ## Good Reflection Examples
 
-### Documentation Improvement
+Note what these have in common: each names a **specific file and a specific
+wrong line**, and each was *verified* before being proposed. A reflection that
+proposes fixing something you have not opened is a guess.
 
-> **Friction Point:** Spent 10 minutes searching for how neighborhood extraction works across multiple files.
+### Correcting a stale memory
+
+> **Friction Point:** Followed a memory that prescribed `echo y | cleanup-worktree.sh`; the script had since grown a real `--yes` flag and a merge gate (#750).
 >
-> **Root Cause:** Process is documented in docs/AUTO_NEIGHBORHOOD_ENRICHMENT.md (tier 2) but not referenced in CLAUDE.md's discovery pipeline section (tier 1).
+> **Root Cause:** Memory entries citing script flags rot silently when the script ships a change. The entry read as authoritative and was 67 days old.
 >
 > **Proposal:**
-> - **Type:** Add
-> - **Target:** CLAUDE.md, line 230 (Discovery Methods section)
-> - **Content:** Add one-line reference: "Neighborhoods auto-extracted via ZIP mapping (see docs/AUTO_NEIGHBORHOOD_ENRICHMENT.md)"
+> - **Type:** Update
+> - **Target:** `feedback_cleanup_worktree_after_gh_merge`
+> - **Content:** Replace the `echo y |` workaround with the shipped flags; add the `--delete-branch`-fails-when-a-worktree-holds-the-branch trap.
+> - **Priority:** High (a wrong memory is worse than a missing one — it gets trusted)
+> - **Risk:** Low (verified against the script's `--help` first)
+
+### Retiring guidance that a skill already implements
+
+> **Friction Point:** Was about to propose adding a diff-size threshold to `/qa` so small diffs skip sub-agents.
+>
+> **Root Cause:** The proposal was based on the skill text actually executed, which came from a **stale plugin cache** (1.20.3) rather than the repo (2.8.0). The repo's `/qa` already has the size gate. Invoking `sequant:qa` resolves to the installed plugin; bare `qa` resolves to `.claude/skills/`.
+>
+> **Proposal:**
+> - **Type:** Withdraw + document the routing trap
+> - **Target:** the proposal itself; memory entry for the skew
+> - **Priority:** High (the finding was an artifact, and acting on it would have duplicated shipped work)
+> - **Risk:** None — verification *removed* work rather than adding it
+
+### Pruning content inherited from another project
+
+> **Bloat:** `references/documentation-tiers.md` prescribed a 700–800 line CLAUDE.md target and named `ARCHITECTURE.md`, `DATA_PIPELINE.md`, `ADMIN_CMS_ARCHITECTURE.md` as "current docs". None exist here; CLAUDE.md is 13 lines by design. Its "**Expand:** <600 lines" rule would have demanded ~590 lines of invented content.
+>
+> **Proposal:**
+> - **Type:** Restructure
+> - **Target:** `references/documentation-tiers.md` (×3 skill dirs)
+> - **Action:** Rewrite around this repo's real tiers (CLAUDE.md index → auto-memory → `docs/` → skills → code comments); drop all line targets.
 > - **Priority:** Medium
-> - **Risk:** Low (just adding a signpost)
-
-### Documentation Pruning
-
-> **Bloat:** CLAUDE.md has 150 lines on Mapbox troubleshooting that solved a one-time issue 6 months ago.
->
-> **Proposal:**
-> - **Type:** Remove + Archive
-> - **Target:** CLAUDE.md lines 450-600
-> - **Action:** Move to docs/archive/mapbox-troubleshooting-2024.md with note "Archived: Issue resolved in react-map-gl v7.1.0"
-> - **Priority:** High (saves 150 lines in hot path)
-> - **Risk:** Low (still searchable if issue recurs)
+> - **Risk:** Low (verified every named doc was absent before rewriting)

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -120,21 +120,35 @@ For each proposal, specify:
 
 ### **Documentation Health Check**
 
-Review CLAUDE.md size and relevance:
-- Current line count (target: 700-800)
-- Sections that feel bloated
-- Sections that are missing
-- Redundancy check
-- Extract candidates (sections >50 lines)
-- Recommendation: [Prune | Expand | Restructure | Extract | Good as-is]
+**CLAUDE.md is an index, not a knowledge store.** Durable knowledge belongs in
+auto-memory, `docs/`, or the relevant skill; CLAUDE.md holds only what must be
+loaded into *every* session (commit rules, hook gotchas, skill-invocation
+rules). A short CLAUDE.md is a sign the other tiers are doing their job — do
+**not** recommend padding it toward some line count. There is no target length.
+
+Review CLAUDE.md relevance:
+- Does every line still apply, and is it still accurate?
+- Anything that only matters in one workflow → move to that skill or `docs/`
+- Anything that is durable session-to-session context → auto-memory
+- Redundancy check (same rule stated here and in a skill)
+- Extract candidates (sections >50 lines — CLAUDE.md should rarely have any)
+- Recommendation: [Prune | Restructure | Extract | Good as-is]
+
+Also check the **memory** tier, which carries most of this repo's knowledge:
+- Entries citing script flags, CLI behavior, or `file:line` **rot silently** —
+  spot-check any entry you relied on this session against current code and fix
+  it. A wrong memory is worse than a missing one.
+- Index (`MEMORY.md`) one-liners still accurate?
 
 ### **Action Items**
 
-Generate a checklist:
-- [ ] Add section to CLAUDE.md: [topic]
-- [ ] Update slash command: [command name]
-- [ ] Move to docs/archive/: [file name]
-- [ ] Create new command: [command name]
+Generate a checklist. Prefer concrete targets — a file, a memory entry, a
+command — over intentions:
+- [ ] Correct/remove a stale memory entry: [name] (verify against current code first)
+- [ ] Add a memory entry for: [durable lesson]
+- [ ] Update skill: [name] — remember all three skill dirs
+- [ ] Update docs: [path] (check main README + marketplace README + docs/)
+- [ ] Add a pointer to CLAUDE.md: [one line + link] — only if needed most sessions
 - [ ] Remove outdated content: [location]
 
 ## Workflow Analytics
@@ -172,7 +186,7 @@ At the end of reflection, ask:
 - [ ] **Session Summary** - What was accomplished, what went well, friction points
 - [ ] **Effectiveness Analysis** - Token efficiency, context gathering, pattern reuse
 - [ ] **Proposed Changes** - Specific changes with target files and rationale
-- [ ] **Documentation Health** - Line count, bloat assessment, recommendations
+- [ ] **Documentation Health** - CLAUDE.md relevance/accuracy (not length) + memory-tier rot check
 - [ ] **Action Items** - Checklist of concrete next steps
 
 **DO NOT respond until all items are verified.**

--- a/skills/reflect/references/documentation-tiers.md
+++ b/skills/reflect/references/documentation-tiers.md
@@ -1,70 +1,82 @@
 # Documentation Tiers
 
-Organize information by access frequency:
+Where knowledge lives in this repo, by how often it's needed and how long it stays true.
 
-## Tier 1: Hot Path (CLAUDE.md)
+**There are no line-count targets.** Judge a tier by whether the right reader
+finds the right thing, not by size. A short CLAUDE.md means the other tiers are
+working, not that it needs filling.
 
-- Used in 50%+ of sessions
-- Core architecture decisions
-- Most common commands and patterns
-- **Target: 700-800 lines** (check with `wc -l CLAUDE.md`)
-- Quick summaries with links to detailed docs
-- Review monthly
+## Tier 1: CLAUDE.md — the always-loaded index
 
-**Keep in CLAUDE.md:**
-- ✅ Core architecture patterns (database, routing, components)
-- ✅ Most common commands (development, discovery, enrichment)
-- ✅ Critical patterns (validation, audit logging, state management)
-- ✅ Quick reference information needed in 50%+ of sessions
+Loaded into **every** session, so everything here is a tax on every session.
 
-## Tier 2: Reference (docs/ folder)
+**Keep only:**
+- ✅ Rules with no natural home in a skill or doc (commit conventions, hook gotchas)
+- ✅ Pointers — a one-line "here's the trap, here's the link"
+- ✅ Things that are wrong to learn late (e.g. skill-invocation namespacing)
 
-- Used in 10-50% of sessions
-- Detailed specs, schemas, guides
-- Can be 1000+ lines per doc
-- Review quarterly
+**Move out:**
+- ❌ Anything that matters in one workflow → that skill
+- ❌ Anything explanatory or >~10 lines → `docs/` and link to it
+- ❌ Session-to-session context about *this developer's* work → auto-memory
 
-**Current specialized docs:**
-- `ARCHITECTURE.md` - System architecture overview
-- `DATA_PIPELINE.md` - Data processing workflows
-- `TESTING.md` - Testing patterns and strategies
-- `ADMIN_CMS_ARCHITECTURE.md` - Full CMS architecture
+## Tier 2: Auto-memory — the main knowledge store
 
-## Tier 3: Archive (docs/archive/)
+`~/.claude/projects/<project>/memory/`, indexed by `MEMORY.md`. This is where
+most of this repo's hard-won knowledge actually lives (100+ entries): pitfalls,
+feedback, architecture decisions, roadmap state.
 
-- Used in <10% of sessions
-- Historical context, deprecated patterns
-- Move here after 6 months of non-use
-- Keep for searchability, not active use
+- One fact per file; `MEMORY.md` carries a one-line pointer.
+- Best tier for "I learned this the hard way and would re-learn it otherwise".
 
-## Tier 4: Code Comments
+**Its failure mode is rot, not bloat.** Entries citing script flags, CLI
+behavior, or `file:line` go stale silently, and a *wrong* memory is worse than a
+missing one — it gets trusted. Verify before asserting; fix on sight.
 
-- Implementation-specific details
-- Edge case handling
-- Why certain approaches were chosen
-- Lives with the code, not in docs
+## Tier 3: docs/ — reference for humans
 
-## When to Extract to Separate Docs
+Real structure: `concepts/`, `features/`, `guides/`, `reference/`,
+`getting-started/`, `examples/`, `internal/`, `incidents/`, `investigations/`.
 
-Move from CLAUDE.md to docs/ when:
-- ✅ Section exceeds 50 lines
-- ✅ Contains detailed workflow steps (>3 steps)
-- ✅ Has extensive examples or command variations
-- ✅ Used occasionally but not in every session
-- ✅ Could evolve independently
+- Detailed specs, architecture, runbooks. Length is fine here.
+- User-facing behavior changes must land here, and often in **more than one
+  place** — check the main README, the marketplace README, and `docs/`.
+- Review when the behavior it describes changes, not on a calendar.
 
-## Documentation Health Metrics
+## Tier 4: Skills — workflow instructions
 
-**CLAUDE.md Health Check:**
-- Current line count vs target (700-800)
-- Lines added in last month
-- Sections that feel bloated
-- Sections that are missing
-- Redundancy between CLAUDE.md and docs/
+`skills/`, `templates/skills/`, `.claude/skills/` — **three real copies**;
+fix all three or `sequant init`/`update` regenerates the bug (CI enforces this
+via `npm run lint:skill-sync`).
 
-**Recommendations:**
-- **Prune:** >900 lines, multiple bloated sections
-- **Expand:** <600 lines, missing critical patterns
-- **Restructure:** Hard to find information
-- **Extract:** Multiple sections >50 lines
-- **Good as-is:** 700-800 lines, balanced content
+- Procedure a skill must follow belongs in its `SKILL.md`.
+- Detail a skill needs only sometimes → its `references/`, linked from `SKILL.md`.
+- **When editing a SKILL.md, grep its `references/` for the same claim.** Prose
+  specs of a rule drift out of sync with the rule itself.
+
+## Tier 5: Code comments
+
+Constraints the code can't show — why this approach, what breaks otherwise.
+Not what the next line does, and not where it came from.
+
+## When to extract from CLAUDE.md
+
+- ✅ It's explanatory rather than a pointer
+- ✅ It only applies to one workflow or one command
+- ✅ It has examples, steps, or rationale
+- ✅ It could evolve independently of the rest
+
+## Health check
+
+**CLAUDE.md:** is every line still true, still needed in *most* sessions, and
+not duplicated in a skill? Recommend `Prune | Restructure | Extract | Good as-is`
+— never "Expand".
+
+**Memory:** spot-check entries relied on this session against current code.
+Are `MEMORY.md` one-liners still accurate? Any entry superseded by shipped work?
+
+**docs/:** does anything contradict what shipped? Behavior changes are the usual
+source of drift.
+
+**Skills:** are the three copies in sync, and does each `SKILL.md` agree with its
+own `references/`?

--- a/skills/reflect/references/phase-reflection.md
+++ b/skills/reflect/references/phase-reflection.md
@@ -70,26 +70,42 @@ Focus on QA/review effectiveness after `/qa`:
 
 ## Good Reflection Examples
 
-### Documentation Improvement
+Note what these have in common: each names a **specific file and a specific
+wrong line**, and each was *verified* before being proposed. A reflection that
+proposes fixing something you have not opened is a guess.
 
-> **Friction Point:** Spent 10 minutes searching for how neighborhood extraction works across multiple files.
+### Correcting a stale memory
+
+> **Friction Point:** Followed a memory that prescribed `echo y | cleanup-worktree.sh`; the script had since grown a real `--yes` flag and a merge gate (#750).
 >
-> **Root Cause:** Process is documented in docs/AUTO_NEIGHBORHOOD_ENRICHMENT.md (tier 2) but not referenced in CLAUDE.md's discovery pipeline section (tier 1).
+> **Root Cause:** Memory entries citing script flags rot silently when the script ships a change. The entry read as authoritative and was 67 days old.
 >
 > **Proposal:**
-> - **Type:** Add
-> - **Target:** CLAUDE.md, line 230 (Discovery Methods section)
-> - **Content:** Add one-line reference: "Neighborhoods auto-extracted via ZIP mapping (see docs/AUTO_NEIGHBORHOOD_ENRICHMENT.md)"
+> - **Type:** Update
+> - **Target:** `feedback_cleanup_worktree_after_gh_merge`
+> - **Content:** Replace the `echo y |` workaround with the shipped flags; add the `--delete-branch`-fails-when-a-worktree-holds-the-branch trap.
+> - **Priority:** High (a wrong memory is worse than a missing one — it gets trusted)
+> - **Risk:** Low (verified against the script's `--help` first)
+
+### Retiring guidance that a skill already implements
+
+> **Friction Point:** Was about to propose adding a diff-size threshold to `/qa` so small diffs skip sub-agents.
+>
+> **Root Cause:** The proposal was based on the skill text actually executed, which came from a **stale plugin cache** (1.20.3) rather than the repo (2.8.0). The repo's `/qa` already has the size gate. Invoking `sequant:qa` resolves to the installed plugin; bare `qa` resolves to `.claude/skills/`.
+>
+> **Proposal:**
+> - **Type:** Withdraw + document the routing trap
+> - **Target:** the proposal itself; memory entry for the skew
+> - **Priority:** High (the finding was an artifact, and acting on it would have duplicated shipped work)
+> - **Risk:** None — verification *removed* work rather than adding it
+
+### Pruning content inherited from another project
+
+> **Bloat:** `references/documentation-tiers.md` prescribed a 700–800 line CLAUDE.md target and named `ARCHITECTURE.md`, `DATA_PIPELINE.md`, `ADMIN_CMS_ARCHITECTURE.md` as "current docs". None exist here; CLAUDE.md is 13 lines by design. Its "**Expand:** <600 lines" rule would have demanded ~590 lines of invented content.
+>
+> **Proposal:**
+> - **Type:** Restructure
+> - **Target:** `references/documentation-tiers.md` (×3 skill dirs)
+> - **Action:** Rewrite around this repo's real tiers (CLAUDE.md index → auto-memory → `docs/` → skills → code comments); drop all line targets.
 > - **Priority:** Medium
-> - **Risk:** Low (just adding a signpost)
-
-### Documentation Pruning
-
-> **Bloat:** CLAUDE.md has 150 lines on Mapbox troubleshooting that solved a one-time issue 6 months ago.
->
-> **Proposal:**
-> - **Type:** Remove + Archive
-> - **Target:** CLAUDE.md lines 450-600
-> - **Action:** Move to docs/archive/mapbox-troubleshooting-2024.md with note "Archived: Issue resolved in react-map-gl v7.1.0"
-> - **Priority:** High (saves 150 lines in hot path)
-> - **Risk:** Low (still searchable if issue recurs)
+> - **Risk:** Low (verified every named doc was absent before rewriting)

--- a/templates/skills/reflect/SKILL.md
+++ b/templates/skills/reflect/SKILL.md
@@ -120,21 +120,35 @@ For each proposal, specify:
 
 ### **Documentation Health Check**
 
-Review CLAUDE.md size and relevance:
-- Current line count (target: 700-800)
-- Sections that feel bloated
-- Sections that are missing
-- Redundancy check
-- Extract candidates (sections >50 lines)
-- Recommendation: [Prune | Expand | Restructure | Extract | Good as-is]
+**CLAUDE.md is an index, not a knowledge store.** Durable knowledge belongs in
+auto-memory, `docs/`, or the relevant skill; CLAUDE.md holds only what must be
+loaded into *every* session (commit rules, hook gotchas, skill-invocation
+rules). A short CLAUDE.md is a sign the other tiers are doing their job — do
+**not** recommend padding it toward some line count. There is no target length.
+
+Review CLAUDE.md relevance:
+- Does every line still apply, and is it still accurate?
+- Anything that only matters in one workflow → move to that skill or `docs/`
+- Anything that is durable session-to-session context → auto-memory
+- Redundancy check (same rule stated here and in a skill)
+- Extract candidates (sections >50 lines — CLAUDE.md should rarely have any)
+- Recommendation: [Prune | Restructure | Extract | Good as-is]
+
+Also check the **memory** tier, which carries most of this repo's knowledge:
+- Entries citing script flags, CLI behavior, or `file:line` **rot silently** —
+  spot-check any entry you relied on this session against current code and fix
+  it. A wrong memory is worse than a missing one.
+- Index (`MEMORY.md`) one-liners still accurate?
 
 ### **Action Items**
 
-Generate a checklist:
-- [ ] Add section to CLAUDE.md: [topic]
-- [ ] Update slash command: [command name]
-- [ ] Move to docs/archive/: [file name]
-- [ ] Create new command: [command name]
+Generate a checklist. Prefer concrete targets — a file, a memory entry, a
+command — over intentions:
+- [ ] Correct/remove a stale memory entry: [name] (verify against current code first)
+- [ ] Add a memory entry for: [durable lesson]
+- [ ] Update skill: [name] — remember all three skill dirs
+- [ ] Update docs: [path] (check main README + marketplace README + docs/)
+- [ ] Add a pointer to CLAUDE.md: [one line + link] — only if needed most sessions
 - [ ] Remove outdated content: [location]
 
 ## Workflow Analytics
@@ -172,7 +186,7 @@ At the end of reflection, ask:
 - [ ] **Session Summary** - What was accomplished, what went well, friction points
 - [ ] **Effectiveness Analysis** - Token efficiency, context gathering, pattern reuse
 - [ ] **Proposed Changes** - Specific changes with target files and rationale
-- [ ] **Documentation Health** - Line count, bloat assessment, recommendations
+- [ ] **Documentation Health** - CLAUDE.md relevance/accuracy (not length) + memory-tier rot check
 - [ ] **Action Items** - Checklist of concrete next steps
 
 **DO NOT respond until all items are verified.**

--- a/templates/skills/reflect/references/documentation-tiers.md
+++ b/templates/skills/reflect/references/documentation-tiers.md
@@ -1,70 +1,82 @@
 # Documentation Tiers
 
-Organize information by access frequency:
+Where knowledge lives in this repo, by how often it's needed and how long it stays true.
 
-## Tier 1: Hot Path (CLAUDE.md)
+**There are no line-count targets.** Judge a tier by whether the right reader
+finds the right thing, not by size. A short CLAUDE.md means the other tiers are
+working, not that it needs filling.
 
-- Used in 50%+ of sessions
-- Core architecture decisions
-- Most common commands and patterns
-- **Target: 700-800 lines** (check with `wc -l CLAUDE.md`)
-- Quick summaries with links to detailed docs
-- Review monthly
+## Tier 1: CLAUDE.md — the always-loaded index
 
-**Keep in CLAUDE.md:**
-- ✅ Core architecture patterns (database, routing, components)
-- ✅ Most common commands (development, discovery, enrichment)
-- ✅ Critical patterns (validation, audit logging, state management)
-- ✅ Quick reference information needed in 50%+ of sessions
+Loaded into **every** session, so everything here is a tax on every session.
 
-## Tier 2: Reference (docs/ folder)
+**Keep only:**
+- ✅ Rules with no natural home in a skill or doc (commit conventions, hook gotchas)
+- ✅ Pointers — a one-line "here's the trap, here's the link"
+- ✅ Things that are wrong to learn late (e.g. skill-invocation namespacing)
 
-- Used in 10-50% of sessions
-- Detailed specs, schemas, guides
-- Can be 1000+ lines per doc
-- Review quarterly
+**Move out:**
+- ❌ Anything that matters in one workflow → that skill
+- ❌ Anything explanatory or >~10 lines → `docs/` and link to it
+- ❌ Session-to-session context about *this developer's* work → auto-memory
 
-**Current specialized docs:**
-- `ARCHITECTURE.md` - System architecture overview
-- `DATA_PIPELINE.md` - Data processing workflows
-- `TESTING.md` - Testing patterns and strategies
-- `ADMIN_CMS_ARCHITECTURE.md` - Full CMS architecture
+## Tier 2: Auto-memory — the main knowledge store
 
-## Tier 3: Archive (docs/archive/)
+`~/.claude/projects/<project>/memory/`, indexed by `MEMORY.md`. This is where
+most of this repo's hard-won knowledge actually lives (100+ entries): pitfalls,
+feedback, architecture decisions, roadmap state.
 
-- Used in <10% of sessions
-- Historical context, deprecated patterns
-- Move here after 6 months of non-use
-- Keep for searchability, not active use
+- One fact per file; `MEMORY.md` carries a one-line pointer.
+- Best tier for "I learned this the hard way and would re-learn it otherwise".
 
-## Tier 4: Code Comments
+**Its failure mode is rot, not bloat.** Entries citing script flags, CLI
+behavior, or `file:line` go stale silently, and a *wrong* memory is worse than a
+missing one — it gets trusted. Verify before asserting; fix on sight.
 
-- Implementation-specific details
-- Edge case handling
-- Why certain approaches were chosen
-- Lives with the code, not in docs
+## Tier 3: docs/ — reference for humans
 
-## When to Extract to Separate Docs
+Real structure: `concepts/`, `features/`, `guides/`, `reference/`,
+`getting-started/`, `examples/`, `internal/`, `incidents/`, `investigations/`.
 
-Move from CLAUDE.md to docs/ when:
-- ✅ Section exceeds 50 lines
-- ✅ Contains detailed workflow steps (>3 steps)
-- ✅ Has extensive examples or command variations
-- ✅ Used occasionally but not in every session
-- ✅ Could evolve independently
+- Detailed specs, architecture, runbooks. Length is fine here.
+- User-facing behavior changes must land here, and often in **more than one
+  place** — check the main README, the marketplace README, and `docs/`.
+- Review when the behavior it describes changes, not on a calendar.
 
-## Documentation Health Metrics
+## Tier 4: Skills — workflow instructions
 
-**CLAUDE.md Health Check:**
-- Current line count vs target (700-800)
-- Lines added in last month
-- Sections that feel bloated
-- Sections that are missing
-- Redundancy between CLAUDE.md and docs/
+`skills/`, `templates/skills/`, `.claude/skills/` — **three real copies**;
+fix all three or `sequant init`/`update` regenerates the bug (CI enforces this
+via `npm run lint:skill-sync`).
 
-**Recommendations:**
-- **Prune:** >900 lines, multiple bloated sections
-- **Expand:** <600 lines, missing critical patterns
-- **Restructure:** Hard to find information
-- **Extract:** Multiple sections >50 lines
-- **Good as-is:** 700-800 lines, balanced content
+- Procedure a skill must follow belongs in its `SKILL.md`.
+- Detail a skill needs only sometimes → its `references/`, linked from `SKILL.md`.
+- **When editing a SKILL.md, grep its `references/` for the same claim.** Prose
+  specs of a rule drift out of sync with the rule itself.
+
+## Tier 5: Code comments
+
+Constraints the code can't show — why this approach, what breaks otherwise.
+Not what the next line does, and not where it came from.
+
+## When to extract from CLAUDE.md
+
+- ✅ It's explanatory rather than a pointer
+- ✅ It only applies to one workflow or one command
+- ✅ It has examples, steps, or rationale
+- ✅ It could evolve independently of the rest
+
+## Health check
+
+**CLAUDE.md:** is every line still true, still needed in *most* sessions, and
+not duplicated in a skill? Recommend `Prune | Restructure | Extract | Good as-is`
+— never "Expand".
+
+**Memory:** spot-check entries relied on this session against current code.
+Are `MEMORY.md` one-liners still accurate? Any entry superseded by shipped work?
+
+**docs/:** does anything contradict what shipped? Behavior changes are the usual
+source of drift.
+
+**Skills:** are the three copies in sync, and does each `SKILL.md` agree with its
+own `references/`?

--- a/templates/skills/reflect/references/phase-reflection.md
+++ b/templates/skills/reflect/references/phase-reflection.md
@@ -70,26 +70,42 @@ Focus on QA/review effectiveness after `/qa`:
 
 ## Good Reflection Examples
 
-### Documentation Improvement
+Note what these have in common: each names a **specific file and a specific
+wrong line**, and each was *verified* before being proposed. A reflection that
+proposes fixing something you have not opened is a guess.
 
-> **Friction Point:** Spent 10 minutes searching for how neighborhood extraction works across multiple files.
+### Correcting a stale memory
+
+> **Friction Point:** Followed a memory that prescribed `echo y | cleanup-worktree.sh`; the script had since grown a real `--yes` flag and a merge gate (#750).
 >
-> **Root Cause:** Process is documented in docs/AUTO_NEIGHBORHOOD_ENRICHMENT.md (tier 2) but not referenced in CLAUDE.md's discovery pipeline section (tier 1).
+> **Root Cause:** Memory entries citing script flags rot silently when the script ships a change. The entry read as authoritative and was 67 days old.
 >
 > **Proposal:**
-> - **Type:** Add
-> - **Target:** CLAUDE.md, line 230 (Discovery Methods section)
-> - **Content:** Add one-line reference: "Neighborhoods auto-extracted via ZIP mapping (see docs/AUTO_NEIGHBORHOOD_ENRICHMENT.md)"
+> - **Type:** Update
+> - **Target:** `feedback_cleanup_worktree_after_gh_merge`
+> - **Content:** Replace the `echo y |` workaround with the shipped flags; add the `--delete-branch`-fails-when-a-worktree-holds-the-branch trap.
+> - **Priority:** High (a wrong memory is worse than a missing one — it gets trusted)
+> - **Risk:** Low (verified against the script's `--help` first)
+
+### Retiring guidance that a skill already implements
+
+> **Friction Point:** Was about to propose adding a diff-size threshold to `/qa` so small diffs skip sub-agents.
+>
+> **Root Cause:** The proposal was based on the skill text actually executed, which came from a **stale plugin cache** (1.20.3) rather than the repo (2.8.0). The repo's `/qa` already has the size gate. Invoking `sequant:qa` resolves to the installed plugin; bare `qa` resolves to `.claude/skills/`.
+>
+> **Proposal:**
+> - **Type:** Withdraw + document the routing trap
+> - **Target:** the proposal itself; memory entry for the skew
+> - **Priority:** High (the finding was an artifact, and acting on it would have duplicated shipped work)
+> - **Risk:** None — verification *removed* work rather than adding it
+
+### Pruning content inherited from another project
+
+> **Bloat:** `references/documentation-tiers.md` prescribed a 700–800 line CLAUDE.md target and named `ARCHITECTURE.md`, `DATA_PIPELINE.md`, `ADMIN_CMS_ARCHITECTURE.md` as "current docs". None exist here; CLAUDE.md is 13 lines by design. Its "**Expand:** <600 lines" rule would have demanded ~590 lines of invented content.
+>
+> **Proposal:**
+> - **Type:** Restructure
+> - **Target:** `references/documentation-tiers.md` (×3 skill dirs)
+> - **Action:** Rewrite around this repo's real tiers (CLAUDE.md index → auto-memory → `docs/` → skills → code comments); drop all line targets.
 > - **Priority:** Medium
-> - **Risk:** Low (just adding a signpost)
-
-### Documentation Pruning
-
-> **Bloat:** CLAUDE.md has 150 lines on Mapbox troubleshooting that solved a one-time issue 6 months ago.
->
-> **Proposal:**
-> - **Type:** Remove + Archive
-> - **Target:** CLAUDE.md lines 450-600
-> - **Action:** Move to docs/archive/mapbox-troubleshooting-2024.md with note "Archived: Issue resolved in react-map-gl v7.1.0"
-> - **Priority:** High (saves 150 lines in hot path)
-> - **Risk:** Low (still searchable if issue recurs)
+> - **Risk:** Low (verified every named doc was absent before rewriting)


### PR DESCRIPTION
## Summary

The `/reflect` skill was inherited from the project sequant was extracted from and never localized. Its guidance isn't merely stale — **following it produces wrong recommendations**, and it fires every time `/reflect` runs.

Found by running `/reflect` and noticing its own Documentation Health Check made no sense against a 13-line CLAUDE.md.

## What was wrong

| Claim in the skill | Reality |
|---|---|
| CLAUDE.md **target: 700–800 lines** | It is **13 lines by design** — knowledge lives in auto-memory (100+ entries) and `docs/` |
| **"Expand:** <600 lines, missing critical patterns" | Would demand ~590 lines of **invented content** |
| "Current specialized docs: `ARCHITECTURE.md`, `DATA_PIPELINE.md`, `TESTING.md`, `ADMIN_CMS_ARCHITECTURE.md`" | **None exist** in this repo |
| Tier 3 = `docs/archive/`, plus an action-item pointing there | **Does not exist** |
| "Good Reflection Examples": Mapbox troubleshooting, `react-map-gl`, neighborhood/ZIP enrichment | All from the other project; all model CLAUDE.md as a 600-line knowledge store |

The auto-memory tier — where most of this repo's knowledge actually lives — wasn't mentioned at all.

## Changes

- **`references/documentation-tiers.md` rewritten** around the real tiers: CLAUDE.md as an always-loaded index → **auto-memory** (the main store) → `docs/` (its actual structure) → skills (three mirrored copies) → code comments. No line targets anywhere.
- **Memory tier documented for the first time**, including its real failure mode: entries citing script flags or `file:line` rot silently, and *a wrong memory is worse than a missing one because it gets trusted*. (This session hit exactly that — a memory prescribing `echo y | cleanup-worktree.sh` after #750 shipped a real `--yes` flag.)
- **Health check** now asks whether CLAUDE.md is still true and still needed in most sessions, and adds a memory rot spot-check. `Expand` is gone as a verdict.
- **`phase-reflection.md` examples** replaced with real ones from this session — each names a specific file and a specific wrong line, and each was verified before being proposed.
- **Action-item template** points at concrete targets (a memory entry; a skill *and its three dirs*; docs across main README + marketplace README + `docs/`).
- **Output-verification checklist** no longer asks for a line count.

## Verification

- [x] Every named doc confirmed **absent** before rewriting (`ARCHITECTURE.md`, `DATA_PIPELINE.md`, `TESTING.md`, `ADMIN_CMS_ARCHITECTURE.md`, `docs/archive/`)
- [x] All three skill dirs byte-identical (`skills/`, `templates/skills/`, `.claude/skills/`)
- [x] `npm run lint:skill-sync` → 42 synced, 0 diverged
- [x] `npx skills-ref validate templates/skills/reflect` → valid
- [x] `npm run lint:skill-calls` → no violations

## Note — a related finding, not fixed here

While verifying, I found `Skill("sequant:qa")` resolves to the **installed plugin cache pinned at 1.20.3** (dated Mar 27), while the repo is at **2.8.0**. This session's `/qa` therefore ran a 2422-line skill instead of the repo's 3159-line one, silently skipping the `SMALL_DIFF` size gate and other shipped work — and produced a proposal to add a feature that already exists. Bare `Skill("qa")` correctly resolves to `.claude/skills/`.

The same cache serves the hooks, so `#763`'s merged hook fix isn't live in the session that merged it.

Recorded in memory; worth a separate issue if you want it addressed in tooling rather than convention.
