### PR TITLE
chore(assess): sync chain flag references and add chain-resume rule

### DIFF
--- a/.claude/skills/assess/SKILL.md
+++ b/.claude/skills/assess/SKILL.md
@@ -198,9 +198,13 @@ Triggers (any one):
 
 Format: `Chain: <CMD_PREFIX> run <N1> <N2> --chain -Q <phases>   # alternative — <one-line reason>` (`<CMD_PREFIX>` resolved in Step 1)
 
-Flag references:
-- `--chain` chains issues (each branches from previous; implies `--sequential`)
+Flag references (only `--chain` itself is emitted by default — the rest are conditional):
+- `--chain` — each successor is rebased onto the predecessor's committed work before it runs; implies `--sequential`
 - `--base <branch>` — issue references a feature branch
+- `--stacked` — implies `--chain`; non-first PRs target the predecessor branch instead of main. Never add it to the default `Chain:` line. Mention it only for 3+ chained issues where incremental PR review is the point (2-issue stacks are manifest-only, so it buys nothing there), and note that it constrains merge order — `/merger` warns when stacked PRs are processed out of order.
+- `--strict-preflight` — turns `--chain`'s content pre-flight warnings (missing AC section, dependency/overlap order, closed issues) into a hard stop before any worktree is provisioned. Rarely worth suggesting here: assess already routes AC-less issues to `?` and blocked issues to `‖`, so the set that reaches a `Chain:` line normally clears the pre-flight anyway. Mention it only when a chain member's ACs or dependency markers are expected to change before the run.
+
+**Chain resume (#760):** When a `Chain:` line covers issues where some links are already complete (`ready_for_merge` or `merged`), the line still lists the **full original issue set** — do not trim it to the incomplete links. `run-orchestrator.ts` computes a chain-correct resume plan from the full list: it skips the completed prefix and rebases the first incomplete link onto that prefix's committed tip. Trimming leaves that link at index 0, where the successor-rebase never fires and it silently builds on `main` (the #748 bug). Only a *contiguous* leading run of completed links is skipped, so a complete → incomplete → complete sequence re-executes the trailing link too. The single-issue `--phases exec,qa   # resume` idiom does not apply inside a `Chain:` line.
 
 ### Step 5: Conflict Detection
 
@@ -293,7 +297,7 @@ The commands block is headed by `Commands:` — no box-drawing, no character cou
 
 1. Only PROCEED and REWRITE issues get commands
 2. Group by identical phases + flags → same line
-3. Resume issues get `# resume` comment
+3. Resume issues get `# resume` comment (does not apply inside a `Chain:` line — see "Chain resume" in Step 4)
 4. Rewrite issues get `# restart` comment
 5. Chain mode issues use `--chain` flag (see `Chain:` annotation rules below)
 6. If ALL issues share the same workflow, emit a single command

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -198,9 +198,13 @@ Triggers (any one):
 
 Format: `Chain: <CMD_PREFIX> run <N1> <N2> --chain -Q <phases>   # alternative — <one-line reason>` (`<CMD_PREFIX>` resolved in Step 1)
 
-Flag references:
-- `--chain` chains issues (each branches from previous; implies `--sequential`)
+Flag references (only `--chain` itself is emitted by default — the rest are conditional):
+- `--chain` — each successor is rebased onto the predecessor's committed work before it runs; implies `--sequential`
 - `--base <branch>` — issue references a feature branch
+- `--stacked` — implies `--chain`; non-first PRs target the predecessor branch instead of main. Never add it to the default `Chain:` line. Mention it only for 3+ chained issues where incremental PR review is the point (2-issue stacks are manifest-only, so it buys nothing there), and note that it constrains merge order — `/merger` warns when stacked PRs are processed out of order.
+- `--strict-preflight` — turns `--chain`'s content pre-flight warnings (missing AC section, dependency/overlap order, closed issues) into a hard stop before any worktree is provisioned. Rarely worth suggesting here: assess already routes AC-less issues to `?` and blocked issues to `‖`, so the set that reaches a `Chain:` line normally clears the pre-flight anyway. Mention it only when a chain member's ACs or dependency markers are expected to change before the run.
+
+**Chain resume (#760):** When a `Chain:` line covers issues where some links are already complete (`ready_for_merge` or `merged`), the line still lists the **full original issue set** — do not trim it to the incomplete links. `run-orchestrator.ts` computes a chain-correct resume plan from the full list: it skips the completed prefix and rebases the first incomplete link onto that prefix's committed tip. Trimming leaves that link at index 0, where the successor-rebase never fires and it silently builds on `main` (the #748 bug). Only a *contiguous* leading run of completed links is skipped, so a complete → incomplete → complete sequence re-executes the trailing link too. The single-issue `--phases exec,qa   # resume` idiom does not apply inside a `Chain:` line.
 
 ### Step 5: Conflict Detection
 
@@ -293,7 +297,7 @@ The commands block is headed by `Commands:` — no box-drawing, no character cou
 
 1. Only PROCEED and REWRITE issues get commands
 2. Group by identical phases + flags → same line
-3. Resume issues get `# resume` comment
+3. Resume issues get `# resume` comment (does not apply inside a `Chain:` line — see "Chain resume" in Step 4)
 4. Rewrite issues get `# restart` comment
 5. Chain mode issues use `--chain` flag (see `Chain:` annotation rules below)
 6. If ALL issues share the same workflow, emit a single command

--- a/templates/skills/assess/SKILL.md
+++ b/templates/skills/assess/SKILL.md
@@ -198,9 +198,13 @@ Triggers (any one):
 
 Format: `Chain: <CMD_PREFIX> run <N1> <N2> --chain -Q <phases>   # alternative — <one-line reason>` (`<CMD_PREFIX>` resolved in Step 1)
 
-Flag references:
-- `--chain` chains issues (each branches from previous; implies `--sequential`)
+Flag references (only `--chain` itself is emitted by default — the rest are conditional):
+- `--chain` — each successor is rebased onto the predecessor's committed work before it runs; implies `--sequential`
 - `--base <branch>` — issue references a feature branch
+- `--stacked` — implies `--chain`; non-first PRs target the predecessor branch instead of main. Never add it to the default `Chain:` line. Mention it only for 3+ chained issues where incremental PR review is the point (2-issue stacks are manifest-only, so it buys nothing there), and note that it constrains merge order — `/merger` warns when stacked PRs are processed out of order.
+- `--strict-preflight` — turns `--chain`'s content pre-flight warnings (missing AC section, dependency/overlap order, closed issues) into a hard stop before any worktree is provisioned. Rarely worth suggesting here: assess already routes AC-less issues to `?` and blocked issues to `‖`, so the set that reaches a `Chain:` line normally clears the pre-flight anyway. Mention it only when a chain member's ACs or dependency markers are expected to change before the run.
+
+**Chain resume (#760):** When a `Chain:` line covers issues where some links are already complete (`ready_for_merge` or `merged`), the line still lists the **full original issue set** — do not trim it to the incomplete links. `run-orchestrator.ts` computes a chain-correct resume plan from the full list: it skips the completed prefix and rebases the first incomplete link onto that prefix's committed tip. Trimming leaves that link at index 0, where the successor-rebase never fires and it silently builds on `main` (the #748 bug). Only a *contiguous* leading run of completed links is skipped, so a complete → incomplete → complete sequence re-executes the trailing link too. The single-issue `--phases exec,qa   # resume` idiom does not apply inside a `Chain:` line.
 
 ### Step 5: Conflict Detection
 
@@ -293,7 +297,7 @@ The commands block is headed by `Commands:` — no box-drawing, no character cou
 
 1. Only PROCEED and REWRITE issues get commands
 2. Group by identical phases + flags → same line
-3. Resume issues get `# resume` comment
+3. Resume issues get `# resume` comment (does not apply inside a `Chain:` line — see "Chain resume" in Step 4)
 4. Rewrite issues get `# restart` comment
 5. Chain mode issues use `--chain` flag (see `Chain:` annotation rules below)
 6. If ALL issues share the same workflow, emit a single command


### PR DESCRIPTION
## Summary

The `/assess` skill's chain section had drifted from chain's current behavior. Three fixes, all documentation-only, mirrored across the three skill directories.

## Changes

**`--chain`'s description predated #748.** It said "each branches from previous"; the successor is now rebased onto the predecessor's committed work before it runs.

**Two chain flags were undocumented.** `--stacked` (implies `--chain`) and `--strict-preflight` (#762) are added as explicitly *conditional* references, each carrying the reason not to reach for it:

- `--stacked` constrains merge order (`/merger` warns on out-of-order processing) and is manifest-only for 2-issue chains
- `--strict-preflight` mostly no-ops here, because assess already routes AC-less issues to `?` and blocked issues to `‖` before they can reach a `Chain:` line

Assess still emits only `--chain` by default, preserving the section's "suggest-only, never auto-apply" contract. No change to the `Chain:` output format, annotation ordering, or collision detection.

**No rule covered a partially-complete chain** — the correctness fix. #760 made the orchestrator compute a chain-correct resume plan from the full issue list. Trimming a `Chain:` line to just the incomplete links leaves the first one at index 0, where the successor-rebase never fires and it silently builds on `main` — the #748 bug that resume plan exists to prevent. The new paragraph documents that, plus the contiguous-prefix caveat in `chain-resume.ts:108-120` (a complete → incomplete → complete sequence re-executes the trailing link). Commands Block Rule 3 gets a one-clause pointer so the single-issue `# resume` idiom is not misapplied inside a chain.

## Not in scope

`--qa-gate` needed no work: 0c45b2c already removed it from assess ahead of the #795 deprecation. The remaining references in `run-command.md`, `cheat-sheet.md`, `git-workflows.md`, and `chain-mode-analysis-2026-05.md` are deliberate deprecation notices and a historical record.

## Verification

- Three mirrors byte-identical; `npm run lint:skill-sync` reports 42/42 synced
- `npm run lint:skill-calls` clean
- `npx skills-ref validate templates/skills/assess` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuSBZVyMZyTmucbYRJWWFq
