### PR TITLE
fix(#808): parse bold AC markers that have no colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`- [ ] **AC-1** Desc` (bold identifier, no colon) no longer parses as zero acceptance criteria (#808)** — all four patterns in `src/lib/ac-parser.ts` required a colon attached to the AC identifier, so a very common authoring style matched nothing at all and `extractAcceptanceCriteria()` returned an empty set. It failed **silently**: no warning, no error, just zero ACs written to `.sequant/state.json`, an empty AC coverage table in `/qa`, and nothing for the `/spec` AC linter to lint — a run could complete having verified nothing. Hit on #803, whose five ACs were authored exactly this way and were only noticed because `/spec` printed the parsed count. Adds a fifth pattern matching `- [ ] **AC-1** Description`, which also covers the no-hyphen form (`**B2**`), checked boxes, and — via a trailing optional colon — the `**AC-1**: Description` variant where the colon sits outside the bold markers. Deliberately limited to the **bold** form: a bare `- [ ] AC1 something` is ambiguous against ordinary checklist prose, and widening that far would trade a silent miss for silent false positives. The `\d+` requirement on the identifier keeps non-identifier bold labels (`**Note**`, `**Verify**`, `**TODO**`) from being mistaken for ACs, which is covered by its own guard test. All existing colon-bearing formats parse unchanged. (#808)
+
 ## [2.9.0] - 2026-07-18
 
 ### Added

--- a/src/lib/ac-parser.test.ts
+++ b/src/lib/ac-parser.test.ts
@@ -34,6 +34,100 @@ describe("AC Parser", () => {
       );
     });
 
