### PR TITLE
chore(deps): bump hono from 4.12.31 to 4.12.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3570,9 +3570,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Supersedes #802 (closed by Dependabot with "updatable in another way" when asked to rebase — the branch was 34 commits behind main).

Cherry-picks Dependabot's original commit (`a743c5f7`, hono 4.12.31 → 4.12.32) onto current main. Diff is identical to the QA-reviewed change on #802: lockfile-only, single `node_modules/hono` entry (version / resolved / integrity).

QA evidence carried over from #802 (see [amended QA review](https://github.com/sequant-io/sequant/pull/802#issuecomment-5125942491)):
- `integrity` matches `npm view hono@4.12.32 dist.integrity` exactly
- Engines compatible: hono requires node `>=16.9.0`, repo requires `>=22.12.0`
- Single-entry diff — all dependent ranges (`@hono/node-server`, `@modelcontextprotocol/sdk`) satisfied
- Upstream release is fixes-only, incl. prototype-pollution hardening (`Object.create(null)` for query/header/param parsing)

Fresh CI on this branch replaces the stale (2026-07-24) evidence that blocked #802's verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4AYmYgbs8Wgf5jPzBtmBP
