### PR TITLE
fix(cleanup-worktree): resolve the branch ref once — documented glob form never worked, shorthand silently skipped branch deletes

### DIFF
--- a/__tests__/cleanup-worktree-branch-resolution.integration.test.ts
+++ b/__tests__/cleanup-worktree-branch-resolution.integration.test.ts
@@ -1,0 +1,217 @@
+// Tests for Issue #838 — cleanup-worktree.sh must act on the RESOLVED branch
+// ref, not the raw argument the caller typed.
+//
+// The worktree lookup matches by SUBSTRING (`index($0, target) > 0`), so `817`
+// and `feature/817-*` both legitimately resolve to a worktree. But three
+// downstream consumers need an EXACT ref:
+//
+//   1. `gh pr list --head`      — exact filter; a shorthand yields no PR, so
+//                                 PR_STATUS is empty and the script reports
+//                                 "PR not merged" for a merged PR.
+//   2. `git branch -D`          — `|| true`-suppressed, so it failed silently
+//   3. `git push origin --delete`  and left the branch behind while the script
+//                                 printed "Cleanup complete!".
+//
+// (1) is the loud symptom; (2)/(3) are the silent ones — observed live during
+// #817's post-merge cleanup, which reported success yet left the local branch
+// needing a manual `git branch -D`.
+//
+// These run the real script against a real throwaway git repo with a real
+// worktree, with `gh` stubbed on PATH so the merge state is controlled and no
+// network call happens. Every assertion is parametrized over the three input
+// forms so a fix that only handles one of them fails here.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const SCRIPT = join(REPO_ROOT, "templates", "scripts", "cleanup-worktree.sh");
+
+const BRANCH = "feature/838-cleanup-branch-resolution";
+
+/** The three ways a caller names this branch. All must behave identically. */
+const INPUT_FORMS: Array<[label: string, arg: string]> = [
+  ["issue-number shorthand", "838"],
+  ["glob form (as skills/docs prescribe)", "feature/838-*"],
+  ["full literal branch name", BRANCH],
+];
+
+let sandbox: string;
+let repo: string;
+let wt: string;
+let binDir: string;
+let origin: string;
+
+function git(args: string[], cwd = repo): void {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${r.stderr || r.stdout}`);
+  }
+}
+
+/**
+ * Write a fake `gh` onto PATH. `state` is echoed for the
+ * `pr list --head <ref> --state merged --jq '.[0].state'` call, but ONLY when
+ * the ref it receives is the exact branch — mirroring real `--head` semantics,
+ * which is the whole point under test. It also records the ref it was handed
+ * so a test can assert what the script actually passed.
+ */
+function stubGh(merged: boolean): void {
+  const script = `#!/bin/bash
+# Record every invocation for assertions.
+echo "$@" >> "${join(binDir, "gh-calls.log")}"
+# Emulate: --head is an EXACT match filter.
+head_ref=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--head" ]; then head_ref="$a"; fi
+  prev="$a"
+done
+if [ "$head_ref" = "${BRANCH}" ] && [ "${merged ? "1" : "0"}" = "1" ]; then
+  echo "MERGED"
+fi
+exit 0
+`;
+  const p = join(binDir, "gh");
+  writeFileSync(p, script);
+  chmodSync(p, 0o755);
+}
+
+function runCleanup(arg: string, extraArgs: string[] = []) {
+  return spawnSync("bash", [SCRIPT, ...extraArgs, arg], {
+    cwd: repo,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      // No TTY under vitest, so the script's non-interactive branch is live —
+      // exactly the automation path that matters.
+    },
+  });
+}
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), "cleanup-wt-838-"));
+  repo = join(sandbox, "repo");
+  wt = join(sandbox, "wt-838");
+  binDir = join(sandbox, "bin");
+  mkdirSync(repo, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+
+  // A real bare `origin` so the script's remote-delete and its trailing
+  // "update main" (checkout/fetch/ff) behave as they do in a real repo. Without
+  // a remote the script errors out before its final line and the teardown
+  // assertions below can't distinguish "worked" from "died early".
+  origin = join(sandbox, "origin.git");
+  spawnSync("git", ["init", "-q", "--bare", "-b", "main", origin]);
+
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.email", "t@example.com"]);
+  git(["config", "user.name", "t"]);
+  writeFileSync(join(repo, "f.txt"), "x\n");
+  git(["add", "."]);
+  git(["commit", "-q", "-m", "init"]);
+  git(["remote", "add", "origin", origin]);
+  git(["push", "-q", "-u", "origin", "main"]);
+  git(["worktree", "add", "-q", "-b", BRANCH, wt]);
+  git(["push", "-q", "origin", BRANCH]);
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe("cleanup-worktree.sh branch resolution (#838)", () => {
+  describe.each(INPUT_FORMS)("input form: %s", (_label, arg) => {
+    it("recognizes a MERGED PR — no warning, no --yes required", () => {
+      stubGh(true);
+      const r = runCleanup(arg);
+
+      // The regression: this warning fired for every form but the literal one.
+      expect(r.stdout).not.toContain("PR for this branch is not merged");
+      expect(r.stdout).not.toContain(
+        "Non-interactive context and PR not merged",
+      );
+      expect(r.stdout).toContain("Cleanup complete");
+    });
+
+    it("passes the resolved ref to gh, never the raw argument", () => {
+      stubGh(true);
+      runCleanup(arg);
+
+      const calls = spawnSync("cat", [join(binDir, "gh-calls.log")], {
+        encoding: "utf8",
+      }).stdout;
+      expect(calls).toContain(`--head ${BRANCH}`);
+      if (arg !== BRANCH) {
+        expect(calls).not.toContain(`--head ${arg}`);
+      }
+    });
+
+    it("actually deletes the local branch", () => {
+      stubGh(true);
+      runCleanup(arg);
+
+      // `git branch -D` is `|| true`-suppressed, so a shorthand failure was
+      // invisible: "Cleanup complete!" printed while the branch survived.
+      const branches = spawnSync("git", ["branch", "--list", BRANCH], {
+        cwd: repo,
+        encoding: "utf8",
+      }).stdout.trim();
+      expect(branches).toBe("");
+    });
+
+    it("still refuses an UNMERGED PR non-interactively (#750 preserved)", () => {
+      stubGh(false);
+      const r = runCleanup(arg);
+
+      expect(r.stdout).toContain("PR for this branch is not merged");
+      expect(r.stdout).toContain("Exiting without changes");
+      // The worktree must survive — this is #750's protection.
+      const wtList = spawnSync("git", ["worktree", "list"], {
+        cwd: repo,
+        encoding: "utf8",
+      }).stdout;
+      expect(wtList).toContain(wt);
+    });
+
+    it("still tears down an UNMERGED PR when --yes is passed (#750 preserved)", () => {
+      stubGh(false);
+      const r = runCleanup(arg, ["--yes"]);
+
+      expect(r.stdout).toContain("PR for this branch is not merged");
+      expect(r.stdout).toContain("Proceeding (--yes/--force)");
+      // Remote delete must STILL be skipped — the #750 hard gate.
+      expect(r.stdout).toContain("Skipped remote-branch delete");
+    });
+  });
+
+  it("resolves correctly when the worktree path contains spaces (#575)", () => {
+    // The two-line awk emission exists so this case survives; a space-joined
+    // single line would split the path here.
+    const spaced = join(sandbox, "work tree with spaces");
+    const branch2 = "feature/838-spaced";
+    git(["worktree", "add", "-q", "-b", branch2, spaced]);
+    stubGh(true);
+
+    const r = spawnSync("bash", [SCRIPT, "838-spaced"], {
+      cwd: repo,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+    });
+
+    expect(r.stdout).toContain(spaced);
+    expect(r.stdout).not.toContain("Worktree not found");
+  });
+});

--- a/templates/scripts/cleanup-worktree.sh
+++ b/templates/scripts/cleanup-worktree.sh
@@ -101,17 +101,56 @@ if [ -z "$BRANCH_NAME" ]; then
     exit 1
 fi
 
-# Find worktree path. Parse porcelain (which separates path/branch onto distinct
-# lines) so paths containing whitespace survive intact, and so we match against
-# the branch ref rather than against a free-form `grep` over the entire line —
-# the latter false-matches whenever the branch name appears in the path string.
-WORKTREE_PATH=$(git worktree list --porcelain | awk -v target="$BRANCH_NAME" '
-  /^worktree / { sub(/^worktree /, ""); path = $0 }
-  /^branch refs\/heads\// {
-    sub(/^branch refs\/heads\//, "")
-    if (index($0, target) > 0) { print path; exit }
-  }
-')
+# Find the worktree path AND the full branch ref it belongs to. Parse porcelain
+# (which separates path/branch onto distinct lines) so paths containing
+# whitespace survive intact, and so we match against the branch ref rather than
+# against a free-form `grep` over the entire line — the latter false-matches
+# whenever the branch name appears in the path string.
+#
+# #838 fixes two defects that both live here:
+#
+#  1. The matcher was a literal substring search, so the `feature/<issue>-*`
+#     form that fullsolve/SKILL.md, exec/SKILL.md and docs/troubleshooting.md
+#     all prescribe compared the `*` literally and failed with "Worktree not
+#     found". The `case` glob arm below makes the documented form work.
+#  2. Only the path was captured, so every downstream consumer re-used the
+#     caller's raw shorthand. `gh pr list --head`, `git branch -D` and
+#     `git push origin --delete` all match EXACTLY and silently no-op on a
+#     shorthand — and the latter two are `|| true`-suppressed, so the script
+#     printed "Cleanup complete!" while leaving the branch behind. Resolve once
+#     here; everything below uses $RESOLVED_BRANCH.
+#
+# Implemented with bash `case` rather than awk so glob matching is native and
+# no regex-escaping dance is needed. `while IFS= read -r` preserves whitespace
+# in paths (the #575 hardening); `mapfile` is deliberately avoided — macOS
+# ships bash 3.2, where it does not exist.
+WORKTREE_PATH=""
+RESOLVED_BRANCH=""
+_wt_path=""
+while IFS= read -r _line; do
+    case "$_line" in
+        "worktree "*)
+            _wt_path="${_line#worktree }"
+            ;;
+        "branch refs/heads/"*)
+            _wt_branch="${_line#branch refs/heads/}"
+            # Two accepted forms, in one test:
+            #   *"$BRANCH_NAME"*  quoted -> literal substring  (`838`)
+            #   $BRANCH_NAME      unquoted -> shell glob       (`feature/838-*`)
+            # The glob arm is what makes the documented `feature/<issue>-*`
+            # form work; before #838 the matcher was a pure substring search,
+            # so the asterisk was compared literally and the documented
+            # invocation died with "Worktree not found".
+            case "$_wt_branch" in
+                *"$BRANCH_NAME"* | $BRANCH_NAME)
+                    WORKTREE_PATH="$_wt_path"
+                    RESOLVED_BRANCH="$_wt_branch"
+                    break
+                    ;;
+            esac
+            ;;
+    esac
+done < <(git worktree list --porcelain)
 
 if [ -z "$WORKTREE_PATH" ]; then
     echo -e "${RED}❌ Error: Worktree not found for branch: $BRANCH_NAME${NC}"
@@ -121,12 +160,17 @@ if [ -z "$WORKTREE_PATH" ]; then
     exit 1
 fi
 
-echo -e "${BLUE}🧹 Cleaning up worktree for: $BRANCH_NAME${NC}"
+echo -e "${BLUE}🧹 Cleaning up worktree for: $RESOLVED_BRANCH${NC}"
 echo -e "${BLUE}Path: $WORKTREE_PATH${NC}"
 echo ""
 
-# Check if PR is merged
-PR_STATUS=$(gh pr list --head "$BRANCH_NAME" --state merged --json number,state --jq '.[0].state' 2>/dev/null || echo "")
+# Check if PR is merged. Queries the RESOLVED ref (#838): `--head` is an exact
+# match, so passing the caller's shorthand here reported "not merged" for every
+# invocation form except a full literal branch name — including the
+# `feature/<issue>-*` form the skills and docs prescribe. A warning that always
+# fires carries no signal and makes --yes/--force the mandatory incantation,
+# which re-arms the very bypass reflex #750 removed.
+PR_STATUS=$(gh pr list --head "$RESOLVED_BRANCH" --state merged --json number,state --jq '.[0].state' 2>/dev/null || echo "")
 
 # Confirmation gate — only reached when the PR is NOT merged. When MERGED we
 # short-circuit past this entirely (no prompt, no TTY check) so the documented
@@ -179,9 +223,11 @@ fi
 echo -e "${BLUE}📂 Removing worktree...${NC}"
 git worktree remove "$WORKTREE_PATH" --force
 
-# Delete local branch
+# Delete local branch. Uses the RESOLVED ref (#838) — `git branch -D 817` finds
+# no such branch and, being `|| true`-suppressed, failed silently: the script
+# reported "Cleanup complete!" while leaving the branch behind.
 echo -e "${BLUE}🌿 Deleting local branch...${NC}"
-git branch -D "$BRANCH_NAME" 2>/dev/null || true
+git branch -D "$RESOLVED_BRANCH" 2>/dev/null || true
 
 # Delete remote branch — hard-gated on merge state. Only delete when the PR is
 # MERGED or an explicit override flag (--delete-remote/--force) was passed.
@@ -189,7 +235,8 @@ git branch -D "$BRANCH_NAME" 2>/dev/null || true
 # PR's head branch makes GitHub close the PR unmerged, stranding the work.
 if [ "$PR_STATUS" = "MERGED" ] || [ "$DELETE_REMOTE" = true ]; then
     echo -e "${BLUE}☁️  Deleting remote branch...${NC}"
-    git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+    # Resolved ref (#838): same silent-no-op class as the local delete above.
+    git push origin --delete "$RESOLVED_BRANCH" 2>/dev/null || true
 else
     echo -e "${YELLOW}⏭️  Skipped remote-branch delete (PR not merged; pass --delete-remote or --force to override).${NC}"
 fi

--- a/templates/scripts/cleanup-worktree.sh
+++ b/templates/scripts/cleanup-worktree.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Clean up a worktree after PR is merged
-# Usage: ./scripts/cleanup-worktree.sh [flags] <branch-name>
+# Usage: ./scripts/cleanup-worktree.sh [flags] <branch>
+# <branch> accepts an issue number / substring (`123`), a glob
+# (`feature/123-*`), or the full branch name — all resolve to the same worktree
+# and, since #838, to the same underlying branch ref.
 # Example: ./scripts/cleanup-worktree.sh feature/123-add-user-dashboard
 #
 # The remote branch is deleted ONLY when the branch's PR is MERGED (the
@@ -28,7 +31,12 @@ NC='\033[0m'
 # Print CLI usage/help (kept in sync with the header comment above).
 print_usage() {
     cat <<'USAGE'
-Usage: ./scripts/cleanup-worktree.sh [flags] <branch-name>
+Usage: ./scripts/cleanup-worktree.sh [flags] <branch>
+
+<branch> may be any of (all resolve to the same worktree):
+  838                    an issue number, or any substring of the branch
+  feature/838-*          a glob
+  feature/838-fix-thing  the full branch name
 
 Clean up a feature worktree. The remote branch is deleted ONLY when the
 branch's PR is MERGED (the documented post-merge contract) or when an


### PR DESCRIPTION
## Summary

`cleanup-worktree.sh` matched the worktree by literal substring and then handed the caller's **raw argument** to every downstream consumer. Two defects, same three lines.

**1. The documented invocation never worked.** `fullsolve/SKILL.md:676`, `exec/SKILL.md:524` and `docs/troubleshooting.md:46` all prescribe `cleanup-worktree.sh feature/<issue-number>-*`. The matcher compared the `*` as a literal character, so that form exited with `❌ Error: Worktree not found`. Verified against the live repo:

```
input '833'                                 -> resolved: 'feature/833-fix-cli-bare-parseint-...'
input 'feature/833-*'                       -> <NONE — Worktree not found>
input 'feature/833-fix-cli-bare-parseint-…' -> resolved: 'feature/833-fix-cli-bare-parseint-...'
```

**2. Downstream consumers got the shorthand, not the ref.** `gh pr list --head`, `git branch -D` and `git push origin --delete` all match **exactly**:

```
$ gh pr list --head "817"                             --state merged --jq '.[0].state'
                                                        # (empty) => "PR not merged"
$ gh pr list --head "feature/817-…-ins"               --state merged --jq '.[0].state'
MERGED
```

So the merge check reported "not merged" for a merged PR on every shorthand invocation. Worse, the two branch deletes are `|| true`-suppressed, so they failed **invisibly** — the script printed `✅ Cleanup complete!` while leaving both local and remote branches in place.

Both were observed live during #817's post-merge cleanup: the not-merged warning fired ~90s after the PR merged, and the local branch survived and needed a manual `git branch -D`.

## Why the merge-check symptom matters beyond a false alarm

#750 built that gate precisely because agents were piping `echo y |` past it. A warning that fires on **every** invocation carries no signal and makes `--yes`/`--force` the mandatory incantation — which re-arms the exact bypass reflex #750 removed. The gate was functionally back to advisory, with no code regression to point at.

## Change

Resolve path **and** ref in one pass, then use `$RESOLVED_BRANCH` everywhere downstream. The awk is replaced with bash `case`, so glob matching is native and no regex-escaping dance is needed — both accepted forms collapse into one test:

```bash
case "$_wt_branch" in
    *"$BRANCH_NAME"* | $BRANCH_NAME)   # quoted = substring; unquoted = glob
