### PR TITLE
fix: close three pre-2.10.0 gaps found by release verification

### DIFF
--- a/.claude/skills/fullsolve/SKILL.md
+++ b/.claude/skills/fullsolve/SKILL.md
@@ -673,7 +673,9 @@ Post completion comment to issue with:
 gh pr merge <N> --squash
 
 # 2. Clean up worktree (removes local worktree + branch)
-./scripts/cleanup-worktree.sh feature/<issue-number>-*
+# Quote the glob: the script resolves the pattern itself, and zsh aborts on an
+# unmatched unquoted glob before the script ever runs.
+./scripts/cleanup-worktree.sh 'feature/<issue-number>-*'
 
 # 3. Issue auto-closes if commit message contains "Fixes #N"
 ```

--- a/__tests__/cleanup-worktree-branch-resolution.integration.test.ts
+++ b/__tests__/cleanup-worktree-branch-resolution.integration.test.ts
@@ -119,6 +119,10 @@ beforeEach(() => {
   git(["init", "-q", "-b", "main"]);
   git(["config", "user.email", "t@example.com"]);
   git(["config", "user.name", "t"]);
+  // Contributors with a global `commit.gpgsign=true` have no pinentry in a
+  // test run, so every commit below would die with "gpg: signing failed".
+  // CI has no signing key and never noticed. Same line the other fixtures use.
+  git(["config", "commit.gpgsign", "false"]);
   writeFileSync(join(repo, "f.txt"), "x\n");
   git(["add", "."]);
   git(["commit", "-q", "-m", "init"]);
@@ -170,6 +174,24 @@ describe("cleanup-worktree.sh branch resolution (#838)", () => {
         encoding: "utf8",
       }).stdout.trim();
       expect(branches).toBe("");
+    });
+
+    it("actually deletes the remote branch on a MERGED PR", () => {
+      stubGh(true);
+      runCleanup(arg);
+
+      // The third consumer of the resolved ref (alongside `gh pr list --head`
+      // and `git branch -D`) is `git push origin --delete`, and it is the one
+      // this file never asserted. That line is `2>/dev/null || true`, so a
+      // regression reintroducing the RAW argument there deletes nothing and
+      // still prints "Cleanup complete!" at exit 0 — the exact silent-failure
+      // class #838 exists to close.
+      const remote = spawnSync(
+        "git",
+        ["ls-remote", "--heads", "origin", BRANCH],
+        { cwd: repo, encoding: "utf8" },
+      ).stdout.trim();
+      expect(remote).toBe("");
     });
 
     it("still refuses an UNMERGED PR non-interactively (#750 preserved)", () => {

--- a/__tests__/pre-tool-hook.integration.test.ts
+++ b/__tests__/pre-tool-hook.integration.test.ts
@@ -100,6 +100,9 @@ describe.each(HOOK_COPIES)(
         cwd: cleanRepo,
       });
       spawnSync("git", ["config", "user.name", "test"], { cwd: cleanRepo });
+      // No pinentry in a test run when the contributor has global commit
+      // signing on; CI has no signing key and never noticed.
+      spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: cleanRepo });
     });
 
     afterAll(() => {
@@ -220,6 +223,9 @@ describe.each(HOOK_COPIES)(
         spawnSync("git", ["init", "-q"], { cwd: repo });
         spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
         spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+        // No pinentry in a test run when the contributor has global commit
+        // signing on; CI has no signing key and never noticed.
+        spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
         writeFileSync(join(repo, "f.txt"), "hello\n");
         const cmd = `gh issue comment 1 --body "if conflicted, run git reset --hard origin/main"`;
         const { code } = runHook(hookPath, cmd, repo);
@@ -276,6 +282,9 @@ describe.each(HOOK_COPIES)(
         spawnSync("git", ["init", "-q"], { cwd: repo });
         spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
         spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+        // No pinentry in a test run when the contributor has global commit
+        // signing on; CI has no signing key and never noticed.
+        spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
         writeFileSync(join(repo, "f.txt"), "hello\n");
         const { code, stderr } = runHook(
           hookPath,
@@ -363,6 +372,9 @@ describe.each(HOOK_COPIES)(
         spawnSync("git", ["init", "-q"], { cwd: repo });
         spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
         spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+        // No pinentry in a test run when the contributor has global commit
+        // signing on; CI has no signing key and never noticed.
+        spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
         writeFileSync(join(repo, "f.txt"), "hello\n");
         const cmd =
           'gh issue comment --body "if conflicted, run `git reset --hard origin/main`..."';
@@ -397,6 +409,9 @@ describe.each(HOOK_COPIES)(
         spawnSync("git", ["init", "-q"], { cwd: repo });
         spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
         spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+        // No pinentry in a test run when the contributor has global commit
+        // signing on; CI has no signing key and never noticed.
+        spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
         writeFileSync(join(repo, "f.txt"), "hello\n");
         spawnSync("git", ["add", "f.txt"], { cwd: repo });
         const { stderr } = runHook(hookPath, "git commit -m 'feat: x'", repo);
@@ -430,6 +445,9 @@ describe.each(HOOK_COPIES)(
         cwd: cleanRepo,
       });
       spawnSync("git", ["config", "user.name", "test"], { cwd: cleanRepo });
+      // No pinentry in a test run when the contributor has global commit
+      // signing on; CI has no signing key and never noticed.
+      spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: cleanRepo });
     });
 
     afterAll(() => {
@@ -444,6 +462,9 @@ describe.each(HOOK_COPIES)(
         spawnSync("git", ["init", "-q"], { cwd: repo });
         spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
         spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+        // No pinentry in a test run when the contributor has global commit
+        // signing on; CI has no signing key and never noticed.
+        spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
         writeFileSync(join(repo, "f.txt"), "hello\n");
         fn(repo);
       } finally {
@@ -520,6 +541,9 @@ describe.each(HOOK_COPIES)(
         spawnSync("git", ["init", "-q"], { cwd: repo });
         spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
         spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+        // No pinentry in a test run when the contributor has global commit
+        // signing on; CI has no signing key and never noticed.
+        spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
         writeFileSync(join(repo, "f.txt"), "hello\n");
         spawnSync("git", ["add", "f.txt"], { cwd: repo });
         const { code } = runHook(
@@ -866,6 +890,9 @@ describe.each(HOOK_PAIRS)(
       spawnSync("git", ["init", "-q"], { cwd: repo });
       spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo });
       spawnSync("git", ["config", "user.name", "test"], { cwd: repo });
+      // No pinentry in a test run when the contributor has global commit
+      // signing on; CI has no signing key and never noticed.
+      spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
       writeFileSync(join(repo, "a.txt"), "a\n");
       spawnSync("git", ["add", "a.txt"], { cwd: repo });
       spawnSync("git", ["commit", "-qm", "feat: init"], { cwd: repo });

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,7 +43,9 @@ Common issues and solutions when using Sequant.
 
 2. Clean up using the cleanup script:
    ```bash
