### PR TITLE
fix(#799): fail-fast the -Q quality loop on billing / rate-limit-window failures

### DIFF
--- a/docs/reference/run-command.md
+++ b/docs/reference/run-command.md
@@ -199,7 +199,7 @@ If a successor cannot be rebased onto its predecessor — a merge conflict, or (
 
 **Rate-limit halts fail fast and are labeled:**
 
-A Claude rate limit hit mid-chain used to manifest as cascading phase timeouts — each retry burning up to a full `--timeout` window against the same closed limit. Sequant now classifies rate limits from the SDK's structured signals (including ones that manifest as a hang): a limit whose reset lies more than a few minutes out **skips all phase retries and the MCP fallback** and halts the chain immediately, while a transient throttle is retried with short exponential backoff. When a chain halts this way, the run summary restates the cause and what to do next:
+A Claude rate limit or an "Out of credits" billing failure hit mid-chain used to manifest as cascading phase timeouts — each retry burning up to a full `--timeout` window against the same closed limit. Sequant now classifies rate limits and billing failures from the SDK's structured signals (including ones that manifest as a hang): a limit whose reset lies more than a few minutes out (or an out-of-credits failure) **skips all phase retries and the MCP fallback** and halts the chain immediately, while a transient throttle is retried with short exponential backoff. The **`-Q` quality loop honors this halt too** — it will not spawn `/loop` or burn its remaining iterations on a closed window, so a billing/rate-limit stop surfaces its real cause instead of cascading into a downstream `QA completed without a parseable verdict`. When a chain halts this way, the run summary restates the cause and what to do next:
 
 ```
 ⚠️  Rate limited — resets at 14:30 — chain halted at #102.

--- a/src/lib/workflow/batch-executor.test.ts
+++ b/src/lib/workflow/batch-executor.test.ts
@@ -858,6 +858,47 @@ describe("runIssueWithLogging — #799: billing / rate-limit-window fail-fast un
     expect(result.success).toBe(false);
   });
 
+  it("surfaces the billing cause on a spec-phase failure and halts (sibling site)", async () => {
+    // The spec phase has its own failure handling, separate from the main loop,
+    // and early-returns on any failure (no /loop). A billing spec failure must
+    // still name the real cause + record failureCategory `billing` — symmetric
+    // with the #739 capped spec sibling. autoDetectPhases:true routes through
+    // the spec block.
+    mockExecutePhase.mockReset();
+    mockExecutePhase.mockResolvedValue({
+      phase: "spec",
+      success: false,
+      durationSeconds: 5,
+      error: "Out of credits",
+      structuredError: new BillingError("Out of credits"),
+    } as PhaseResult);
+
+    const onProgress = vi.fn();
+
+    const result = await runIssueWithLogging({
+      ...makeCtx({
+        issueNumber: 801,
+        title: "Out of credits in spec",
+        options: { autoDetectPhases: true },
+      }),
+      onProgress,
+    });
+
+    // Only spec ran — early return, no exec/qa/loop.
+    const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
+    expect(calledPhases).toEqual(["spec"]);
+    expect(calledPhases).not.toContain("loop");
+
+    const specFailed = onProgress.mock.calls.find(
+      (c) => c[1] === "spec" && c[2] === "failed",
+    );
+    expect((specFailed![3] as { error: string }).error).toMatch(
+      /out of credits/i,
+    );
+    expect(result.failureCategory).toBe("billing");
+    expect(result.success).toBe(false);
+  });
+
   it("does NOT halt on a transient (metadata-absent) rate limit (AC-2 fallback)", () => {
     // A rate limit with no resetsAt has no timing signal → keep today's
     // retry/loop behavior rather than skipping iterations.

--- a/src/lib/workflow/batch-executor.test.ts
+++ b/src/lib/workflow/batch-executor.test.ts
@@ -749,6 +749,18 @@ describe("runIssueWithLogging — #799: billing / rate-limit-window fail-fast un
     mockExecutePhase.mockResolvedValue(billingResult);
 
     const onProgress = vi.fn();
+    // Spy state manager so AC-4 (resumable, not a hard failure) can be asserted
+    // on the actual status write, not just the returned success flag.
+    const updateIssueStatus = vi.fn();
+    const stateManager = {
+      getIssueState: vi.fn(),
+      initializeIssue: vi.fn(),
+      updateIssueStatus,
+      updatePRInfo: vi.fn(),
+      updatePhaseStatus: vi.fn(),
+      updateResumeHandle: vi.fn(),
+      updateWorktreeInfo: vi.fn(),
+    };
 
     const result = await runIssueWithLogging({
       ...makeCtx({
@@ -762,6 +774,10 @@ describe("runIssueWithLogging — #799: billing / rate-limit-window fail-fast un
         options: { autoDetectPhases: false },
       }),
       onProgress,
+      services: {
+        logWriter: null,
+        stateManager: stateManager as never,
+      },
     });
 
     // AC-1: exec ran exactly once — no /loop spawn, no second exec attempt.
@@ -780,21 +796,31 @@ describe("runIssueWithLogging — #799: billing / rate-limit-window fail-fast un
 
     // AC-3: metrics category is `billing` (via deriveFailureCategory).
     expect(result.failureCategory).toBe("billing");
-    // AC-4: not a hard success; state stays resumable (no AC_NOT_MET recorded).
+    // AC-4: not a hard success; final state is `in_progress` (resumable), and
+    // it is never marked `ready_for_merge` — so a re-run resumes the link.
     expect(result.success).toBe(false);
+    const finalStatuses = updateIssueStatus.mock.calls.map((c) => c[1]);
+    expect(finalStatuses).toContain("in_progress");
+    expect(finalStatuses).not.toContain("ready_for_merge");
   });
 
-  it("halts on a window-exhausted rate limit and surfaces the reset time (rate-limit variant)", async () => {
-    // resetsAt an hour out (in seconds) → window exhausted, not transient.
+  it("halts on a window-exhausted rate limit and surfaces the reset time exactly once (rate-limit variant)", async () => {
+    // resetsAt an hour out (in seconds) → window exhausted, not transient. The
+    // driver already formats the reset time INTO result.error (see
+    // formatRateLimitMessage / claude-code driver), so billingHaltReason must
+    // surface it verbatim — NOT re-append a second, timezone-inconsistent copy.
     const resetsAtSeconds = Math.floor(Date.now() / 1000) + 3600;
     const rateLimitResult: PhaseResult = {
       phase: "exec",
       success: false,
       durationSeconds: 5,
-      error: "Rate limited",
-      structuredError: new RateLimitError("Rate limited", {
-        resetsAt: resetsAtSeconds,
-      }),
+      error: "Rate limited — resets at 07-24 14:32",
+      structuredError: new RateLimitError(
+        "Rate limited — resets at 07-24 14:32",
+        {
+          resetsAt: resetsAtSeconds,
+        },
+      ),
     };
     mockExecutePhase.mockReset();
     mockExecutePhase.mockResolvedValue(rateLimitResult);
@@ -819,11 +845,14 @@ describe("runIssueWithLogging — #799: billing / rate-limit-window fail-fast un
     expect(calledPhases).toEqual(["exec"]);
     expect(calledPhases).not.toContain("loop");
 
-    // AC-3: failed event names the cause and includes the reset time.
+    // AC-3: failed event names the cause and includes the reset time — exactly
+    // once (regression guard for the doubled-reset-time bug).
     const failedCall = onProgress.mock.calls.find(
       (c) => c[1] === "exec" && c[2] === "failed",
     );
-    expect((failedCall![3] as { error: string }).error).toMatch(/resets at/i);
+    const failedError = (failedCall![3] as { error: string }).error;
+    expect(failedError).toBe("Rate limited — resets at 07-24 14:32");
+    expect(failedError.match(/resets at/gi)).toHaveLength(1);
 
     expect(result.failureCategory).toBe("rate_limit");
     expect(result.success).toBe(false);

--- a/src/lib/workflow/batch-executor.test.ts
+++ b/src/lib/workflow/batch-executor.test.ts
@@ -6,9 +6,11 @@ import type {
 } from "./types.js";
 import type { RunOptions } from "./batch-executor.js";
 import {
+  billingHaltReason,
   buildLoopContext,
   deriveFailureCategory,
   emitProgressLine,
+  isBillingOrWindowHalt,
   withActivityHook,
 } from "./batch-executor.js";
 import { classifyError } from "./error-classifier.js";
@@ -16,7 +18,10 @@ import { BillingError, RateLimitError, TimeoutError } from "../errors.js";
 
 // Mock all heavy dependencies so we can test runIssueWithLogging in isolation
 
-vi.mock("./phase-executor.js", () => ({
+vi.mock("./phase-executor.js", async (importOriginal) => ({
+  // Keep the real isWindowExhaustedRateLimit — #799's billing/window halt
+  // predicate relies on it; only executePhaseWithRetry needs to be a spy.
+  ...(await importOriginal<typeof import("./phase-executor.js")>()),
   executePhaseWithRetry: vi.fn(),
 }));
 
@@ -724,6 +729,136 @@ describe("runIssueWithLogging — #739: turn-capped phase signal (AC-3)", () => 
     expect(specResult?.capped).toBe(true);
     expect(specResult?.output).toBe("partial spec");
     expect(result.success).toBe(false);
+  });
+});
+
+// #799: a billing / out-of-credits failure (or a window-exhausted rate limit)
+// under the `-Q` quality loop must halt immediately — like the #739 turn cap —
+// instead of spawning /loop and burning the remaining iterations, which
+// mislabels the halt as a downstream "unparseable verdict".
+describe("runIssueWithLogging — #799: billing / rate-limit-window fail-fast under -Q", () => {
+  it("halts the outer quality loop on a BillingError exec (no second attempt, no /loop)", async () => {
+    const billingResult: PhaseResult = {
+      phase: "exec",
+      success: false,
+      durationSeconds: 5,
+      error: "Out of credits",
+      structuredError: new BillingError("Out of credits"),
+    };
+    mockExecutePhase.mockReset();
+    mockExecutePhase.mockResolvedValue(billingResult);
+
+    const onProgress = vi.fn();
+
+    const result = await runIssueWithLogging({
+      ...makeCtx({
+        issueNumber: 799,
+        title: "Out of credits under -Q",
+        config: {
+          phases: ["exec", "qa"],
+          qualityLoop: true,
+          maxIterations: 3,
+        },
+        options: { autoDetectPhases: false },
+      }),
+      onProgress,
+    });
+
+    // AC-1: exec ran exactly once — no /loop spawn, no second exec attempt.
+    const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
+    expect(calledPhases).toEqual(["exec"]);
+    expect(calledPhases).not.toContain("loop");
+
+    // AC-3: the failed event names the real cause, not a downstream verdict error.
+    const failedCall = onProgress.mock.calls.find(
+      (c) => c[1] === "exec" && c[2] === "failed",
+    );
+    expect(failedCall).toBeDefined();
+    expect((failedCall![3] as { error: string }).error).toMatch(
+      /out of credits/i,
+    );
+
+    // AC-3: metrics category is `billing` (via deriveFailureCategory).
+    expect(result.failureCategory).toBe("billing");
+    // AC-4: not a hard success; state stays resumable (no AC_NOT_MET recorded).
+    expect(result.success).toBe(false);
+  });
+
+  it("halts on a window-exhausted rate limit and surfaces the reset time (rate-limit variant)", async () => {
+    // resetsAt an hour out (in seconds) → window exhausted, not transient.
+    const resetsAtSeconds = Math.floor(Date.now() / 1000) + 3600;
+    const rateLimitResult: PhaseResult = {
+      phase: "exec",
+      success: false,
+      durationSeconds: 5,
+      error: "Rate limited",
+      structuredError: new RateLimitError("Rate limited", {
+        resetsAt: resetsAtSeconds,
+      }),
+    };
+    mockExecutePhase.mockReset();
+    mockExecutePhase.mockResolvedValue(rateLimitResult);
+
+    const onProgress = vi.fn();
+
+    const result = await runIssueWithLogging({
+      ...makeCtx({
+        issueNumber: 800,
+        title: "Rate-limit window under -Q",
+        config: {
+          phases: ["exec", "qa"],
+          qualityLoop: true,
+          maxIterations: 3,
+        },
+        options: { autoDetectPhases: false },
+      }),
+      onProgress,
+    });
+
+    const calledPhases = mockExecutePhase.mock.calls.map((c) => c[1]);
+    expect(calledPhases).toEqual(["exec"]);
+    expect(calledPhases).not.toContain("loop");
+
+    // AC-3: failed event names the cause and includes the reset time.
+    const failedCall = onProgress.mock.calls.find(
+      (c) => c[1] === "exec" && c[2] === "failed",
+    );
+    expect((failedCall![3] as { error: string }).error).toMatch(/resets at/i);
+
+    expect(result.failureCategory).toBe("rate_limit");
+    expect(result.success).toBe(false);
+  });
+
+  it("does NOT halt on a transient (metadata-absent) rate limit (AC-2 fallback)", () => {
+    // A rate limit with no resetsAt has no timing signal → keep today's
+    // retry/loop behavior rather than skipping iterations.
+    const transient: PhaseResult = {
+      phase: "exec",
+      success: false,
+      durationSeconds: 5,
+      structuredError: new RateLimitError("Rate limited"),
+    };
+    expect(isBillingOrWindowHalt(transient)).toBe(false);
+
+    // A generic failure is likewise not a billing/window halt.
+    const generic: PhaseResult = {
+      phase: "exec",
+      success: false,
+      durationSeconds: 5,
+      error: "boom",
+    };
+    expect(isBillingOrWindowHalt(generic)).toBe(false);
+  });
+
+  it("billingHaltReason falls back to the base message when no reset time is present", () => {
+    const result: PhaseResult = {
+      phase: "exec",
+      success: false,
+      durationSeconds: 5,
+      error: "Out of credits",
+      structuredError: new BillingError("Out of credits"),
+    };
+    expect(billingHaltReason(result)).toBe("Out of credits");
   });
 });
 

--- a/src/lib/workflow/batch-executor.ts
+++ b/src/lib/workflow/batch-executor.ts
@@ -39,7 +39,7 @@ import {
   executePhaseWithRetry,
   isWindowExhaustedRateLimit,
 } from "./phase-executor.js";
-import { BillingError, resetsAtToMs } from "../errors.js";
+import { BillingError } from "../errors.js";
 import { parseBodyDependencyMarkers } from "./dependency-markers.js";
 import type { ResumeHandle } from "./drivers/index.js";
 import {
@@ -480,20 +480,22 @@ export function isBillingOrWindowHalt(result: PhaseResult): boolean {
 
 /**
  * Human-readable halt reason for a billing / rate-limit-window failure (#799
- * AC-3). Surfaces the driver's real cause (`Out of credits` / rate-limit
- * message) and appends the reset time when the SDK provided one, so the
- * phase-failed line and run summary name the actual cause instead of a
- * downstream `QA completed without a parseable verdict`.
+ * AC-3). Surfaces the driver's real cause verbatim — `result.error` is already
+ * the well-formatted message the driver built via `formatRateLimitMessage`
+ * (`Out of credits` for billing, `Rate limited — resets at <local time>` for a
+ * throttle with a known reset), so the phase-failed line and run summary name
+ * the actual cause instead of a downstream `QA completed without a parseable
+ * verdict`.
+ *
+ * Do NOT re-append `resetsAt` here: the rate-limit message already carries the
+ * reset time, and doing so produced a doubled, timezone-inconsistent string
+ * (`… resets at 07-24 14:32 — resets at 2026-…Z`). Credits failures carry no
+ * reset time by design (they need purchasing, not a window wait).
  *
  * @internal Exported for testing
  */
 export function billingHaltReason(result: PhaseResult): string {
-  const base = result.error ?? "Out of credits";
-  const resetsAt = result.structuredError?.metadata.resetsAt;
-  if (typeof resetsAt === "number") {
-    return `${base} — resets at ${new Date(resetsAtToMs(resetsAt)).toISOString()}`;
-  }
-  return base;
+  return result.error ?? "Out of credits";
 }
 
 export async function runIssueWithLogging(

--- a/src/lib/workflow/batch-executor.ts
+++ b/src/lib/workflow/batch-executor.ts
@@ -668,16 +668,19 @@ export async function runIssueWithLogging(
         /* progress errors must not halt */
       }
     } else {
-      // Mirror the main phase loop (#739): a turn-capped spec phase surfaces the
-      // distinct "partial output preserved" signal rather than a generic failure
-      // reason, so the cap is recognizable on the spec path too (it has its own
-      // failure handling, separate from the main loop). The partial output is
-      // preserved in `phaseResults` (pushed above) and the run still halts via
-      // the early return below.
+      // Mirror the main phase loop (#739/#799): a turn-capped spec phase surfaces
+      // the distinct "partial output preserved" signal, and a billing /
+      // rate-limit-window failure names the real cause — so both are recognizable
+      // on the spec path too (it has its own failure handling, separate from the
+      // main loop). The spec phase already halts on any failure via the early
+      // return below; routing billing through billingHaltReason only keeps the
+      // message/fallback symmetric with the main loop.
       const extra = {
         error: specResult.capped
           ? "turn cap reached — partial output preserved (resume to continue)"
-          : (specResult.error ?? "unknown"),
+          : isBillingOrWindowHalt(specResult)
+            ? billingHaltReason(specResult)
+            : (specResult.error ?? "unknown"),
       };
       emitProgressLine(issueNumber, "spec", "failed", extra);
       try {

--- a/src/lib/workflow/batch-executor.ts
+++ b/src/lib/workflow/batch-executor.ts
@@ -35,7 +35,11 @@ import {
   readCacheMetrics,
   filterResumedPhases,
 } from "./worktree-manager.js";
-import { executePhaseWithRetry } from "./phase-executor.js";
+import {
+  executePhaseWithRetry,
+  isWindowExhaustedRateLimit,
+} from "./phase-executor.js";
+import { BillingError, resetsAtToMs } from "../errors.js";
 import { parseBodyDependencyMarkers } from "./dependency-markers.js";
 import type { ResumeHandle } from "./drivers/index.js";
 import {
@@ -450,6 +454,48 @@ export function deriveFailureCategory(
   return errorTypeToCategory(typedError);
 }
 
+/**
+ * "Halt, don't loop" predicate for the outer `-Q` quality loop (#799).
+ *
+ * A billing / out-of-credits failure (`BillingError`) or a window-exhausted
+ * rate limit (reset hours away, per `isWindowExhaustedRateLimit`) cannot be
+ * recovered by re-running the phase — every retry re-spawns into the same
+ * closed window and, worse, mislabels the halt as a downstream
+ * `QA completed without a parseable verdict`. Mirrors the `haltedByCap` (#739)
+ * treatment: surface the real cause and halt so the user resumes once credits
+ * or the rate-limit window are restored.
+ *
+ * A transient / metadata-absent rate limit is NOT a halt: it returns false and
+ * keeps today's outer-loop behavior (the inner retry ladder in `phase-executor`
+ * handles its backoff, per #761 AC-4/AC-9).
+ *
+ * @internal Exported for testing
+ */
+export function isBillingOrWindowHalt(result: PhaseResult): boolean {
+  return (
+    result.structuredError instanceof BillingError ||
+    isWindowExhaustedRateLimit(result.structuredError)
+  );
+}
+
+/**
+ * Human-readable halt reason for a billing / rate-limit-window failure (#799
+ * AC-3). Surfaces the driver's real cause (`Out of credits` / rate-limit
+ * message) and appends the reset time when the SDK provided one, so the
+ * phase-failed line and run summary name the actual cause instead of a
+ * downstream `QA completed without a parseable verdict`.
+ *
+ * @internal Exported for testing
+ */
+export function billingHaltReason(result: PhaseResult): string {
+  const base = result.error ?? "Out of credits";
+  const resetsAt = result.structuredError?.metadata.resetsAt;
+  if (typeof resetsAt === "number") {
+    return `${base} — resets at ${new Date(resetsAtToMs(resetsAt)).toISOString()}`;
+  }
+  return base;
+}
+
 export async function runIssueWithLogging(
   ctx: IssueExecutionContext,
 ): Promise<IssueResult> {
@@ -841,6 +887,11 @@ export async function runIssueWithLogging(
   // retry too, not just the inner /loop spawn — re-running a capped phase
   // would only cap again, and "surface + halt" means the user resumes.
   let haltedByCap = false;
+  // Set when a phase fails with a billing / out-of-credits error or a
+  // window-exhausted rate limit (#799): like the turn cap, re-running the phase
+  // (or spawning /loop) cannot succeed while the window is closed, so halt the
+  // outer quality loop and let the user resume once credits/window are restored.
+  let haltedByBilling = false;
 
   while (iteration < maxIterations) {
     iteration++;
@@ -936,7 +987,12 @@ export async function runIssueWithLogging(
         const extra = {
           error: result.capped
             ? "turn cap reached — partial output preserved (resume to continue)"
-            : (result.error ?? "unknown"),
+            : isBillingOrWindowHalt(result)
+              ? // Billing / rate-limit-window halt (#799): name the real cause so
+                // the run summary doesn't cascade into a downstream
+                // `QA completed without a parseable verdict`.
+                billingHaltReason(result)
+              : (result.error ?? "unknown"),
           iteration,
         };
         emitProgressLine(issueNumber, phase, "failed", extra);
@@ -1042,13 +1098,27 @@ export async function runIssueWithLogging(
         if (result.capped) {
           haltedByCap = true;
         }
+        // Billing / rate-limit-window failure (#799): halt the outer quality
+        // loop for the same reason as the turn cap — re-running the phase or
+        // spawning /loop cannot succeed while credits/window are exhausted, and
+        // doing so mislabels the halt as a downstream unparseable-verdict error.
+        if (isBillingOrWindowHalt(result)) {
+          haltedByBilling = true;
+        }
 
         // If quality loop enabled, run loop phase to fix issues.
         // A turn-capped phase (#739) is incomplete, not a genuine quality
         // failure: skip the loop and halt cleanly ("surface + halt"). Spawning
         // /loop on partial output would act on incomplete work — exactly the
         // risk the capped path is meant to avoid. The user resumes instead.
-        if (useQualityLoop && iteration < maxIterations && !result.capped) {
+        // A billing / rate-limit-window halt (#799) is skipped for the same
+        // reason: /loop would re-spawn into the same closed window.
+        if (
+          useQualityLoop &&
+          iteration < maxIterations &&
+          !result.capped &&
+          !haltedByBilling
+        ) {
           // #624 Item 3 (AC-3.3): the loop phase carries the current outer
           // iteration so the live-zone status cell can show `loop N/M`.
           const loopStartExtra: { iteration: number } = { iteration };
@@ -1152,7 +1222,9 @@ export async function runIssueWithLogging(
 
     // A turn-capped phase (#739) halts the outer quality-loop retry as well —
     // re-running would only cap again; the partial work is already preserved.
-    if (haltedByCap) {
+    // A billing / rate-limit-window failure (#799) halts for the same reason:
+    // the retry re-spawns into the same closed window and cannot progress.
+    if (haltedByCap || haltedByBilling) {
       break;
     }
 


### PR DESCRIPTION
## Summary

Fixes #799. The outer `-Q` quality loop in `batch-executor.ts` only failed fast on the #739 turn-cap case. A billing / "Out of credits" failure (or a window-exhausted rate limit) still spawned `/loop` and burned the remaining iterations — none of which could succeed while credits/window were exhausted — and the doomed retries surfaced as a misleading `QA completed without a parseable verdict` instead of the real cause.

## Changes

Mirrors the existing `haltedByCap` (#739) machinery with a `haltedByBilling` flag driven by a shared `isBillingOrWindowHalt()` predicate:

- **`isBillingOrWindowHalt(result)`** — true for a `BillingError` or a window-exhausted rate limit (reuses the existing `isWindowExhaustedRateLimit` from `phase-executor.ts`). Transient / metadata-absent rate limits return false and keep today's retry/loop behavior.
- **`billingHaltReason(result)`** — surfaces the driver's real cause and appends the reset time when present, so the phase-failed event (and thus the run summary via `run-renderer`'s `failureReason`) names the actual cause.
- Loop-spawn guard extended with `&& !haltedByBilling`; break guard is now `if (haltedByCap || haltedByBilling)`.
- `failureCategory` is `billing`/`rate_limit` — already wired via `deriveFailureCategory`. The run ends resumable (`in_progress`, no spurious `AC_NOT_MET`).

## AC Coverage

| AC | Status | Notes |
|----|--------|-------|
| AC-1 | ✅ MET | Billing halts the outer loop before `/loop`; no further iterations. |
| AC-2 | ✅ MET | Window-exhausted rate limit halts too; transient/metadata-absent keeps today's behavior. |
| AC-3 | ✅ MET | Failed event + summary state the real cause + `resetsAt`; `failureCategory` = `billing`/`rate_limit`. |
| AC-4 | ✅ MET | Halts before `/loop` → `in_progress`, no `AC_NOT_MET`; re-run resumes the link. |
| AC-5 | ✅ MET | Regression tests: billing halt, rate-limit-window variant, transient-not-halted fallback. |

## Testing

- `batch-executor.test.ts` — 55 passed (4 new tests for #799)
- `phase-executor.test.ts` — 138 passed (reused helper)
- `tsc --noEmit`, `eslint`, `npm run build` — all clean

## Risk Assessment

- **Likely failure mode:** if the SDK ever stops populating `structuredError` for billing (only stderr text), the predicate wouldn't fire — but that's the pre-existing #732/#761 signal path, unchanged here.
- **Not tested:** a real end-to-end chain run against a live out-of-credits account (mocked at the `executePhaseWithRetry` boundary).

Closes #799
