### PR TITLE
chore(deps): ignore typescript major bumps until typescript-eslint supports TS7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
           - "minor"
           - "patch"
     open-pull-requests-limit: 10
+    ignore:
+      # TypeScript 7 (native port) is outside the peer range of typescript-eslint
+      # 8.x (peer: >=4.8.4 <6.1.0), so the major bump fails `npm ci` with ERESOLVE.
+      # Blocked until typescript-eslint ships TS7 support. Re-evaluate then. (#780)
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` for `typescript` **major** updates in the npm ecosystem.

## Why

TypeScript 7 (the native/Go port) falls outside the peer range of `typescript-eslint` 8.x (`peer typescript ">=4.8.4 <6.1.0"`). The major bump therefore fails `npm ci` with `ERESOLVE`, and every node-based CI job fails at install — see #780, which was closed for this reason.

Without this ignore, Dependabot reopens the bump on every new TS7 patch release. This suppresses the major bump until the linter toolchain supports TS7; minor/patch typescript updates are unaffected.

Refs #780.