### PR TITLE
docs: sync reference/feature docs for the next release

### DIFF
--- a/docs/features/plugin-distribution.md
+++ b/docs/features/plugin-distribution.md
@@ -78,6 +78,33 @@ sequant_logs       # Review past run results
 
 **Plugin** is for interactive Claude Code users. **npm** is for power users, CI pipelines, and programmatic access.
 
+## Keeping the plugin up to date
+
+**Plugins do not auto-update.** Claude Code pins an install to the version (commit SHA) you installed it at and never moves it on its own — even as new releases ship. An install can silently run months-old skills and hooks while newer versions are available.
+
+To pick up a new release, update the installed plugin and restart Claude Code:
+
+```
+claude plugin update sequant@sequant
+```
+
+Note the distinction from refreshing the marketplace listing:
+
+| Command | What it does |
+|---------|--------------|
+| `claude plugin update sequant@sequant` | Updates the **installed plugin** to the latest marketplace version (restart Claude Code after). |
+| `/plugin marketplace update sequant-io/sequant` | Refreshes only the local marketplace **listing** — it does not touch any installed plugin. |
+
+### Staleness warning
+
+`pre-tool.sh` compares the running plugin's version against the local marketplace clone and prints a single warn-only line to stderr when the install falls behind:
+
+```
+sequant plugin v<installed> is stale (marketplace has v<latest>) — run: claude plugin update sequant@sequant, then restart Claude Code
+```
+
+The check is zero-network (grep/sed/awk only), never blocks the tool call, and is rate-limited to once per day via a stamp file. It only fires for real plugin-cache installs (paths under `plugins/cache/`) — repo-local dev copies never warn. See [Plugin Updates & Versioning](../internal/plugin-updates.md) for the full versioning and auto-update opt-in details.
+
 ## Configuration
 
 After `/sequant:setup`, edit `.sequant/settings.json` to customize:

--- a/docs/reference/run-command.md
+++ b/docs/reference/run-command.md
@@ -166,6 +166,8 @@ This is useful for complex issues where initial implementation may need refineme
 npx sequant run 42 --quality-loop --max-iterations 5
 ```
 
+When a phase fails on one iteration but **recovers** on a later one, the issue is reported as passed consistently across the live view, the summary table, and the JSON log — a transient failure that the loop later fixes is not left showing as `failed`. The summary's failure reason reflects the *last* failing attempt, not the first.
+
 ### Chain Mode
 
 Run dependent issues where each branches from the previous:
@@ -209,6 +211,14 @@ Resume is the standard chain resume: re-running the identical command skips the 
 **Checkpoint Commits:**
 
 After each issue passes QA, a checkpoint commit is automatically created. This serves as a recovery point if later issues in the chain fail.
+
+**Resuming a partially-completed chain:**
+
+If a chain stops part-way (a failed link, a broken rebase, or a rate-limit halt), just **re-run the identical command** — no extra flag needed. Sequant skips the contiguous prefix of links that are already `ready_for_merge`/`merged` and resumes at the first incomplete link, provisioning it from (and rebasing it onto) the last completed link's committed tip rather than `main`. Skipped links are listed explicitly in the run output with their resume commit.
+
+- A `merged` prefix resumes from the base branch (its work is already in `origin/main`).
+- If a completed link's branch and checkpoint are both gone and its tip cannot be reconstructed, resume **fails fast** with a clear message instead of silently building the successor on the wrong base.
+- `--force` bypasses resume entirely and redoes the whole chain from scratch.
 
 The checkpoint stages **only the files touched by the current issue's commits** (computed via `git diff --name-only baseBranch...HEAD`). Files dirty outside that scope — for example, `.claude/memory.md` or `.sequant-manifest.json` modified by `sequant sync` or mid-run Claude Code memory writes — are **not** swept into the checkpoint.
 

--- a/docs/reference/worktree-isolation.md
+++ b/docs/reference/worktree-isolation.md
@@ -130,6 +130,27 @@ cleaned up by:
   `worktree-isolation` module
 - `git worktree prune` — git's built-in stale worktree cleanup
 
+### `cleanup-worktree.sh` flags and remote-branch safety
+
+Local teardown (the worktree plus its local branch) always runs, freeing the
+branch lock for a subsequent `gh pr merge --delete-branch`. The **remote**
+branch, however, is hard-gated: it is deleted only when the branch's PR is
+`MERGED` or an explicit override flag is passed. Deleting an open PR's head
+branch makes GitHub close the PR unmerged, so an unmerged PR's remote branch is
+left intact by default.
+
+| Flag | Effect |
+|------|--------|
+| `-y`, `--yes` | Skip the confirmation prompt (for automation). Does **not** override the merge gate on remote deletion. |
+| `--delete-remote` | Delete the remote branch even when the PR is not merged. Still honors the confirmation prompt. |
+| `--force` | Implies both `--yes` and `--delete-remote`. |
+| `-h`, `--help` | Print usage and exit. |
+
+The confirmation prompt only appears when the PR is not merged. In a
+non-interactive context (no TTY) with no confirm flag, the script exits safely
+without changes instead of stalling on `read` — pass `--yes` or `--force` to
+proceed.
+
 ## API Reference
 
 ### `createSubWorktree(issueWorktreePath, agentIndex)`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,8 +44,12 @@ Common issues and solutions when using Sequant.
 2. Clean up using the cleanup script:
    ```bash
    ./scripts/cleanup-worktree.sh feature/<issue-number>-*
