### PR TITLE
fix(#826): frozen install in new-feature.sh so provisioning cannot dirty the lockfile

### DIFF
--- a/templates/scripts/new-feature.sh
+++ b/templates/scripts/new-feature.sh
@@ -176,6 +176,34 @@ if [ -f "${MAIN_REPO_DIR}/.claude/settings.local.json" ]; then
     cp "${MAIN_REPO_DIR}/.claude/settings.local.json" .claude/settings.local.json
 fi
 
+# Frozen install (#826). `npm install` normalizes and REWRITES package-lock.json
+# whenever the local npm disagrees with the npm that committed it — observed:
+# npm 10 stripping the `libc` fields a newer npm wrote via dependabot. Every
+# freshly provisioned worktree then started with an unstaged lockfile, and that
+# one dirty file cascades: `rebaseBeforePR` refuses to run so the #295 stale-base
+# guard silently never fires, `checkWorktreeFreshness` counts it as uncommitted
+# work so stale worktrees are never recreated, and chain checkpoints skip on an
+# "unrelated dirty file" — breaking chain resume (#760) on every link.
+#
+# `npm ci` never rewrites the lockfile. #816 made this same substitution for the
+# TypeScript provisioning path; this script was missed by that fix.
+#
+# The enclosing `[ ! -d node_modules ]` guard means this only ever runs against
+# an absent node_modules, which is exactly `npm ci`'s precondition.
+frozen_install() {
+    if ! npm ci --silent; then
+        echo -e "${RED}❌ Dependency install failed (npm ci).${NC}" >&2
+        echo -e "${YELLOW}   The committed package-lock.json is out of sync with package.json.${NC}" >&2
+        echo -e "${YELLOW}   Fix in the main repo, then re-run:${NC}" >&2
+        echo -e "${YELLOW}     npm install --package-lock-only && git commit package-lock.json${NC}" >&2
+        echo -e "${YELLOW}   Worktree left in place at: $(pwd)${NC}" >&2
+        # Explicit exit rather than relying on `set -e` so the cause is named:
+        # a bare abort here leaves a half-provisioned worktree with no
+        # explanation of why (AC-4).
+        exit 1
+    fi
+}
+
 # Install dependencies if needed
 if [ ! -d "node_modules" ]; then
     # Check for npm install cache optimization (opt-in via SEQUANT_NPM_CACHE=true)
@@ -200,14 +228,14 @@ if [ ! -d "node_modules" ]; then
                 cp -r "${MAIN_REPO_DIR}/node_modules" ./node_modules
             else
                 echo -e "${BLUE}📦 Installing dependencies (package-lock changed)...${NC}"
-                npm install --silent
+                frozen_install
                 # Update cache hash
                 mkdir -p "$CACHE_DIR"
                 echo "$CURRENT_HASH" > "$HASH_FILE"
             fi
         else
             echo -e "${BLUE}📦 Installing dependencies (initializing cache)...${NC}"
-            npm install --silent
+            frozen_install
             # Initialize cache hash
             if [ -n "$CURRENT_HASH" ]; then
                 mkdir -p "$CACHE_DIR"
@@ -216,7 +244,7 @@ if [ ! -d "node_modules" ]; then
         fi
     else
         echo -e "${BLUE}📦 Installing dependencies...${NC}"
-        npm install --silent
+        frozen_install
     fi
 fi
 


### PR DESCRIPTION
## Summary

`scripts/new-feature.sh` still used `npm install --silent` at all three install sites. #816 made exactly this substitution for the TypeScript worktree-manager path — this script was missed by it.

`npm install` normalizes and **rewrites** `package-lock.json` whenever the local npm disagrees with the npm that committed it (here: npm 10 stripping the `libc` fields a newer npm wrote via dependabot). So every freshly provisioned worktree began life with an unstaged lockfile, and that single dirty file cascades into three unrelated-looking failures:

- `rebaseBeforePR` refuses to run (`cannot rebase: You have unstaged changes`), so the #295 stale-base guard **silently never fires** while the run log still reports success
- `checkWorktreeFreshness` counts it as uncommitted work, so stale worktrees are never recreated
- chain checkpoints skip on an "unrelated dirty file", breaking chain resume (#760) on every link

Found while provisioning the #804 worktree; it would otherwise have ridden along in PR #825.

## Change

All three sites now go through a `frozen_install` helper wrapping `npm ci --silent`, which never rewrites the lockfile. Extracting the helper means the three sites cannot drift apart — which is how this one got missed in the first place.

The enclosing `[ ! -d node_modules ]` guard means the install only ever runs against an absent `node_modules`, which is exactly `npm ci`'s precondition.

Edits `templates/scripts/new-feature.sh` — `scripts/new-feature.sh` is a symlink to it, so editing the link would have been a no-op.

## AC verification

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | ✅ MET | 0 occurrences of `npm install --silent` remain; 3 `frozen_install` call sites |
| AC-2 | ✅ MET | **Verified by running, not inspection** — see A/B below |
| AC-3 | ✅ MET | Cache-hit path still `cp -r`s `node_modules` with no install; cache-miss and cache-init call `frozen_install` then update the hash file. Only the two install sites changed |
| AC-4 | ✅ MET | Failure path exercised against a genuinely out-of-sync lockfile — see below |

### AC-2: A/B on a scratch worktree at the same commit

```
$ npm install --silent      # old behavior
dirty files: 1
 M package-lock.json
lockfile diff: 0 insertions, 12 deletions

$ git checkout package-lock.json && rm -rf node_modules
$ npm ci --silent           # fixed behavior
exit: 0
dirty files: 0
node_modules present: yes
```

The 12 deletions are the `libc` fields — the exact signature #816 documents.

### AC-4: failure path

Injected an out-of-sync dependency into `package.json` so `npm ci` genuinely fails, then ran the extracted helper verbatim:

```
❌ Dependency install failed (npm ci).
   The committed package-lock.json is out of sync with package.json.
   Fix in the main repo, then re-run:
     npm install --package-lock-only && git commit package-lock.json
   Worktree left in place at: /tmp/lockprobe-826
--- exit code: 1 ---
```

Execution stops there (the probe's trailing "SHOULD NOT REACH HERE" never prints). A bare `set -e` abort would have exited just as non-zero but left a half-provisioned worktree with no explanation of why — hence the explicit handler rather than relying on `set -e`.

## Test plan

- [x] `bash -n templates/scripts/new-feature.sh` — syntax OK
- [x] A/B lockfile test above (AC-2)
- [x] Out-of-sync failure path (AC-4)
- [x] Cache-path structure preserved (AC-3)
- [ ] shellcheck — not installed locally; CI's hooks/shell validation covers it

## Non-Goals

- Migrating this script to the TypeScript worktree-manager path.
- Generalizing beyond npm (pnpm/yarn) — the script hardcodes npm elsewhere too; separate concern.

Closes #826