+    // #808: the bold-ID-without-colon style matched none of the four original
+    // patterns, so an issue written this way parsed as ZERO ACs — silently.
+    it("should parse bold AC markers with no colon", () => {
+      const issueBody = `
+## Acceptance Criteria
+
+- [ ] **AC-1** User can login with email and password
+- [ ] **AC-2** Session persists across page refreshes
+`;
+
+      const criteria = parseAcceptanceCriteria(issueBody);
+
+      expect(criteria.length).toBe(2);
+      expect(criteria[0].id).toBe("AC-1");
+      expect(criteria[0].description).toBe(
+        "User can login with email and password",
+      );
+      expect(criteria[1].id).toBe("AC-2");
+      expect(criteria[1].description).toBe(
+        "Session persists across page refreshes",
+      );
+    });
+
+    it("should parse the no-colon letter-number form (e.g., B2)", () => {
+      const criteria = parseAcceptanceCriteria(
+        "- [ ] **B2** /spec extracts and stores ACs in state\n",
+      );
+
+      expect(criteria.length).toBe(1);
+      expect(criteria[0].id).toBe("B2");
+      expect(criteria[0].description).toBe(
+        "/spec extracts and stores ACs in state",
+      );
+    });
+
+    it("should parse a checked box with a no-colon bold marker", () => {
+      const criteria = parseAcceptanceCriteria(
+        "- [x] **AC-1** Completed criterion\n",
+      );
+
+      expect(criteria.length).toBe(1);
+      expect(criteria[0].id).toBe("AC-1");
+      expect(criteria[0].description).toBe("Completed criterion");
+    });
+
+    it("should absorb a colon placed outside the bold markers", () => {
+      const criteria = parseAcceptanceCriteria(
+        "- [ ] **AC-1**: Description after an outside colon\n",
+      );
+
+      expect(criteria.length).toBe(1);
+      expect(criteria[0].id).toBe("AC-1");
+      // Without the `:?` in the pattern this would be ": Description after…".
+      expect(criteria[0].description).toBe(
+        "Description after an outside colon",
+      );
+    });
+
+    it("should not treat a non-identifier bold label as an AC", () => {
+      const issueBody = `
+- [ ] **Note** this is just a checklist item
+- [ ] **Verify** the deployment looks right
+- [ ] **TODO** something else
+`;
+
+      expect(parseAcceptanceCriteria(issueBody)).toEqual([]);
+    });
+
+    it("should parse issue #803's body verbatim (regression fixture)", () => {
+      // Copied unmodified from https://github.com/sequant-io/sequant/issues/803
+      // as originally authored. This body produced 0 ACs before #808.
+      const issueBody = `## Acceptance Criteria
+
+- [ ] **AC-1** After assembling the combined state and before running test/build, \`combined-branch-test.ts\` reinstalls dependencies when the lockfile changed (compare lockfile vs the base, or install unconditionally). Use the **detected package manager** (this repo is pnpm; don't hardcode \`npm install\`).
+- [ ] **AC-2** With deps reinstalled, a combined state whose branches only changed the lockfile (added a dep) reports \`npm test\`/\`npm run build\` **passed** — reproduce the #109-113-class scenario in a test/fixture and assert no false BLOCKED.
+- [ ] **AC-3** When test/build genuinely fails, the finding message includes a **non-empty reason**: fall back to a stdout tail when stderr is empty (both truncated). No more \`failed on combined state: \` with nothing after it.
+- [ ] **AC-4** Install failures themselves are surfaced distinctly (a bad merged lockfile → clear "dependency install failed" finding, not a downstream mystery test failure).
+- [ ] **AC-5** Regression test covering: (a) lockfile-changed combined state passes after reinstall, (b) empty-stderr failure still yields a diagnosable message.
+`;
+
+      const criteria = parseAcceptanceCriteria(issueBody);
+
+      expect(criteria.map((c) => c.id)).toEqual([
+        "AC-1",
+        "AC-2",
+        "AC-3",
+        "AC-4",
+        "AC-5",
+      ]);
+      expect(criteria[3].description).toContain(
+        "Install failures themselves are surfaced distinctly",
+      );
+    });
+
     it("should parse letter-number format (e.g., B2)", () => {
       const issueBody = `
 ## Acceptance Criteria

--- a/src/lib/ac-parser.ts
+++ b/src/lib/ac-parser.ts
@@ -41,6 +41,9 @@ import {
  * - `- [ ] **B2:** Description`
  * - `- [ ] **AC1:** Description`
  * - `- [ ] **AC-1: Description**` (bold wraps ID + description)
+ * - `- [ ] **AC-1** Description` (bold ID, no colon)
+ * - `- [ ] **AC-1**: Description` (colon outside the bold)
+ * - `- [ ] AC-1: Description`
  */
 const AC_PATTERNS = [
   // Pattern 1: `- [ ] **AC-1:** Description` or `- [x] **AC-1:** Description`
@@ -51,6 +54,21 @@ const AC_PATTERNS = [
   /^-\s*\[[x\s]\]\s*\*\*([A-Za-z]+-?\d+):\s*(.+?)\*\*\s*(.*)$/gim,
   // Pattern 4: `- [ ] AC-1: Description` (no bold)
   /^-\s*\[[x\s]\]\s*([A-Za-z]+-?\d+):\s*(.+)$/gim,
+  // Pattern 5: `- [ ] **AC-1** Description` / `- [ ] **AC-1**: Description` (#808)
+  //
+  // The colon-less form is a very common authoring style, and before this
+  // pattern existed it matched nothing at all — an issue written this way
+  // parsed as ZERO acceptance criteria, silently, with no warning anywhere
+  // downstream (#803's five ACs were written exactly like this).
+  //
+  // The trailing `:?` also absorbs a colon placed *outside* the bold, which
+  // would otherwise land in the description as a leading ": ".
+  //
+  // Deliberately requires the bold markers. A bare `- [ ] AC1 something` is
+  // ambiguous against ordinary checklist prose, so widening that far would
+  // trade a silent miss for silent false positives. The `\d+` at the end of
+  // the ID keeps non-identifier bold labels (`**Note**`, `**Verify**`) out.
+  /^-\s*\[[x\s]\]\s*\*\*([A-Za-z]+-?\d+)\*\*:?\s*(.+)$/gim,
 ];
 
 /**
@@ -144,6 +162,8 @@ function parseACLine(line: string): { id: string; description: string } | null {
  * - `- [ ] **AC-1:** Description`
  * - `- [ ] **B2:** Description`
  * - `- [ ] **AC-1: Description**` (bold wraps ID + description)
+ * - `- [ ] **AC-1** Description` (bold ID, no colon)
+ * - `- [ ] **AC-1**: Description` (colon outside the bold)
  * - `- [ ] AC-1: Description`
  *
  * @param issueBody - The full GitHub issue body markdown


### PR DESCRIPTION
## Summary

All four patterns in `src/lib/ac-parser.ts` required a **colon** attached to the AC identifier, so `- [ ] **AC-1** Description` — bold identifier, no colon — matched nothing and `extractAcceptanceCriteria()` returned an empty set.

It failed **silently**. No warning, no error, no "0 ACs parsed". Downstream: zero acceptance criteria in `.sequant/state.json`, an empty AC coverage table in `/qa`, and nothing for the `/spec` AC linter to lint. A run could complete having verified nothing.

Found while running `/fullsolve 803` — that issue's five ACs were authored exactly this way and parsed as zero. It was caught only because `/spec` happens to print the parsed count; the body was normalized by hand to unblock state tracking.

Adds a fifth pattern:

```ts
/^-\s*\[[x\s]\]\s*\*\*([A-Za-z]+-?\d+)\*\*:?\s*(.+)$/gim
```

## AC Verification

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | `- [ ] **AC-1** Description` extracts with id `AC-1` and correct description | ✅ Implemented | `ac-parser.ts:55-71`; test *"should parse bold AC markers with no colon"* |
| AC-2 | Same for `**B2**` and for checked boxes `- [x] **AC-1**` | ✅ Implemented | Tests *"should parse the no-colon letter-number form"* and *"should parse a checked box with a no-colon bold marker"*. `[A-Za-z]+-?\d+` covers the no-hyphen form without a second pattern |
| AC-3 | All four existing colon-bearing formats parse unchanged | ✅ Implemented | All 20 pre-existing `ac-parser.test.ts` cases pass untouched; the new pattern cannot steal them (it requires `**` immediately after the digits, which a `**AC-1:**` line does not have) |
| AC-4 | A bold token that is not an identifier is still not extracted | ✅ Implemented | Test *"should not treat a non-identifier bold label as an AC"* covers `**Note**`, `**Verify**`, `**TODO**`. The `\d+` requirement is what excludes them |
| AC-5 | Unit tests cover each new format plus #803's body verbatim | ✅ Implemented | 6 new cases, including *"should parse issue #803's body verbatim (regression fixture)"* with the body copied unmodified as originally authored |

**Bonus beyond the ACs:** the trailing `:?` also absorbs a colon placed *outside* the bold (`- [ ] **AC-1**: Description`), which would otherwise land in the description as a leading `": "`. Covered by its own test.

## Scope note

Deliberately limited to the **bold** form. A bare `- [ ] AC1 something` is genuinely ambiguous against ordinary checklist prose, and matching it would trade a silent miss for silent false positives — a worse failure mode than the one being fixed. Stated in a code comment at the pattern.

## Sibling-site scan

`ac-parser.ts` is the **only** checkbox-based AC extractor in the codebase. The other `AC-\d+` matchers were checked and none share this defect:

| Site | Pattern | Verdict |
|------|---------|---------|
| `phase-executor.ts:221` | `/^\s*\|\s*\*?\*?AC-\d+/` | Markdown *table* rows, not checkboxes — different corpus |
| `qa/SKILL.md:2330` | `awk '/^(#+ AC-[0-9]+\|\*\*AC-[0-9]+)/'` | Already colon-agnostic |
| `scripts/qa/precheck.ts:207` | `/AC-\d+/g` | Bare ID extraction, colon-agnostic |
| `exec/SKILL.md:355`, `qa/SKILL.md:635` | `grep -E '\|[^\|]+\|\s*AC-[0-9]+:'` | Reads the *derived ACs table that `/spec` itself generates* with a colon — not user-authored text |

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npx vitest run src/lib/ac-parser.test.ts` — 26 passed (20 pre-existing + 6 new)
- [x] AC-adjacent suites (`ac-linter`, `scope`) — 129 passed
- [x] Full `npm test` — **191 files, 4048 passed, 1 expected fail, 2 skipped, 0 failures**
- [x] Regression value verified: with the new pattern removed, **5 of the 6 new tests fail**. The sixth is the over-match guard, which correctly passes both ways.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