-   ./scripts/cleanup-worktree.sh feature/<issue-number>-*
+   ./scripts/cleanup-worktree.sh 'feature/<issue-number>-*'
+   # Quote the glob — the script resolves the pattern itself, and zsh aborts
+   # on an unmatched unquoted glob before the script ever runs.
    # Local worktree + branch are always removed. The remote branch is deleted
    # only when the PR is merged — an unmerged PR's remote branch is left intact
    # so GitHub doesn't close the PR unmerged.

--- a/skills/fullsolve/SKILL.md
+++ b/skills/fullsolve/SKILL.md
@@ -673,7 +673,9 @@ Post completion comment to issue with:
 gh pr merge <N> --squash
 
 # 2. Clean up worktree (removes local worktree + branch)
-./scripts/cleanup-worktree.sh feature/<issue-number>-*
+# Quote the glob: the script resolves the pattern itself, and zsh aborts on an
+# unmatched unquoted glob before the script ever runs.
+./scripts/cleanup-worktree.sh 'feature/<issue-number>-*'
 
 # 3. Issue auto-closes if commit message contains "Fixes #N"
 ```

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -36,6 +36,16 @@ vi.mock("../lib/config.js", () => ({
   getConfig: vi.fn(),
 }));
 
+// Mock the MCP pin (#793). `syncSequantMcpPin` reads and writes `.mcp.json`
+// through node's `fs` directly, so it bypasses the `../lib/fs.js` mock above.
+// These tests never chdir, which means an unmocked call resolves
+// `process.cwd()` to the sequant repo itself and rewrites the real tracked
+// `.mcp.json`. Verified: without this mock, `vitest run src/commands/sync.test.ts`
+// leaves ` M .mcp.json` behind.
+vi.mock("../lib/mcp-config.js", () => ({
+  syncSequantMcpPin: vi.fn(() => ({ updated: false, reason: "no-file" })),
+}));
+
 import {
   getSkillsVersion,
   areSkillsOutdated,
@@ -50,7 +60,9 @@ import {
   listTemplateFiles,
 } from "../lib/templates.js";
 import { getConfig } from "../lib/config.js";
+import { syncSequantMcpPin } from "../lib/mcp-config.js";
 
+const mockSyncMcpPin = vi.mocked(syncSequantMcpPin);
 const mockFileExists = vi.mocked(fileExists);
 const mockReadFile = vi.mocked(readFile);
 const mockWriteFile = vi.mocked(writeFile);
@@ -66,6 +78,9 @@ describe("sync command", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.spyOn(console, "log").mockImplementation(() => {});
+    // resetAllMocks strips the factory implementation, so restore a valid
+    // SyncMcpPinResult — sync.ts reads `.updated` off the return value.
+    mockSyncMcpPin.mockReturnValue({ updated: false, reason: "no-file" });
   });
 
   afterEach(() => {
@@ -426,6 +441,64 @@ describe("sync command", () => {
           String(c[0]).includes("already up to date"),
         ),
       ).toBe(true);
+    });
+
+    it("re-pins .mcp.json even on the up-to-date fast path (#793)", async () => {
+      // The pin must run BEFORE the "already up to date" early return. A
+      // version-only upgrade leaves every template byte-identical, so this
+      // fast path is exactly the case where the pin most needs refreshing —
+      // and it was the case `update` handled but `sync` silently skipped.
+      mockGetManifest.mockResolvedValue({
+        version: "1.1.0",
+        stack: "nextjs",
+        installedAt: "2024-01-01",
+        files: {},
+      });
+      mockFileExists.mockResolvedValue(true);
+      mockReadFile.mockResolvedValue("1.1.0");
+      mockGetPackageVersion.mockReturnValue("1.1.0");
+      mockGetConfig.mockResolvedValue(null);
+      mockComputeTemplateChanges.mockResolvedValue([
+        {
+          path: ".claude/skills/exec/SKILL.md",
+          templatePath: "templates/skills/exec/SKILL.md",
+          status: "unchanged",
+          rendered: "x",
+        },
+      ]);
+      mockSyncMcpPin.mockReturnValue({
+        updated: true,
+        from: "sequant@latest",
+        to: "sequant@1.1.0",
+      });
+
+      const logSpy = vi.spyOn(console, "log");
+      await syncCommand();
+
+      expect(mockSyncMcpPin).toHaveBeenCalledTimes(1);
+      expect(
+        logSpy.mock.calls.some((c) => String(c[0]).includes("MCP pin")),
+      ).toBe(true);
+    });
+
+    it("passes dryRun through to the .mcp.json pin so a preview never writes (#793)", async () => {
+      mockGetManifest.mockResolvedValue({
+        version: "1.1.0",
+        stack: "nextjs",
+        installedAt: "2024-01-01",
+        files: {},
+      });
+      mockFileExists.mockResolvedValue(true);
+      mockReadFile.mockResolvedValue("1.0.0");
+      mockGetPackageVersion.mockReturnValue("1.1.0");
+      mockGetConfig.mockResolvedValue(null);
+      mockComputeTemplateChanges.mockResolvedValue([]);
+
+      await syncCommand({ dryRun: true });
+
+      expect(mockSyncMcpPin).toHaveBeenCalledWith(expect.any(String), {
+        dryRun: true,
+      });
     });
 
     it("reports drift instead of false up-to-date when content differs at equal version", async () => {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -23,6 +23,7 @@ import {
   type CopyTemplatesOptions,
 } from "../lib/templates.js";
 import { getConfig } from "../lib/config.js";
+import { syncSequantMcpPin } from "../lib/mcp-config.js";
 import { writeFile, readFile, fileExists, getFileStats } from "../lib/fs.js";
 import {
   generateAgentsMd,
@@ -298,6 +299,21 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
   // Get config tokens for template processing
   const config = await getConfig();
   const tokens = config?.tokens || {};
+
+  // Re-pin the project .mcp.json MCP server to the installed version (#793).
+  // `syncSequantMcpPin`'s contract has always named this the `update`/`sync`
+  // path, but only `update` ever called it, so a `sync` left the pin stale.
+  // Placed here for the same reason update.ts states: it must precede the
+  // "already up to date" fast path below, because a version-only upgrade
+  // leaves every template byte-identical and returns early — and that is
+  // exactly the case where the pin most needs refreshing.
+  const mcpPin = syncSequantMcpPin(process.cwd(), { dryRun });
+  if (mcpPin.updated && !quiet) {
+    const verb = dryRun ? "Would update" : "Updated";
+    console.log(
+      chalk.blue(`${verb} .mcp.json MCP pin: ${mcpPin.from} → ${mcpPin.to}`),
+    );
+  }
 
   // The version marker is only a fast-path hint — verify actual content before
   // claiming "up to date". On a version match we still diff bundled templates

--- a/src/lib/workflow/qa-stagnation.test.ts
+++ b/src/lib/workflow/qa-stagnation.test.ts
@@ -317,6 +317,10 @@ describe("snapshotLoopProgress (.sequant/ exclusion)", () => {
     execSync("git init -q -b main", { cwd: repo });
     execSync("git config user.email test@test.local", { cwd: repo });
     execSync("git config user.name test", { cwd: repo });
+    // Contributors with global commit signing have no pinentry in a test run,
+    // so the commits below died with "gpg: signing failed". CI has no signing
+    // key and never noticed.
+    execSync("git config commit.gpgsign false", { cwd: repo });
     fs.writeFileSync(path.join(repo, "README.md"), "seed\n");
     execSync("git add README.md && git commit -q -m seed", { cwd: repo });
   });
@@ -449,6 +453,10 @@ describe("qa-loop integration (AC-4)", () => {
     execSync("git init -q -b main", { cwd: repo });
     execSync("git config user.email test@test.local", { cwd: repo });
     execSync("git config user.name test", { cwd: repo });
+    // Contributors with global commit signing have no pinentry in a test run,
+    // so the commits below died with "gpg: signing failed". CI has no signing
+    // key and never noticed.
+    execSync("git config commit.gpgsign false", { cwd: repo });
     fs.writeFileSync(path.join(repo, "README.md"), "seed\n");
     execSync("git add README.md && git commit -q -m seed", { cwd: repo });
   });

--- a/src/lib/workflow/skills-preflight.integration.test.ts
+++ b/src/lib/workflow/skills-preflight.integration.test.ts
@@ -70,7 +70,10 @@ describe("run skills pre-flight (#813 AC-5 integration)", () => {
     execSync("git init -b main", { cwd: repo, stdio: "pipe" });
     writeFileSync(join(repo, "README.md"), "# test\n");
     execSync(
-      "git add . && git -c user.email=t@t -c user.name=t commit -m init",
+      // `-c commit.gpgsign=false`: contributors with global commit signing have
+      // no pinentry in a test run, so this commit died with "gpg: signing
+      // failed". CI has no signing key and never noticed.
+      "git add . && git -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -m init",
       {
         cwd: repo,
         stdio: "pipe",

--- a/templates/scripts/cleanup-worktree.sh
+++ b/templates/scripts/cleanup-worktree.sh
@@ -2,9 +2,12 @@
 
 # Clean up a worktree after PR is merged
 # Usage: ./scripts/cleanup-worktree.sh [flags] <branch>
-# <branch> accepts an issue number / substring (`123`), a glob
-# (`feature/123-*`), or the full branch name — all resolve to the same worktree
-# and, since #838, to the same underlying branch ref.
+# <branch> accepts an issue number / substring (`123`), a QUOTED glob
+# (`'feature/123-*'`), or the full branch name — all resolve to the same
+# worktree and, since #838, to the same underlying branch ref.
+# Quote the glob: this script resolves the pattern itself, so it must arrive
+# unexpanded. zsh (the default macOS shell) aborts on an unmatched unquoted
+# glob before the script ever runs; bash would pass it through literally.
 # Example: ./scripts/cleanup-worktree.sh feature/123-add-user-dashboard
 #
 # The remote branch is deleted ONLY when the branch's PR is MERGED (the
@@ -35,8 +38,12 @@ Usage: ./scripts/cleanup-worktree.sh [flags] <branch>
 
 <branch> may be any of (all resolve to the same worktree):
   838                    an issue number, or any substring of the branch
-  feature/838-*          a glob
+  'feature/838-*'        a glob — MUST be quoted (see below)
   feature/838-fix-thing  the full branch name
+
+Quote the glob form. This script resolves the pattern itself, so it must
+arrive unexpanded; zsh aborts on an unmatched unquoted glob before the
+script ever runs.
 
 Clean up a feature worktree. The remote branch is deleted ONLY when the
 branch's PR is MERGED (the documented post-merge contract) or when an

--- a/templates/skills/fullsolve/SKILL.md
+++ b/templates/skills/fullsolve/SKILL.md
@@ -673,7 +673,9 @@ Post completion comment to issue with:
 gh pr merge <N> --squash
 
 # 2. Clean up worktree (removes local worktree + branch)
-./scripts/cleanup-worktree.sh feature/<issue-number>-*
+# Quote the glob: the script resolves the pattern itself, and zsh aborts on an
+# unmatched unquoted glob before the script ever runs.
+./scripts/cleanup-worktree.sh 'feature/<issue-number>-*'
 
 # 3. Issue auto-closes if commit message contains "Fixes #N"
 ```