-   # Add --yes to skip the prompt in automation; --force to also drop an
-   # unmerged PR's remote branch. See: cleanup-worktree.sh --help
+   # Local worktree + branch are always removed. The remote branch is deleted
+   # only when the PR is merged — an unmerged PR's remote branch is left intact
+   # so GitHub doesn't close the PR unmerged.
+   # Add --yes to skip the prompt in automation; --delete-remote (or --force,
+   # which also implies --yes) to drop an unmerged PR's remote branch anyway.
+   # See: cleanup-worktree.sh --help
    ```
 
 3. Or clean manually:


### PR DESCRIPTION
## Summary

Documentation audit against the unreleased work since **v2.8.0**, ahead of the next release. Fanned out auditors over each user-facing change area and verified every doc claim against the current source. Four real gaps closed; the rest of the docs (CHANGELOG, `analytics.md`, `cheat-sheet.md`, README, `/release` skill, marketplace README) were verified already-accurate and left untouched.

## Changes

| File | Update | Issue |
|------|--------|-------|
| `docs/reference/run-command.md` | Document partial-chain resume, and consistent recovered-phase status across live view / summary / JSON log | #760, #766 |
| `docs/reference/worktree-isolation.md` | `cleanup-worktree.sh` flag table + merge-gated remote-branch deletion | #750 |
| `docs/troubleshooting.md` | Clarify local-always / remote-only-when-merged cleanup, and `--delete-remote`/`--force` overrides | #750 |
| `docs/features/plugin-distribution.md` | "Keeping the plugin up to date" + staleness-warning behavior | #784, #788 |

## Verified already-accurate (no edit)

- **CHANGELOG** — every `feat`/`fix` since v2.8.0 already has an `[Unreleased]` entry.
- **`analytics.md`** — `sequant stats` failure-category breakdown (#783) documented in its own PR; enum list incl. new `rate_limit`/`billing` matches `error-classifier.ts`.
- **`run-command.md`** pre-existing sections + **`cheat-sheet.md`** — `--strict-preflight` / content pre-flight (#762), rate-limit halt (#761), successor branching (#748) already correct (flag spelling checked against `bin/cli.ts`).
- **README**, **`/release` skill** (all 3 mirrors), **marketplace README** source — plugin-update note accurate.

## Out of scope (intentionally not here)

- README `### What's new in <minor>` section — authored at release time by `/release` Step 4.66 (editorial, version-dependent), not pre-release.
- #767 / #769 / #763 — internal correctness fixes with no user-facing doc to update.

## Verification

Spot-checked highest-risk claims against source: verbatim staleness stderr string matches `pre-tool.sh:321`, linked `docs/internal/plugin-updates.md` exists, `error-capture.md` sample is illustrative (not a stale enum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
