### PR TITLE
docs: gate tests ship with a recorded mutation result (#834)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,7 @@
 ## Skills
 
 - When invoking a sequant skill via `Skill(skill: "<name>", ...)` from inside another sequant skill, qualify names that collide with Anthropic top-level skills as `Skill(skill: "sequant:<name>", ...)`. Bare colliding names silently misroute to Anthropic's version. Enforced in CI by `npm run lint:skill-calls` (`scripts/lint-skill-calls.ts`). See #562 / #568.
+
+## Testing
+
+- **Gate tests ship with a recorded mutation result.** A test whose job is to gate a claim — a fixture exists, a skill section is present, a flag is wired — must be mutation-verified before it counts as coverage: delete the thing it asserts, confirm exactly that test fails, restore, and record the result in the commit message or PR body. Scope file-reading assertions to the delimited region they mean to check; matching the whole file lets a doc header or comment satisfy the assertion. See #830, where deleting the injection fixture's payload left the suite green.


### PR DESCRIPTION
Adopts one convention in `CLAUDE.md`, from #830's second look:

> **Gate tests ship with a recorded mutation result.** A test whose job is to gate a claim — a fixture exists, a skill section is present, a flag is wired — must be mutation-verified before it counts as coverage: delete the thing it asserts, confirm exactly that test fails, restore, and record the result in the commit message or PR body. Scope file-reading assertions to the delimited region they mean to check; matching the whole file lets a doc header or comment satisfy the assertion.

**Why now.** In #830, `trust-model-skill.test.ts` asserted that the prompt-injection fixture hid an agent-directed instruction, using a pattern matched against the whole file. The fixture's own explanatory header necessarily quotes `run`/`env`/`POST` while describing the payload, so it satisfied the assertion — deleting the real payload line left the suite at 16/16 green. The one thing that CI gate existed to hold, it did not hold.

**Why a convention and not tooling.** #834 covers the deterministic half (a lint over the skill's own enforcement chain). An auto-mutating harness for file-reading gate tests is buildable — there are now four such tests — but is deliberately deferred there until a third case demands it. Mutation-verifying by hand took about two minutes for four assertions in #830, so the convention is cheap enough to be worth stating before the tooling exists.

Docs-only. Related: #834, #830, #819.