--- a/vitest.global-setup.ts
+++ b/vitest.global-setup.ts
@@ -7,5 +7,11 @@ import { execSync } from "child_process";
  * `node dist/bin/cli.js` don't each need their own beforeAll build.
  */
 export default function setup() {
+  // Hermetic git: tests that create throwaway repos must not inherit the
+  // contributor's global/system git config. Workers are forked after this
+  // runs, so they inherit these.
+  process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+  process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+
   execSync("npm run build", { stdio: "ignore" });
 }


### PR DESCRIPTION
Pre-release verification of the 27 unreleased commits since `v2.9.0` surfaced three gaps that all ship green today, plus one recurring test-portability bug.

## 1. The documented glob form never worked under zsh

#838 fixed the script's resolver, but every caller doc still showed the form **unquoted**. zsh — the default macOS shell — aborts on an unmatched glob before the script runs:

```
zsh:1: no matches found: feature/838-*
```

bash passes it through literally, which is why it was never caught. Quoted in the script's own usage text, `docs/troubleshooting.md`, and all three `fullsolve/SKILL.md` mirrors.

The `rm -rf ...-*` line in troubleshooting.md is deliberately left unquoted — that one wants shell expansion.

## 2. `sequant sync` never re-pinned `.mcp.json`

`syncSequantMcpPin`'s contract has named this the `update`/`sync` path since #793, but only `update.ts` called it, so a plain `sync` left the pin stale. Wired into `syncCommand` ahead of the "already up to date" fast path, for the reason `update.ts` documents: a version-only upgrade leaves every template byte-identical and returns early, which is exactly when the pin most needs refreshing.