```

`while IFS= read -r` preserves whitespace in paths (#575's hardening, covered by a dedicated test). `mapfile` is deliberately avoided — macOS ships bash 3.2.

Usage/`--help` and the header comment now document all three accepted forms, since previously only the full branch name was shown and the other two were undiscoverable.

## Test plan

New `__tests__/cleanup-worktree-branch-resolution.integration.test.ts` drives the **real script** against a real throwaway git repo with a real worktree and a real bare `origin`, with `gh` stubbed on `PATH` to emulate `--head`'s exact-match semantics. Every assertion is parametrized over all three input forms, so a fix handling only one of them fails.

#750's protections are asserted in **both** directions: an unmerged PR still refuses non-interactively, and still skips the remote delete under `--yes`.

- [x] 16 tests pass
- [x] `bash -n` syntax check
- [x] `--help` output verified
- [x] Full `__tests__/` sweep: **63 files, 1148 tests, 0 failures**

### Mutation record (per the CLAUDE.md gate-test rule)

Each mutation applied to the committed fix, then reverted and re-confirmed green:

| Mutation | Result |
|---|---|
| *(baseline)* | 0 failed / 16 passed |
| M1 · drop the `\| $BRANCH_NAME` glob arm | **5 failed** — every glob-form test |
| M2 · merge check back to `--head "$BRANCH_NAME"` | **6 failed** |
| M3 · `git branch -D "$BRANCH_NAME"` | **2 failed** — the two non-literal forms (the literal form correctly still passes, since there `BRANCH_NAME == RESOLVED_BRANCH`) |

## Note

The new test is subprocess- and git-heavy (~30s added to the integration project). It is parametrized 3 forms × 5 behaviors because the ACs require exactly that matrix; if the integration suite's runtime becomes a problem, collapsing the three merged-path assertions into one per form is the obvious trim.

Closes #838
