### PR TITLE
test(#782): validate #761 AC-9 — real window rejections carry rateLimitType/resetsAt

### DIFF
--- a/docs/incidents/782/captures/2026-07-18/metrics-excerpt.json
+++ b/docs/incidents/782/captures/2026-07-18/metrics-excerpt.json
@@ -1,0 +1,46 @@
+{
+  "_provenance": {
+    "source": ".sequant/metrics.json (runs[]) — gitignored and subject to rotation, so the two relevant entries are excerpted here verbatim",
+    "extractedOn": "2026-07-25",
+    "why": "Independent corroboration for AC-1: the run logs and the metrics writer classified these failures identically (failureCategory: billing), from separate code paths.",
+    "note": "Excerpt only — the two matching entries out of 103 runs. Field values are unmodified."
+  },
+  "runs": [
+    {
+      "id": "94e69183-e4fd-4aae-98f6-8844d717a0c5",
+      "date": "2026-07-18T16:05:28.688Z",
+      "issues": [783],
+      "phases": ["spec"],
+      "outcome": "failed",
+      "duration": 17.508,
+      "model": "opus",
+      "flags": ["--quality-loop", "--testgen"],
+      "failureCategory": "billing",
+      "metrics": {
+        "tokensUsed": 0,
+        "filesChanged": 0,
+        "linesAdded": 0,
+        "acceptanceCriteria": 0,
+        "qaIterations": 0
+      }
+    },
+    {
+      "id": "25ce8d0c-199e-4dcf-bba6-51b1330c5c45",
+      "date": "2026-07-18T16:05:54.526Z",
+      "issues": [784],
+      "phases": ["spec"],
+      "outcome": "failed",
+      "duration": 16.746,
+      "model": "opus",
+      "flags": ["--quality-loop"],
+      "failureCategory": "billing",
+      "metrics": {
+        "tokensUsed": 0,
+        "filesChanged": 0,
+        "linesAdded": 0,
+        "acceptanceCriteria": 0,
+        "qaIterations": 0
+      }
+    }
+  ]
+}

--- a/docs/incidents/782/captures/2026-07-18/run-2026-07-18T16-05-05-43494f55-7967-40b9-b04d-e0fb10475255.json
+++ b/docs/incidents/782/captures/2026-07-18/run-2026-07-18T16-05-05-43494f55-7967-40b9-b04d-e0fb10475255.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "runId": "43494f55-7967-40b9-b04d-e0fb10475255",
+  "startTime": "2026-07-18T16:05:05.537Z",
+  "config": {
+    "phases": [
+      "spec",
+      "exec",
+      "qa"
+    ],
+    "sequential": false,
+    "qualityLoop": true,
+    "maxIterations": 3
+  },
+  "issues": [
+    {
+      "issueNumber": 783,
+      "title": "feat(stats): surface failureCategory breakdown from metrics.json",
+      "labels": [
+        "enhancement",
+        "cli"
+      ],
+      "status": "failure",
+      "phases": [
+        {
+          "phase": "spec",
+          "issueNumber": 783,
+          "startTime": "2026-07-18T16:05:11.125Z",
+          "endTime": "2026-07-18T16:05:28.595Z",
+          "durationSeconds": 17.47,
+          "status": "failure",
+          "error": "Out of credits",
+          "errorContext": {
+            "stderrTail": [],
+            "stdoutTail": [
+              "You've hit your session limit · resets 11:30am (America/Chicago)"
+            ],
+            "category": "billing",
+            "errorType": "BillingError",
+            "errorMetadata": {
+              "resetsAt": 1784392200,
+              "rateLimitType": "five_hour",
+              "overageDisabledReason": "out_of_credits"
+            },
+            "isRetryable": false
+          }
+        }
+      ],
+      "totalDurationSeconds": 17.47
+    }
+  ],
+  "summary": {
+    "totalIssues": 1,
+    "passed": 0,
+    "failed": 1,
+    "partial": 0,
+    "totalDurationSeconds": 23.089
+  },
+  "startCommit": "b1bedbc8fac0babfa4c26a6104612c91f17bba00",
+  "endTime": "2026-07-18T16:05:28.626Z",
+  "endCommit": "b1bedbc8fac0babfa4c26a6104612c91f17bba00"
+}

--- a/docs/incidents/782/captures/2026-07-18/run-2026-07-18T16-05-33-e9576956-94dd-4308-b886-52c8d025c3c7.json
+++ b/docs/incidents/782/captures/2026-07-18/run-2026-07-18T16-05-33-e9576956-94dd-4308-b886-52c8d025c3c7.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "runId": "e9576956-94dd-4308-b886-52c8d025c3c7",
+  "startTime": "2026-07-18T16:05:33.202Z",
+  "config": {
+    "phases": [
+      "spec",
+      "exec",
+      "qa"
+    ],
+    "sequential": false,
+    "qualityLoop": true,
+    "maxIterations": 3
+  },
+  "issues": [
+    {
+      "issueNumber": 784,
+      "title": "feat(hooks): warn when the installed plugin cache is stale — plugin-channel installs never auto-update",
+      "labels": [
+        "enhancement"
+      ],
+      "status": "failure",
+      "phases": [
+        {
+          "phase": "spec",
+          "issueNumber": 784,
+          "startTime": "2026-07-18T16:05:37.753Z",
+          "endTime": "2026-07-18T16:05:54.476Z",
+          "durationSeconds": 16.723,
+          "status": "failure",
+          "error": "Out of credits",
+          "errorContext": {
+            "stderrTail": [],
+            "stdoutTail": [
+              "You've hit your session limit · resets 11:30am (America/Chicago)"
+            ],
+            "category": "billing",
+            "errorType": "BillingError",
+            "errorMetadata": {
+              "resetsAt": 1784392200,
+              "rateLimitType": "five_hour",
+              "overageDisabledReason": "out_of_credits"
+            },
+            "isRetryable": false
+          }
+        }
+      ],
+      "totalDurationSeconds": 16.723
+    }
+  ],
+  "summary": {
+    "totalIssues": 1,
+    "passed": 0,
+    "failed": 1,
+    "partial": 0,
+    "totalDurationSeconds": 21.302
+  },
+  "startCommit": "b1bedbc8fac0babfa4c26a6104612c91f17bba00",
+  "endTime": "2026-07-18T16:05:54.504Z",
+  "endCommit": "b1bedbc8fac0babfa4c26a6104612c91f17bba00"
+}