Verified end to end in a scratch project — dry-run reports without writing, real sync writes, second sync is correctly silent.

`sync.test.ts` never chdirs, so an unmocked pin call resolved `process.cwd()` to this repo and rewrote the tracked `.mcp.json`. Mocked, and covered by two tests that both fail when the pin call is removed.

## 3. The #838 test never asserted the remote branch delete

Its own header names three consumers of the resolved ref. It asserted `gh pr list --head` and `git branch -D`, but not `git push origin --delete` — the one line still written as:

```sh
git push origin --delete "$RESOLVED_BRANCH" 2>/dev/null || true
```

A regression reintroducing the raw argument there deleted nothing and still printed "Cleanup complete!" at exit 0 — the exact silent-failure class #838 exists to close.

Mutation-verified: the new assertion fails for the shorthand and glob forms and passes for the literal form, where raw and resolved coincide.

## 4. Hermetic git in the test suite

Four harnesses committed without `-c commit.gpgsign=false`, so they were green in CI (no signing key) and red for any contributor with commit signing enabled — including all 16 tests of the new #838 file.

That one-liner has been added to `main` **five separate times**, each inside an unrelated feature PR whose new test file happened to commit: #528 (`45decdc4`), #537 (`9bb54319`), #748 (`fd9b67e0`), #760 (`db0cee47`), #803 (`54eb6c28`) — plus a docs entry (`3ae47446`, 2026-01-06) documenting the failure. It recurred anyway in #838's and #842's new files.

The per-file convention is itself the recurring bug, and CI structurally cannot catch this class: no signing key, no global config, no hooks. The only detector is a contributor's machine, where the cheapest response is always another one-liner.

So `vitest.global-setup.ts` now sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null`. Workers fork after global setup and inherit it. Verified by removing `qa-stagnation.test.ts`'s per-file fix **entirely**: 26/26 pass on the guard alone.

This also closes sibling leaks nothing defended against — `core.hooksPath` would run the contributor's hooks inside test repos, `core.autocrlf` would corrupt fixtures on Windows.

The four per-file calls are kept as defense in depth: they document intent and still work if a file is run outside this vitest config.

## Verification

Full suite on a signing-enabled machine: **221 files, 4581 passed, 0 failed** (was 34 failed). Build and lint clean. `lint:skill-sync` 44/44 synced, `lint:skill-gates` no violations.

## Follow-ups filed, not in scope here

#844 wrong-branch deletion · #845 bare `parseInt` · #846 swallowed install status · #847 `npm ci` hardcoding · #848 exit-0 on error · #849 state reconciliation · #850 AC parser
