### PR TITLE
feat(#793): pin generated MCP config to installed version instead of @latest

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -387,7 +387,7 @@ You're all set — run `/assess <issue>` to start working on a GitHub issue.
 
 **MCP tools not available:**
 - Ensure Node.js 22.12+ is installed (`node --version`)
-- The MCP server starts automatically via `npx sequant@latest serve`
+- The MCP server starts automatically via `npx -y sequant@<version> serve` (pinned to your installed version, not `@latest`, so reconnects don't reinstall on every release — see #793)
 - Check Claude Code settings if tools don't appear
 
 **Settings not being picked up:**

--- a/__tests__/integration/mcp-serve.integration.test.ts
+++ b/__tests__/integration/mcp-serve.integration.test.ts
@@ -17,6 +17,7 @@ import * as net from "net";
 import {
   detectMcpClients,
   getSequantMcpConfig,
+  getSequantPackageSpec,
   addSequantToMcpConfig,
 } from "../../src/lib/mcp-config.js";
 
@@ -266,7 +267,8 @@ describe.skipIf(!mcpSdkAvailable)("MCP Server — Integration", () => {
       const config = getSequantMcpConfig();
 
       expect(config.command).toBe("npx");
-      expect(config.args).toEqual(["-y", "sequant@latest", "serve"]);
+      // Pinned to the installed version, not @latest (#793).
+      expect(config.args).toEqual(["-y", getSequantPackageSpec(), "serve"]);
     });
 
     it("should add sequant config to an existing MCP config file", () => {

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -28,13 +28,15 @@ Use Sequant from Claude Desktop, Cursor, VS Code, or any MCP-compatible AI tool.
   "mcpServers": {
     "sequant": {
       "command": "npx",
-      "args": ["sequant@latest", "serve"]
+      "args": ["-y", "sequant@2.9.0", "serve"]
     }
   }
 }
 ```
 
 No `cwd` or `env` needed — Claude Code runs from the project root and inherits your shell environment.
+
+> **Version pinning (#793).** `sequant init` writes a concrete version (`sequant@<your installed version>`), **not** `sequant@latest`. `@latest` forces `npx` to re-resolve and reinstall the package on the first MCP reconnect after every sequant release — the exact moment a corrupted npx cache turns into an opaque `Failed to reconnect to sequant: -32000`. Pinning removes that per-release reinstall; the MCP server then tracks new releases when you run **`sequant update`** (which rewrites the pin to the version you just installed), mirroring how the Claude Code plugin cache already pins. Plugin users get the release-pinned version automatically and pick up new versions when they update the plugin. If a reconnect ever fails with `-32000`, see [Troubleshooting → MCP Server Issues](../troubleshooting.md#mcp-server-issues). The examples below show `2.9.0` as a representative version — substitute your own (`sequant --version`).
 
 **Other clients** — pick your client and add the config manually. Each is slightly different.
 
@@ -47,7 +49,7 @@ Claude Desktop doesn't run from your project directory, so you must set `cwd`:
   "mcpServers": {
     "sequant": {
       "command": "npx",
-      "args": ["sequant@latest", "serve"],
+      "args": ["-y", "sequant@2.9.0", "serve"],
       "cwd": "/absolute/path/to/your/project"
     }
   }
@@ -63,7 +65,7 @@ If you're using an API key instead of Max plan, add the `env` field:
   "mcpServers": {
     "sequant": {
       "command": "npx",
-      "args": ["sequant@latest", "serve"],
+      "args": ["-y", "sequant@2.9.0", "serve"],
       "cwd": "/absolute/path/to/your/project",
       "env": {
         "ANTHROPIC_API_KEY": "sk-ant-..."
@@ -82,7 +84,7 @@ Cursor runs from the workspace root, so no `cwd` needed:
   "mcpServers": {
     "sequant": {
       "command": "npx",
-      "args": ["sequant@latest", "serve"]
+      "args": ["-y", "sequant@2.9.0", "serve"]
     }
   }
 }
@@ -95,7 +97,7 @@ Cursor runs from the workspace root, so no `cwd` needed:
   "mcpServers": {
     "sequant": {
       "command": "npx",
-      "args": ["sequant@latest", "serve"],
+      "args": ["-y", "sequant@2.9.0", "serve"],
       "cwd": "/absolute/path/to/your/project"
     }
   }

--- a/docs/features/plugin-distribution.md
+++ b/docs/features/plugin-distribution.md
@@ -62,7 +62,7 @@ sequant_logs       # Review past run results
 
 - **Plugin install:** Instant — skills and hooks load immediately
 - **`/sequant:setup`:** ~10 seconds — creates config and detects stack
-- **MCP server:** Starts automatically via `npx sequant@latest serve` (stdio transport)
+- **MCP server:** Starts automatically via `npx -y sequant@<version> serve` (stdio transport), pinned to the plugin's release version (#793)
 - **First `/fullsolve`:** 10–30 minutes depending on issue complexity
 
 ## Plugin vs npm
@@ -122,13 +122,17 @@ After `/sequant:setup`, edit `.sequant/settings.json` to customize:
 
 ## MCP Server Details
 
-The plugin bundles an MCP server that starts automatically:
+The plugin bundles an MCP server that starts automatically. The bundled
+`.mcp.json` pins `sequant` to the plugin's release version (#793) — the build
+step stamps the concrete version in place of `@latest`, so an `npx` reconnect
+never re-resolves `@latest` (which was surfacing as `-32000` after releases).
+You pick up a new version when you update the plugin:
 
 ```json
 {
   "sequant": {
     "command": "npx",
-    "args": ["-y", "sequant@latest", "serve"]
+    "args": ["-y", "sequant@2.9.0", "serve"]
   }
 }
 ```

--- a/docs/guides/mcp-integrations.md
+++ b/docs/guides/mcp-integrations.md
@@ -6,6 +6,8 @@
 
 MCP (Model Context Protocol) servers extend Claude's capabilities with specialized tools. Sequant supports three optional MCP integrations that enhance specific workflows.
 
+> **Looking for Sequant's own MCP server?** This guide covers the *optional third-party* MCPs below. Sequant also ships its **own** MCP server (`sequant serve`, tools `sequant_status`/`sequant_run`/`sequant_logs`), configured in `.mcp.json`. It's pinned to your installed version rather than `@latest` so reconnects don't reinstall on every release (#793) — `sequant init` writes the pin and `sequant update` refreshes it. See [MCP Server → Version pinning](../features/mcp-server.md#add-the-mcp-config), and [Troubleshooting → MCP Server Issues](../troubleshooting.md#mcp-server-issues) if a reconnect fails with `-32000`.
+
 ## Supported MCPs
 
 | MCP Server | Skills Enhanced | Purpose |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -394,6 +394,47 @@ The warning only fires when the resolved install path is *exactly* `$HOME/node_m
    claude -p "Say hello" --print
    ```
 
+## MCP Server Issues
+
+### MCP server won't (re)connect — `Failed to reconnect: -32000`
+
+**Problem:** Claude Code fails to start or reconnect the `sequant` MCP server, most often reported through `/plugin` or `/mcp` as `Failed to reconnect to sequant: -32000`. The `-32000` is a generic JSON-RPC transport error — it means the server process never came up, not that sequant itself crashed.
+
+**Most common cause — a corrupted npx cache slot.** The `.mcp.json` launches the server with `npx -y sequant@<version> serve`. Any time npx has to (re)install that package, a half-written or interrupted cache can turn into a hard failure. This is most likely with an `sequant@latest` config (the pre-#793 default, and still what an un-updated install carries), because `@latest` forces npx to re-resolve and reinstall whenever the published latest changes — so the reconnect **right after a `sequant` release** is exactly when it bites. Sequant now pins a concrete version by default (see [MCP Server → Version pinning](features/mcp-server.md#add-the-mcp-config)), which removes that per-release reinstall; run `sequant update` (or update the plugin) to move an old `@latest` config onto a pin. The underlying error is an npm bug — an atomic-rename collision with a leftover temp directory:
+
+```
+npm error code ENOTEMPTY
+npm error syscall rename
+npm error ENOTEMPTY: directory not empty, rename
+  '.../_npx/<hash>/node_modules/sequant' -> '.../_npx/<hash>/node_modules/.sequant-XXXXXXXX'
+```
+
+Because this happens **inside npx, before `sequant serve` runs**, sequant cannot detect or self-heal it — the fix is to clear the stale cache entry.
+
+**Solutions:**
+
+1. Confirm it's the npx cache (not a sequant bug) by running the exact launch command by hand and reading the real error:
+   ```bash
+   npx -y sequant@latest serve
+   # A healthy start prints: "Sequant MCP server started (stdio)"
+   # A cache problem prints the ENOTEMPTY rename error above
+   ```
+
+2. Remove the leftover temp directory (surgical — only touches the stale staging dir):
+   ```bash
+   rm -rf ~/.npm/_npx/*/node_modules/.sequant-*
+   ```
+
+3. If that isn't enough, clear npx's cached copy of sequant more broadly, then let it reinstall:
+   ```bash
+   npm cache clean --force
+   npx -y sequant@latest serve   # re-download; expect the "started (stdio)" line
+   ```
+
+4. Reconnect in Claude Code (re-run `/plugin` or `/mcp`, or restart the session).
+
+**If it recurs on every release:** you're almost certainly still on an `sequant@latest` config. The durable fix is to **pin the version** so reconnects stop reinstalling: run `sequant update` (it rewrites `.mcp.json` to `sequant@<installed version>`), or update the Claude Code plugin (its bundled config is pinned to the release). Multiple Node prefixes on `PATH` (e.g. `fnm`/`nvm` **and** Homebrew) also make npx cache corruption more likely, because different node versions share and race on the same `~/.npm/_npx` cache — standardizing on one node manager helps. As a last resort you can point the MCP entry at a locally-installed binary (`sequant serve` instead of `npx -y sequant@<version> serve`) if you have a global install — but do **not** commit that form to `.mcp.json`, since other contributors rely on the `npx` fallback. See #793.
+
 ## Update Issues
 
 ### Conflicts during update

--- a/scripts/prepare-marketplace.ts
+++ b/scripts/prepare-marketplace.ts
@@ -148,11 +148,26 @@ function main(): void {
       cpSync(templatesHooksDir, outputHooksDir, { recursive: true });
     }
 
-    // 4. Copy .mcp.json (MCP server config for plugin users)
+    // 4. Copy .mcp.json (MCP server config for plugin users), pinning the
+    //    server to this release's version (#793). The source template stays on
+    //    `sequant@latest` (portable, tracks HEAD for contributors), but the
+    //    distributed plugin config is stamped with the concrete version so an
+    //    npx reconnect never re-resolves `@latest` — the reinstall-on-release
+    //    that surfaced as `-32000`. Plugin users pick up the new pin when they
+    //    update the plugin. `npm run prepare:marketplace` already runs on every
+    //    release path, so the stamp stays in sync automatically.
     console.log("📋 Copying MCP server config...");
     const mcpJsonPath = join(PROJECT_ROOT, "templates", "mcp.json");
     if (existsSync(mcpJsonPath)) {
-      cpSync(mcpJsonPath, join(OUTPUT_DIR, ".mcp.json"));
+      const packageVersion = JSON.parse(
+        readFileSync(join(PROJECT_ROOT, "package.json"), "utf8"),
+      ).version as string;
+      const pinnedMcp = readFileSync(mcpJsonPath, "utf8").replace(
+        /sequant@latest/g,
+        `sequant@${packageVersion}`,
+      );
+      writeFileSync(join(OUTPUT_DIR, ".mcp.json"), pinnedMcp);
+      console.log(`   Pinned MCP server to sequant@${packageVersion}`);
     } else {
       console.error(
         "❌ templates/mcp.json not found. Plugin users won't get MCP server.",
@@ -204,6 +219,10 @@ function validate(): void {
     const mcpConfig = JSON.parse(readFileSync(outputMcpJson, "utf8"));
     // Plugin .mcp.json uses flat format (server name as top-level key)
     const sequantServer = mcpConfig?.sequant;
+    const args: unknown = sequantServer?.args;
+    const pin = Array.isArray(args)
+      ? args.find((a) => typeof a === "string" && a.startsWith("sequant@"))
+      : undefined;
     if (!sequantServer) {
       console.error("  ❌ .mcp.json missing sequant server entry");
       errors++;
@@ -212,8 +231,14 @@ function validate(): void {
         '  ❌ .mcp.json must use "npx" command (not hardcoded paths)',
       );
       errors++;
+    } else if (!pin || pin === "sequant@latest") {
+      // Must be a concrete pin (#793) — `@latest` re-resolves on every reconnect.
+      console.error(
+        `  ❌ .mcp.json must pin a concrete sequant version (got ${pin ?? "no sequant@ arg"}, not sequant@latest)`,
+      );
+      errors++;
     } else {
-      console.log("  ✅ .mcp.json (MCP server config)");
+      console.log(`  ✅ .mcp.json (MCP server config, pinned ${pin})`);
     }
   } else {
     console.error(

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -387,7 +387,7 @@ You're all set — run `/assess <issue>` to start working on a GitHub issue.
 
 **MCP tools not available:**
 - Ensure Node.js 22.12+ is installed (`node --version`)
-- The MCP server starts automatically via `npx sequant@latest serve`
+- The MCP server starts automatically via `npx -y sequant@<version> serve` (pinned to your installed version, not `@latest`, so reconnects don't reinstall on every release — see #793)
 - Check Claude Code settings if tools don't appear
 
 **Settings not being picked up:**

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -107,7 +107,8 @@ vi.mock("../lib/mcp-config.js", () => ({
   addSequantToMcpConfig: vi.fn(() => true),
   getSequantMcpConfig: vi.fn(() => ({
     command: "npx",
-    args: ["-y", "sequant@latest", "serve"],
+    // Pinned to the installed version (#793); representative value for the mock.
+    args: ["-y", "sequant@9.9.9", "serve"],
   })),
   isSequantInProjectMcpJson: vi.fn(() => false),
   createProjectMcpJson: vi.fn(() => ({

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/stacks.js";
 import { writeFile } from "../lib/fs.js";
 import { isStdinTTY, isCI, getNonInteractiveReason } from "../lib/tty.js";
+import { syncSequantMcpPin } from "../lib/mcp-config.js";
 
 interface UpdateOptions {
   dryRun?: boolean;
@@ -161,6 +162,19 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
       await saveConfig(config);
       console.log(chalk.green("✔ Configuration saved\n"));
     }
+  }
+
+  // Re-pin the project .mcp.json MCP server to the installed version (#793).
+  // Independent of template changes: a version-only upgrade leaves every
+  // template unchanged (so the flow would short-circuit at "Everything is up to
+  // date" below) but should still refresh the pin so the MCP server tracks the
+  // release the user just updated to. Runs here, before that short-circuit.
+  const mcpPin = syncSequantMcpPin(process.cwd(), { dryRun: options.dryRun });
+  if (mcpPin.updated) {
+    const verb = options.dryRun ? "Would update" : "Updated";
+    console.log(
+      chalk.blue(`${verb} .mcp.json MCP pin: ${mcpPin.from} → ${mcpPin.to}`),
+    );
   }
 
   // Compute changes using the shared, variable-aware comparison.

--- a/src/lib/mcp-config.test.ts
+++ b/src/lib/mcp-config.test.ts
@@ -10,16 +10,21 @@ import {
   detectMcpClients,
   addSequantToMcpConfig,
   getSequantMcpConfig,
+  getSequantPackageSpec,
   isSequantInProjectMcpJson,
   createProjectMcpJson,
+  syncSequantMcpPin,
 } from "./mcp-config.js";
 
 describe("mcp-config", () => {
   describe("getSequantMcpConfig", () => {
-    it("should return config with npx command", () => {
+    it("should return config with npx command pinned to the installed version", () => {
       const config = getSequantMcpConfig();
       expect(config.command).toBe("npx");
-      expect(config.args).toEqual(["-y", "sequant@latest", "serve"]);
+      // Pinned to the installed version, not @latest (#793).
+      expect(config.args).toEqual(["-y", getSequantPackageSpec(), "serve"]);
+      expect(config.args).not.toContain("sequant@latest");
+      expect(getSequantPackageSpec()).toMatch(/^sequant@\d+\.\d+\.\d+/);
     });
 
     it("should include cwd for claude-desktop", () => {
@@ -264,7 +269,7 @@ describe("mcp-config", () => {
       expect(content.mcpServers.sequant.command).toBe("npx");
       expect(content.mcpServers.sequant.args).toEqual([
         "-y",
-        "sequant@latest",
+        getSequantPackageSpec(),
         "serve",
       ]);
     });
@@ -372,6 +377,104 @@ describe("mcp-config", () => {
       // Array replaced with proper object
       expect(Array.isArray(content.mcpServers)).toBe(false);
       expect(content.mcpServers.sequant.command).toBe("npx");
+    });
+  });
+
+  describe("syncSequantMcpPin (#793)", () => {
+    const tmpDir = path.join(os.tmpdir(), "sequant-mcp-pin-test-" + Date.now());
+    const mcpPath = () => path.join(tmpDir, ".mcp.json");
+
+    beforeEach(() => {
+      fs.mkdirSync(tmpDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeMcp(sequant: unknown): void {
+      fs.writeFileSync(mcpPath(), JSON.stringify({ mcpServers: { sequant } }));
+    }
+
+    it("rewrites a stale pin to the installed version", () => {
+      writeMcp({ command: "npx", args: ["-y", "sequant@0.0.1", "serve"] });
+
+      const result = syncSequantMcpPin(tmpDir);
+
+      expect(result.updated).toBe(true);
+      expect(result.from).toBe("sequant@0.0.1");
+      expect(result.to).toBe(getSequantPackageSpec());
+      const content = JSON.parse(fs.readFileSync(mcpPath(), "utf-8"));
+      expect(content.mcpServers.sequant.args).toEqual([
+        "-y",
+        getSequantPackageSpec(),
+        "serve",
+      ]);
+    });
+
+    it("rewrites an @latest pin to the installed version", () => {
+      writeMcp({ command: "npx", args: ["-y", "sequant@latest", "serve"] });
+
+      const result = syncSequantMcpPin(tmpDir);
+
+      expect(result.updated).toBe(true);
+      expect(result.from).toBe("sequant@latest");
+      expect(result.to).toBe(getSequantPackageSpec());
+    });
+
+    it("is a no-op when the pin already matches the installed version", () => {
+      writeMcp({
+        command: "npx",
+        args: ["-y", getSequantPackageSpec(), "serve"],
+      });
+
+      const before = fs.readFileSync(mcpPath(), "utf-8");
+      const result = syncSequantMcpPin(tmpDir);
+
+      expect(result).toEqual({ updated: false, reason: "already-current" });
+      // File untouched.
+      expect(fs.readFileSync(mcpPath(), "utf-8")).toBe(before);
+    });
+
+    it("does not create .mcp.json when it is absent", () => {
+      const result = syncSequantMcpPin(tmpDir);
+
+      expect(result).toEqual({ updated: false, reason: "no-file" });
+      expect(fs.existsSync(mcpPath())).toBe(false);
+    });
+
+    it("no-ops when there is no sequant entry", () => {
+      fs.writeFileSync(
+        mcpPath(),
+        JSON.stringify({ mcpServers: { other: { command: "node" } } }),
+      );
+
+      const result = syncSequantMcpPin(tmpDir);
+
+      expect(result).toEqual({ updated: false, reason: "no-entry" });
+    });
+
+    it("does not clobber a local-binary override with no sequant@ arg", () => {
+      writeMcp({ command: "sequant", args: ["serve"] });
+
+      const result = syncSequantMcpPin(tmpDir);
+
+      expect(result).toEqual({ updated: false, reason: "no-pin" });
+      const content = JSON.parse(fs.readFileSync(mcpPath(), "utf-8"));
+      expect(content.mcpServers.sequant.args).toEqual(["serve"]);
+    });
+
+    it("dryRun previews the change without writing", () => {
+      writeMcp({ command: "npx", args: ["-y", "sequant@0.0.1", "serve"] });
+      const before = fs.readFileSync(mcpPath(), "utf-8");
+
+      const result = syncSequantMcpPin(tmpDir, { dryRun: true });
+
+      expect(result.updated).toBe(true);
+      expect(result.from).toBe("sequant@0.0.1");
+      expect(result.to).toBe(getSequantPackageSpec());
+      // File must be untouched on a dry run.
+      expect(fs.readFileSync(mcpPath(), "utf-8")).toBe(before);
     });
   });
 });

--- a/src/lib/mcp-config.ts
+++ b/src/lib/mcp-config.ts
@@ -8,9 +8,31 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { getVersion } from "./version.js";
 
 /** Path to the project-level MCP config file used by Claude Code */
 export const PROJECT_MCP_JSON = ".mcp.json";
+
+/**
+ * npm package specifier used to launch the MCP server (#793).
+ *
+ * We pin to the installed version rather than `@latest` so that `npx` does not
+ * re-resolve and reinstall the package on the first MCP reconnect after every
+ * sequant release — the reinstall was surfacing as an opaque
+ * `Failed to reconnect to sequant: -32000` when npx's cache was corrupted
+ * (npm ENOTEMPTY). `setup`/`update` (re)write this pin, so the MCP server
+ * tracks new releases when the user runs `sequant update` — matching how the
+ * plugin cache already pins. See docs/troubleshooting.md ("MCP Server Issues").
+ *
+ * Falls back to `latest` if the installed version cannot be resolved, so a
+ * failed lookup never writes a bogus `sequant@0.0.0` pin into `.mcp.json`.
+ */
+export function getSequantPackageSpec(): string {
+  const version = getVersion();
+  return version && version !== "0.0.0"
+    ? `sequant@${version}`
+    : "sequant@latest";
+}
 
 export type McpClientType = "claude-desktop" | "cursor" | "vscode-continue";
 
@@ -41,7 +63,7 @@ export function getSequantMcpConfig(options?: {
 }): Record<string, unknown> {
   const config: Record<string, unknown> = {
     command: "npx",
-    args: ["-y", "sequant@latest", "serve"],
+    args: ["-y", getSequantPackageSpec(), "serve"],
   };
 
   // Add cwd for clients that don't run from the project directory
@@ -235,4 +257,80 @@ export function createProjectMcpJson(
     return { created: false, merged: true, skipped: false };
   }
   return { created: true, merged: false, skipped: false };
+}
+
+export interface SyncMcpPinResult {
+  updated: boolean;
+  /** Why no rewrite happened, when updated === false. */
+  reason?: "no-file" | "no-entry" | "no-pin" | "already-current";
+  /** Previous package spec, when updated === true (e.g. "sequant@latest"). */
+  from?: string;
+  /** New package spec, when updated === true (e.g. "sequant@2.9.0"). */
+  to?: string;
+}
+
+/**
+ * Re-pin an existing project `.mcp.json` sequant entry to the installed version (#793).
+ *
+ * Unlike {@link createProjectMcpJson} (which skips when a sequant entry already
+ * exists), this is the `update`/`sync` path: it refreshes the version pin so the
+ * MCP server tracks the release the user just updated to. It only rewrites the
+ * `sequant@<version>` token inside `args` and leaves everything else untouched.
+ *
+ * No-ops (returns `updated: false`) when:
+ * - `.mcp.json` doesn't exist (`no-file`) — we never create it here; that's init's job
+ * - there's no sequant server entry (`no-entry`)
+ * - the entry uses a local-binary form with no `sequant@…` arg (`no-pin`) — a
+ *   deliberate contributor override we must not clobber
+ * - the pin already matches the installed version (`already-current`)
+ *
+ * With `opts.dryRun`, computes `from`/`to` and returns `updated: true` for a
+ * pending change but does not write the file — the caller reports it as a preview.
+ */
+export function syncSequantMcpPin(
+  projectDir?: string,
+  opts?: { dryRun?: boolean },
+): SyncMcpPinResult {
+  const mcpJsonPath = path.resolve(projectDir ?? ".", PROJECT_MCP_JSON);
+  if (!fs.existsSync(mcpJsonPath)) {
+    return { updated: false, reason: "no-file" };
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(fs.readFileSync(mcpJsonPath, "utf-8"));
+  } catch {
+    // Corrupt file — leave it alone rather than overwriting user content.
+    return { updated: false, reason: "no-file" };
+  }
+
+  const servers = config?.mcpServers as Record<string, unknown> | undefined;
+  const sequant = servers?.sequant as { args?: unknown } | undefined;
+  if (!sequant) {
+    return { updated: false, reason: "no-entry" };
+  }
+
+  const args = sequant.args;
+  if (!Array.isArray(args)) {
+    return { updated: false, reason: "no-pin" };
+  }
+
+  const pinIndex = args.findIndex(
+    (a) => typeof a === "string" && a.startsWith("sequant@"),
+  );
+  if (pinIndex === -1) {
+    return { updated: false, reason: "no-pin" };
+  }
+
+  const from = args[pinIndex] as string;
+  const to = getSequantPackageSpec();
+  if (from === to) {
+    return { updated: false, reason: "already-current" };
+  }
+
+  if (!opts?.dryRun) {
+    args[pinIndex] = to;
+    fs.writeFileSync(mcpJsonPath, JSON.stringify(config, null, 2) + "\n");
+  }
+  return { updated: true, from, to };
 }

--- a/templates/skills/setup/SKILL.md
+++ b/templates/skills/setup/SKILL.md
@@ -387,7 +387,7 @@ You're all set — run `/assess <issue>` to start working on a GitHub issue.
 
 **MCP tools not available:**
 - Ensure Node.js 22.12+ is installed (`node --version`)
-- The MCP server starts automatically via `npx sequant@latest serve`
+- The MCP server starts automatically via `npx -y sequant@<version> serve` (pinned to your installed version, not `@latest`, so reconnects don't reinstall on every release — see #793)
 - Check Claude Code settings if tools don't appear
 
 **Settings not being picked up:**


### PR DESCRIPTION
## Summary

Fixes #793. The generated `.mcp.json` launched the MCP server with `sequant@latest`, which forces `npx` to re-resolve and reinstall the package on the first MCP reconnect **after every release** — the exact moment a corrupted npx cache (npm `ENOTEMPTY`) turns into an opaque `Failed to reconnect to sequant: -32000`. This implements the issue's recommended **Option 1**: pin to a concrete version so reconnects stop reinstalling, and let the MCP server track releases when the user runs `sequant update` (mirroring how the plugin cache already pins).

## Design: sources track HEAD, distributed artifacts are pinned

| File | Pin? | Why |
|------|------|-----|
| `getSequantMcpConfig()` output (user's `.mcp.json` via init/update) | **pinned** | `sequant@<installed version>`, refreshed by `sequant update` |
| Plugin marketplace `.mcp.json` (via `prepare-marketplace`) | **pinned at build time** | stamped with the release version; picks up new versions on plugin update |
| `templates/mcp.json`, root `.mcp.json` (source) | stays `@latest` | portable HEAD-tracking sources; contributors rely on the npx fallback |

## Changes

- **`src/lib/mcp-config.ts`** — `getSequantMcpConfig()` emits `sequant@<version>` via `getVersion()`, falling back to `@latest` if the version can't be resolved (never writes a bogus `sequant@0.0.0`). New `syncSequantMcpPin()` re-pins an existing `.mcp.json` to the installed version — no-ops on missing file, no sequant entry, a local-binary override (no `sequant@…` arg), or an already-current pin; `--dry-run` previews without writing.
- **`src/commands/update.ts`** — calls `syncSequantMcpPin()` **before** the "everything up to date" short-circuit, so a version-only upgrade still refreshes the pin. `init`/`setup` already write the pin through `createProjectMcpJson`.
- **`scripts/prepare-marketplace.ts`** — stamps the plugin `.mcp.json` with the release version at build time (this step already runs on every release path, so no release-script edits) and validates the output is a concrete pin, not `@latest`. **This addresses the observed incident, which was plugin-side (`/plugin` reconnect).**
- **Tests** — `mcp-config`, `init`, and the `mcp-serve` integration test assert the pin; added a `syncSequantMcpPin` suite (stale/`@latest`→pin, already-current no-op, absent file, no entry, local-binary override, dry-run).
- **Docs** — `mcp-server.md` (new "Version pinning" note + examples), `plugin-distribution.md`, `mcp-integrations.md` (cross-ref), the three mirrored `setup/SKILL.md`, and the troubleshooting `-32000` entry now explain the pin and how the server tracks releases.

## Acceptance Criteria

- [x] **AC-1** Decide whether to pin — **yes, pin** (Option 1), confirmed with the maintainer.
- [x] **AC-2** `getSequantMcpConfig` emits the installed version; `setup`/`update` (re)write it; tests updated (`mcp-config.test.ts`, `init.test.ts`).
- [x] **AC-3** Docs (`mcp-server.md`, `mcp-integrations.md`) explain the pin and release tracking.
- [x] **AC-4** Cross-references the troubleshooting `-32000` / ENOTEMPTY entry.

## Beyond the literal AC (flagged)

AC-2 scopes the change to the generator, but the reported incident was plugin-side. Rather than leave plugin users unfixed, I also pin the plugin's marketplace `.mcp.json` via build-time stamping — DRY, auto-tracks releases, and requires no changes to the release scripts. Source `templates/mcp.json` and the repo's own root `.mcp.json` intentionally stay `@latest`; a maintainer wanting the dev-repo config pinned can run `sequant update`.

## Verification

- `npm run build` ✅  `npm run lint` ✅ (0 warnings)
- Targeted tests: 140 passed (`mcp-config`, `version-check`, `init`, `update`)
- `npm run prepare:marketplace` stamps `sequant@2.9.0` into the plugin config and the pin-validation passes.

## Risk assessment

- **Likely failure mode:** if `getVersion()` ever resolves the wrong `package.json`, the pin could target an unintended version — mitigated by the `@latest` fallback and the existing name-guarded lookup.
- **Not tested:** the release-time bump of the plugin marketplace pin is verified via a manual `prepare:marketplace` run, not an automated release e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