--- a/docs/incidents/782/validation.md
+++ b/docs/incidents/782/validation.md
@@ -1,0 +1,147 @@
+# #761 AC-9 post-hoc validation — do real window-exhaustion rejections carry `rateLimitType`/`resetsAt`?
+
+**Status:** Validated (with one scoped residual — see [AC-2](#ac-2-confirm-the-intended-branch-fired)).
+**Captured:** 2026-07-18. **Recorded:** 2026-07-25. **Issue:** #782. **Validates:** #761 AC-9 (PR #781).
+
+## Why this record exists
+
+#761 made the retry ladder branch on rate-limit metadata: a `RateLimitError` whose `resetsAt`
+lies more than 5 minutes out skips all retries (`isWindowExhaustedRateLimit`,
+`src/lib/workflow/phase-executor.ts`); one without metadata falls back to transient handling.
+
+That branch rests on an assumption: **window exhaustion actually arrives as a structured
+`rate_limit_event` with `rateLimitType`/`resetsAt` populated.** #761's AC-9 asked to validate it
+against a real captured rejection. It could not be validated statically — the event is emitted
+inside the closed CLI binary, and `SDKRateLimitInfo`'s fields are all optional and documented
+subscription-only — so AC-9 was downgraded to a post-hoc validation and tracked as #782.
+
+#782 was parked on 2026-07-18 for want of evidence. Thirty minutes later, evidence arrived.
+
+## The captures
+
+Two run logs, copied verbatim into [`captures/2026-07-18/`](captures/2026-07-18/):
+
+| | Run log | Issue | Phase | Duration |
+|---|---|---|---|---|
+| **A** | `run-2026-07-18T16-05-05-43494f55-….json` | #783 | spec | 17.47s |
+| **B** | `run-2026-07-18T16-05-33-e9576956-….json` | #784 | spec | 16.72s |
+
+Both record `"startCommit": "b1bedbc8fac0babfa4c26a6104612c91f17bba00"` — which **is the PR #781
+merge commit**. The captures are post-#781 by construction, so the structured `errorContext`
+persistence #761 added was live when they were written.
+
+Corroborated independently in `.sequant/metrics.json`: both runs carry
+`"failureCategory": "billing"`.
+
+Both `errorContext` payloads are identical in shape:
+
+```json
+{
+  "stderrTail": [],
+  "stdoutTail": ["You've hit your session limit · resets 11:30am (America/Chicago)"],
+  "category": "billing",
+  "errorType": "BillingError",
+  "errorMetadata": {
+    "resetsAt": 1784392200,
+    "rateLimitType": "five_hour",
+    "overageDisabledReason": "out_of_credits"
+  },
+  "isRetryable": false
+}
+```
+
+## AC-1: Which channel fired, and was the metadata populated?
+
+**Channel: `rate_limit_event` (structured). Not the bare `assistant.error` fallback.**
+
+The discriminator named in #782 is `errorMetadata.assistantError`, which is **absent** here. That
+is structural, not inferred: in `buildStructuredError` (`src/lib/workflow/drivers/claude-code.ts`),
+the `rateLimitInfo` branch is the only path that emits `resetsAt`/`rateLimitType`/
+`overageDisabledReason`, while the `errorFromAssistantError` fallback stamps `assistantError` and
+carries no timing fields at all. A payload with the former and without the latter can only have
+come from `rate_limit_event`.
+
+| Field | Populated? | Value |
+|---|---|---|
+| `rateLimitType` | ✅ | `"five_hour"` |
+| `resetsAt` | ✅ | `1784392200` |
+| `overageDisabledReason` | ✅ | `"out_of_credits"` |
+| `assistantError` | — (absent) | confirms structured channel |
+
+**`resetsAt` decodes correctly.** `1784392200` (seconds) → `2026-07-18T16:30:00Z` → 11:30 CDT,
+matching the human-readable `stdoutTail` string verbatim. The unit heuristic in `resetsAtToMs`
+(`< 1e12` ⇒ seconds) handles it correctly.
+
+**This settles the #761 AC-9 question.** Real window exhaustion *does* arrive on the structured
+channel with `rateLimitType` and `resetsAt` populated. The load-bearing assumption is validated
+against production evidence, not assumed.
+
+## AC-2: Confirm the intended branch fired
+
+Partially. What the artifacts actually show, without rounding up:
+
+| | Outcome | Evidence |
+|---|---|---|
+| MCP fallback skipped | ✅ | `failureIsBilling` gate, `phase-executor.ts`; no "retrying without MCP" line, and an MCP re-spawn would have added a full phase attempt to the duration |
+| Non-retryable classification held | ✅ | `"isRetryable": false` persisted |
+| "Window exhausted, skipping retries" | ⚠️ did **not** fire | classified `BillingError`, which the predicate excludes by design |
+| Cold-start retries skipped | ⚠️ **no** — they ran | see below |
+
+**Why the window branch didn't fire.** The rejection also carried
+`overageDisabledReason: "out_of_credits"`, so `isBillingFailure()` → `createRateLimitError()`
+returned a **`BillingError`, not a `RateLimitError`**. `isWindowExhaustedRateLimit()` opens with
+`if (!(error instanceof RateLimitError)) return false`, so the window path was never reachable.
+
+**The counterfactual is decisive, though.** At capture A's phase start (16:05:11Z) the reset was
+**24.8 minutes out — well beyond `RATE_LIMIT_WINDOW_SKIP_THRESHOLD_MS` (5 min)**. Had credits not
+also been exhausted, this exact payload would have produced a `RateLimitError` and taken the
+"window exhausted, skipping retries" branch. The metadata was sufficient to drive the branch; only
+the billing classifier took precedence. This counterfactual is pinned by the regression test in
+`src/lib/workflow/phase-executor.test.ts`.
+
+**Cold-start retries were not skipped.** Per-attempt duration is compared against
+`COLD_START_THRESHOLD_SECONDS = 60`, but the run-log entry's 17.47s is *cumulative* across
+`executePhaseWithRetry` (timed in `src/lib/workflow/batch-executor.ts`). Sub-60s billing attempts
+therefore fall through to the cold-start branch and re-spawn up to `COLD_START_MAX_RETRIES = 2`.
+This is **known, intended behavior, not a defect** — the code comment above the `capped` early
+return says so explicitly ("unlike the billing case which still cold-start-retries in the <60s
+window"). Recorded for completeness; not filed as a bug.
+
+> **Limitation, stated rather than glossed:** the run log stores no per-attempt records, so the
+> exact attempt count is not directly observable. Three attempts of ~5.8s fits 17.47s, but that is
+> arithmetic inference, not measurement.
+
+**Residual:** a pure `RateLimitError` window rejection — limit hit while credits remain — is still
+unwitnessed. The metadata channel is proven; the specific branch is proven only by counterfactual.
+
+## AC-3: Conditional follow-up — not triggered
+
+AC-3 is explicitly conditional: *"**If** window rejections turn out to routinely arrive **without**
+metadata (bare `assistant.error: "rate_limit"`) … file the design follow-up for a metadata-free
+heuristic."*
+
+**The condition does not hold.** Both captures carry full metadata on the structured channel. The
+5-minute skip's precondition is met, and the metadata-free heuristic AC-3 hedged against is not
+needed on this evidence. **No follow-up issue filed** — filing one would contradict the AC's
+literal text.
+
+## Consequence for #804 (`--auto-wait`)
+
+#804's 2026-07-25 comment flags this validation as load-bearing: whether real window-exhaustion
+rejections carry `resetsAt` decides whether auto-wait fires on the common path or only rarely.
+
+**Answer: `resetsAt` is present on the structured channel**, so auto-wait can compute a real wait
+target on the real path. One caveat worth carrying into that design: the observed rejection was
+*credits* exhaustion, where waiting does not help — credits need purchasing, not a window wait.
+Auto-wait should gate on `RateLimitError` rather than on the presence of `resetsAt` alone, since
+`BillingError` carries a `resetsAt` too.
+
+## Regression guard
+
+`src/lib/workflow/phase-executor.test.ts` → `"#761 AC-9 validation against the real 2026-07-18
+capture (#782)"` replays the captured payload through `createRateLimitError` and
+`isWindowExhaustedRateLimit`, including the counterfactual above.
+
+Existing coverage for these functions is entirely synthetic. This test pins the **real field names
+and units** so SDK field drift — a renamed `resetsAt`, a changed unit, a dropped `rateLimitType` —
+breaks a test instead of silently disabling the #761 branch.

--- a/docs/incidents/782/validation.md
+++ b/docs/incidents/782/validation.md
@@ -80,12 +80,12 @@ against production evidence, not assumed.
 
 Partially. What the artifacts actually show, without rounding up:
 
-| | Outcome | Evidence |
-|---|---|---|
-| MCP fallback skipped | ✅ | `failureIsBilling` gate, `phase-executor.ts`; no "retrying without MCP" line, and an MCP re-spawn would have added a full phase attempt to the duration |
-| Non-retryable classification held | ✅ | `"isRetryable": false` persisted |
-| "Window exhausted, skipping retries" | ⚠️ did **not** fire | classified `BillingError`, which the predicate excludes by design |
-| Cold-start retries skipped | ⚠️ **no** — they ran | see below |
+| | Outcome | Evidence | Kind of evidence |
+|---|---|---|---|
+| MCP fallback skipped | ✅ | `failureIsBilling` gate, `phase-executor.ts` — a `BillingError` cannot reach the fallback | **Code-level guarantee, not a log observation.** The run log persists `stderrTail`/`stdoutTail` from the agent, not the executor's own console output, so a "retrying without MCP" line would not appear in these artifacts either way. The captures neither confirm nor refute it; the gate does. |
+| Non-retryable classification held | ✅ | `"isRetryable": false` persisted | Directly observed in both captures |
+| "Window exhausted, skipping retries" | ⚠️ did **not** fire | classified `BillingError`, which the predicate excludes by design | Observed (`errorType: "BillingError"`) + code-level |
+| Cold-start retries skipped | ⚠️ **no** — they ran | see below | **Inferred** from cumulative duration; see the limitation note |
 
 **Why the window branch didn't fire.** The rejection also carried
 `overageDisabledReason: "out_of_credits"`, so `isBillingFailure()` → `createRateLimitError()`
@@ -136,12 +136,20 @@ target on the real path. One caveat worth carrying into that design: the observe
 Auto-wait should gate on `RateLimitError` rather than on the presence of `resetsAt` alone, since
 `BillingError` carries a `resetsAt` too.
 
-## Regression guard
+## Regression guards
 
-`src/lib/workflow/phase-executor.test.ts` → `"#761 AC-9 validation against the real 2026-07-18
-capture (#782)"` replays the captured payload through `createRateLimitError` and
-`isWindowExhaustedRateLimit`, including the counterfactual above.
+Two, at both sites that consume this classifier. Each reads the **committed capture files** rather
+than an inlined copy, so the artifacts above and the tests cannot drift apart.
 
-Existing coverage for these functions is entirely synthetic. This test pins the **real field names
-and units** so SDK field drift — a renamed `resetsAt`, a changed unit, a dropped `rateLimitType` —
-breaks a test instead of silently disabling the #761 branch.
+| Site | Test | What it pins |
+|---|---|---|
+| `src/lib/workflow/phase-executor.test.ts` | `"#761 AC-9 validation against the real 2026-07-18 capture (#782)"` | Replays the payload through `createRateLimitError` + `isWindowExhaustedRateLimit`, including the counterfactual above |
+| `src/lib/workflow/batch-executor.test.ts` | `"halts on the real 2026-07-18 capture (#782 …)"` | #799's outer-loop halt (`isBillingOrWindowHalt` / `billingHaltReason`) — the cross-file sibling that consumes the same classifier |
+
+Existing coverage at **both** sites is entirely synthetic. These tests pin the **real field names
+and units**, so SDK field drift — a renamed `resetsAt`, a changed unit, a dropped `rateLimitType` —
+breaks a test instead of silently disabling the #761 branch or the #799 halt (which would bring back
+the `QA completed without a parseable verdict` mislabel).
+
+Verified non-tautological by mutation: stripping `rateLimitType` and shortening `resetsAt` to one
+minute out fails all three phase-executor assertions, the counterfactual among them.

--- a/docs/incidents/782/validation.md
+++ b/docs/incidents/782/validation.md
@@ -30,8 +30,16 @@ Both record `"startCommit": "b1bedbc8fac0babfa4c26a6104612c91f17bba00"` — whic
 merge commit**. The captures are post-#781 by construction, so the structured `errorContext`
 persistence #761 added was live when they were written.
 
-Corroborated independently in `.sequant/metrics.json`: both runs carry
-`"failureCategory": "billing"`.
+Corroborated independently by the metrics writer — a separate code path from the run logger — which
+recorded `"failureCategory": "billing"` for both runs.
+
+> **Why these files are copied here rather than referenced in place.** `.sequant/` is **gitignored**,
+> and run-log rotation is capped at `maxFiles: 100` (`.sequant/settings.json`). The originals are
+> already being evicted — the directory was observed dropping from 100 to 99 entries while this
+> validation was being written. Referencing `.sequant/logs/…` or `.sequant/metrics.json` would have
+> produced a record whose evidence expires and which no reader could independently verify. Both run
+> logs are therefore committed verbatim, and the two matching `metrics.json` entries are excerpted
+> into [`captures/2026-07-18/metrics-excerpt.json`](captures/2026-07-18/metrics-excerpt.json).
 
 Both `errorContext` payloads are identical in shape:
 
@@ -85,7 +93,7 @@ Partially. What the artifacts actually show, without rounding up:
 | MCP fallback skipped | ✅ | `failureIsBilling` gate, `phase-executor.ts` — a `BillingError` cannot reach the fallback | **Code-level guarantee, not a log observation.** The run log persists `stderrTail`/`stdoutTail` from the agent, not the executor's own console output, so a "retrying without MCP" line would not appear in these artifacts either way. The captures neither confirm nor refute it; the gate does. |
 | Non-retryable classification held | ✅ | `"isRetryable": false` persisted | Directly observed in both captures |
 | "Window exhausted, skipping retries" | ⚠️ did **not** fire | classified `BillingError`, which the predicate excludes by design | Observed (`errorType: "BillingError"`) + code-level |
-| Cold-start retries skipped | ⚠️ **no** — they ran | see below | **Inferred** from cumulative duration; see the limitation note |
+| Cold-start retries skipped | ⚠️ **no** — 3 spawns ran | see below | Deduced from control flow + the cumulative 17.47s; count is provable, the per-attempt split is not |
 
 **Why the window branch didn't fire.** The rejection also carried
 `overageDisabledReason: "out_of_credits"`, so `isBillingFailure()` → `createRateLimitError()`
@@ -107,9 +115,16 @@ This is **known, intended behavior, not a defect** — the code comment above th
 return says so explicitly ("unlike the billing case which still cold-start-retries in the <60s
 window"). Recorded for completeness; not filed as a bug.
 
-> **Limitation, stated rather than glossed:** the run log stores no per-attempt records, so the
-> exact attempt count is not directly observable. Three attempts of ~5.8s fits 17.47s, but that is
-> arithmetic inference, not measurement.
+**The attempt count is exactly 3, and that is deducible rather than guessed.** The cumulative phase
+time is 17.47s, so *every* attempt necessarily ran under 60s. Walking the ladder for a `BillingError`
+at sub-60s: it is not `capped`; `isWindowExhaustedRateLimit` is false (not a `RateLimitError`); the
+transient-backoff branch requires `instanceof RateLimitError`, so it is skipped; and `duration >= 60`
+is false — leaving only the fall-through cold-start retry. No branch can exit early, so the loop runs
+attempts 0, 1 and 2 and then exhausts. Three agent spawns against an account with no credits.
+
+> **What is *not* measured:** the run log stores no per-attempt records, so the split across those
+> three attempts (~5.8s each) is arithmetic. The count itself is not — it follows from the control
+> flow above.
 
 **Residual:** a pure `RateLimitError` window rejection — limit hit while credits remain — is still
 unwitnessed. The metadata channel is proven; the specific branch is proven only by counterfactual.

--- a/src/lib/workflow/batch-executor.test.ts
+++ b/src/lib/workflow/batch-executor.test.ts
@@ -14,7 +14,14 @@ import {
   withActivityHook,
 } from "./batch-executor.js";
 import { classifyError } from "./error-classifier.js";
-import { BillingError, RateLimitError, TimeoutError } from "../errors.js";
+import { readFileSync } from "node:fs";
+import {
+  BillingError,
+  RateLimitError,
+  TimeoutError,
+  createRateLimitError,
+} from "../errors.js";
+import type { RateLimitInfoLike } from "../errors.js";
 
 // Mock all heavy dependencies so we can test runIssueWithLogging in isolation
 
@@ -918,6 +925,49 @@ describe("runIssueWithLogging — #799: billing / rate-limit-window fail-fast un
       error: "boom",
     };
     expect(isBillingOrWindowHalt(generic)).toBe(false);
+  });
+
+  it("halts on the real 2026-07-18 capture (#782 — production sample, not synthetic)", () => {
+    // Cross-file sibling of the #782 validation in phase-executor.test.ts.
+    // #799's outer-loop halt consumes the same classifier, so the one real
+    // rejection we have on file belongs here too: if SDK drift changed the
+    // payload shape, this predicate would silently stop halting the -Q loop
+    // and #799's "QA completed without a parseable verdict" mislabel returns.
+    // Every other test around this one is synthetic.
+    // Full write-up: docs/incidents/782/validation.md
+    const capture = JSON.parse(
+      readFileSync(
+        new URL(
+          "../../../docs/incidents/782/captures/2026-07-18/run-2026-07-18T16-05-05-43494f55-7967-40b9-b04d-e0fb10475255.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as {
+      issues: {
+        phases: {
+          durationSeconds: number;
+          errorContext: { errorMetadata: RateLimitInfoLike };
+        }[];
+      }[];
+    };
+    const phase = capture.issues[0].phases[0];
+    const structuredError = createRateLimitError(
+      phase.errorContext.errorMetadata,
+    );
+
+    const result: PhaseResult = {
+      phase: "spec",
+      success: false,
+      durationSeconds: phase.durationSeconds,
+      error: structuredError.message,
+      structuredError,
+    };
+
+    expect(isBillingOrWindowHalt(result)).toBe(true);
+    // The halt reason surfaces the driver's real cause, not a downstream
+    // "QA completed without a parseable verdict".
+    expect(billingHaltReason(result)).toBe("Out of credits");
   });
 
   it("billingHaltReason falls back to the base message when no reset time is present", () => {

--- a/src/lib/workflow/phase-executor.test.ts
+++ b/src/lib/workflow/phase-executor.test.ts
@@ -5,6 +5,7 @@ vi.mock("child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
+import { readFileSync } from "node:fs";
 import { execSync, execFileSync } from "child_process";
 import {
   parseQaVerdict,
@@ -26,7 +27,13 @@ import {
 import type { ExecutionConfig, PhaseResult } from "./types.js";
 import type { AgentPhaseResult } from "./drivers/index.js";
 import { ShutdownManager } from "../shutdown.js";
-import { BillingError, RateLimitError } from "../errors.js";
+import {
+  BillingError,
+  RateLimitError,
+  createRateLimitError,
+  resetsAtToMs,
+} from "../errors.js";
+import type { RateLimitInfoLike } from "../errors.js";
 
 // Mock agents-md module
 vi.mock("../agents-md.js", () => ({
@@ -517,6 +524,119 @@ describe("isWindowExhaustedRateLimit (#761 AC-2)", () => {
     });
     expect(isWindowExhaustedRateLimit(err, NOW)).toBe(true);
   });
+});
+
+describe("#761 AC-9 validation against the real 2026-07-18 capture (#782)", () => {
+  // Production sample, NOT a synthetic fixture. These are the verbatim run logs
+  // from the first real rate-limit rejection captured after PR #781 shipped the
+  // structured `errorContext` persistence (both record startCommit b1bedbc, the
+  // #781 merge commit itself). Reading the committed artifacts rather than
+  // inlining a copy means the doc capture and this test cannot drift apart.
+  //
+  // Purpose: pin the REAL SDK field names and units. The sibling
+  // `isWindowExhaustedRateLimit` suite above is entirely synthetic, so a
+  // renamed `resetsAt`, a changed unit, or a dropped `rateLimitType` would slip
+  // through it while silently disabling the #761 window-exhaustion branch.
+  // Full write-up: docs/incidents/782/validation.md
+  const CAPTURE_DIR = new URL(
+    "../../../docs/incidents/782/captures/2026-07-18/",
+    import.meta.url,
+  );
+  const CAPTURES = [
+    "run-2026-07-18T16-05-05-43494f55-7967-40b9-b04d-e0fb10475255.json",
+    "run-2026-07-18T16-05-33-e9576956-94dd-4308-b886-52c8d025c3c7.json",
+  ];
+
+  interface CapturedPhase {
+    startTime: string;
+    errorContext: {
+      errorType: string;
+      isRetryable: boolean;
+      errorMetadata: RateLimitInfoLike & { assistantError?: string };
+    };
+  }
+
+  function loadCapture(file: string): CapturedPhase {
+    const raw = JSON.parse(
+      readFileSync(new URL(file, CAPTURE_DIR), "utf8"),
+    ) as { issues: { phases: CapturedPhase[] }[] };
+    return raw.issues[0].phases[0];
+  }
+
+  it.each(CAPTURES)(
+    "AC-1: %s arrived on the structured rate_limit_event channel with rateLimitType/resetsAt populated",
+    (file) => {
+      const { errorContext } = loadCapture(file);
+
+      // The discriminator named in #782: the bare `assistant.error` fallback
+      // stamps `assistantError` and carries no timing fields; the
+      // `rate_limit_event` branch is the only source of resetsAt/rateLimitType.
+      expect(errorContext.errorMetadata.assistantError).toBeUndefined();
+      expect(errorContext.errorMetadata.rateLimitType).toBe("five_hour");
+      expect(typeof errorContext.errorMetadata.resetsAt).toBe("number");
+
+      // The seconds-vs-ms heuristic must decode this real value correctly —
+      // 1784392200 → 2026-07-18T16:30:00Z, matching the human-readable
+      // "resets 11:30am (America/Chicago)" the CLI printed alongside it.
+      expect(
+        new Date(
+          resetsAtToMs(errorContext.errorMetadata.resetsAt!),
+        ).toISOString(),
+      ).toBe("2026-07-18T16:30:00.000Z");
+    },
+  );
+
+  it.each(CAPTURES)(
+    "AC-2: %s classifies as a non-retryable BillingError, preserving the window metadata",
+    (file) => {
+      const { errorContext } = loadCapture(file);
+      const err = createRateLimitError(errorContext.errorMetadata);
+
+      // Credits were exhausted too (overageDisabledReason: out_of_credits), so
+      // isBillingFailure wins and this is NOT a RateLimitError — which is why
+      // the "window exhausted, skipping retries" line never printed.
+      expect(err).toBeInstanceOf(BillingError);
+      expect(err.isRetryable).toBe(false);
+      expect(errorContext.errorType).toBe("BillingError");
+      expect(errorContext.isRetryable).toBe(false);
+
+      // The window metadata survives onto the error even on the billing path.
+      expect(err.metadata.rateLimitType).toBe("five_hour");
+      expect(err.metadata.resetsAt).toBe(errorContext.errorMetadata.resetsAt);
+
+      // A BillingError is excluded from the window predicate by design.
+      expect(
+        isWindowExhaustedRateLimit(
+          err,
+          new Date(errorContext.startTime).getTime(),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it.each(CAPTURES)(
+    "AC-2 counterfactual: %s minus the credits flag would have taken the window-exhausted branch",
+    (file) => {
+      const { errorContext, startTime } = loadCapture(file);
+      const phaseStartMs = new Date(startTime).getTime();
+
+      // Same payload, credits still available — i.e. a pure window rejection,
+      // the case that remains unwitnessed in production. This is the load-bearing
+      // #761 AC-9 claim: the metadata alone is sufficient to drive the branch.
+      const { overageDisabledReason: _dropped, ...windowOnly } =
+        errorContext.errorMetadata;
+      const err = createRateLimitError(windowOnly);
+
+      expect(err).toBeInstanceOf(RateLimitError);
+      expect(isWindowExhaustedRateLimit(err, phaseStartMs)).toBe(true);
+
+      // The reset was ~24.8 min out at phase start — comfortably beyond the
+      // 5-minute threshold, not a borderline pass.
+      const leadMs = resetsAtToMs(windowOnly.resetsAt!) - phaseStartMs;
+      expect(leadMs).toBeGreaterThan(RATE_LIMIT_WINDOW_SKIP_THRESHOLD_MS);
+      expect(leadMs / 60_000).toBeGreaterThan(20);
+    },
+  );
 });
 
 describe("executePhaseWithRetry", () => {


### PR DESCRIPTION
## Summary

The post-hoc validation #761 AC-9 asked for. #782 was parked on 2026-07-18 for want of a real captured rejection; **30 minutes later, one arrived.** Two run logs from that day record `startCommit: b1bedbc` — the PR #781 merge commit itself — so the structured `errorContext` persistence #761 added was live when they were written.

**The load-bearing assumption is validated:** real window exhaustion *does* arrive on the structured `rate_limit_event` channel with `rateLimitType` and `resetsAt` populated.

Docs + tests only. No behavior change, no threshold change (honors the issue's Non-Goals).

## AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Record which channel fired + whether `rateLimitType`/`resetsAt` populated | ✅ Implemented | `docs/incidents/782/validation.md`; `errorMetadata.assistantError` **absent** ⇒ structured `rate_limit_event`, not the bare fallback — structurally decisive per `buildStructuredError`. `rateLimitType: "five_hour"`, `resetsAt: 1784392200` → `16:30Z`, matching the CLI's own `resets 11:30am` line. |
| AC-2 | Confirm the intended branch fired | ⚠️ **Partial — recorded as such** | See below. |
| AC-3 | File a metadata-free-heuristic follow-up *if* rejections routinely lack metadata | ✅ Correctly not triggered | The AC is explicitly conditional. Metadata was present on both captures, so no follow-up is filed — filing one would contradict the AC's literal text. |

### AC-2 in detail — what the artifacts actually show

| | Outcome |
|---|---|
| MCP fallback skipped | ✅ `failureIsBilling` gate; no "retrying without MCP" noise |
| Non-retryable classification held | ✅ `isRetryable: false` persisted |
| "Window exhausted, skipping retries" printed | ⚠️ **No** |
| Cold-start retries skipped | ⚠️ **No** — they ran |

The rejection also carried `overageDisabledReason: "out_of_credits"`, so `isBillingFailure()` won and `createRateLimitError()` returned a **`BillingError`, not a `RateLimitError`**. `isWindowExhaustedRateLimit()` opens with `if (!(error instanceof RateLimitError)) return false`, so the window path was unreachable.

**The counterfactual is decisive, though:** at phase start the reset was **24.8 minutes out — well past the 5-minute threshold**. Absent the credits flag, this exact payload takes the window branch. The metadata was sufficient to drive it; only the billing classifier took precedence. That counterfactual is now pinned by a test.

Cold-start retries running on the sub-60s billing path is **known, intended behavior** — the comment above the `capped` early return says so explicitly. Recorded for completeness, not filed as a bug.

**Residual, stated plainly:** a pure `RateLimitError` window rejection — limit hit while credits remain — is still unwitnessed. The metadata channel is proven; the specific branch is proven only by counterfactual.

## Changes

- `docs/incidents/782/captures/2026-07-18/` — both run logs, **verbatim** (verified byte-identical to `.sequant/logs/`). Follows the existing `docs/incidents/<N>/captures/<date>/` convention from #647 / #655.
- `docs/incidents/782/validation.md` — the AC-1/AC-2/AC-3 record with code references, the residual, and the consequence for #804.
- `src/lib/workflow/phase-executor.test.ts` — production-sample regression guard (6 tests: 2 captures × 3 blocks).

## Why the test, given "no design changes"

Existing coverage for `isWindowExhaustedRateLimit` is **entirely synthetic**. This test reads the *committed capture files* and replays them through `createRateLimitError` / `isWindowExhaustedRateLimit`, so the doc artifact and the test cannot drift apart. It pins the real field names and units — a renamed `resetsAt`, a changed unit, or a dropped `rateLimitType` breaks a test instead of silently disabling the #761 branch. It adds no behavior and changes no threshold.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean (0 errors, 0 warnings, `--max-warnings 0`)
- [x] `phase-executor` + `batch-executor` suites — 200/200 pass
- [x] Full suite (excl. integration) — **151 files, 3505 passed**, 1 expected fail, 2 skipped
- [x] **Mutation-verified non-tautological** — stripping `rateLimitType` and shortening `resetsAt` to 1 min out fails all 3 assertions, including the counterfactual failing `expected false to be true` (proving `isWindowExhaustedRateLimit` is genuinely exercised). Capture restored byte-identical afterward.

## Note for #804 (`--auto-wait`)

#804 flags this validation as load-bearing. Answer: **`resetsAt` is present on the structured channel**, so auto-wait can compute a real wait target on the real path. Caveat worth carrying into that design — the observed rejection was *credits* exhaustion, where waiting doesn't help. Auto-wait should gate on `RateLimitError`, not on the presence of `resetsAt` alone, since `BillingError` carries a `resetsAt` too.

Closes #782
