### PR TITLE
fix(#880): give the Ink render tests a local timeout above the unit project's 5s default

### DIFF
--- a/src/ui/tui/App.test.tsx
+++ b/src/ui/tui/App.test.tsx
@@ -27,6 +27,26 @@ function snapshot(issues: IssueRuntimeState[]): RunSnapshot {
   };
 }
 
+/**
+ * Ink render tests need more than the `unit` vitest project's 5s default.
+ *
+ * The project deliberately keeps that default so a genuinely slow unit test
+ * stays a real signal (`vitest.config.ts` says so, and points at this
+ * local-override escape hatch). An Ink render is not slow logic, but it is not
+ * cheap either: in isolation the tests in this file measure 180-640ms each, and
+ * the render-plus-`advanceTimersByTimeAsync` case measured **5100ms** under the
+ * CPU contention of a full 229-file run — a timeout, not a wrong assertion
+ * (#880). Same class as #842: a test inheriting a default sized for something
+ * cheaper, except the cost here is an in-process TUI render, not a subprocess.
+ *
+ * Applied at FILE scope rather than to the one test that was observed failing.
+ * The flush test is the worst case, but a sibling that measures 640ms in
+ * isolation is on the same curve, and fixing only the observed instance leaves
+ * the class open. Still strictly local — every other file in the `unit` project
+ * keeps the 5s signal, which is what makes this safe (AC-2).
+ */
+vi.setConfig({ testTimeout: 30_000 });
+
 describe("App row cap (#699 AC-4)", () => {
   it("renders a single box for the ready single-issue case", () => {
     const snap = snapshot([issue(699, "running")]);

--- a/src/ui/tui/ElapsedTimer.test.tsx
+++ b/src/ui/tui/ElapsedTimer.test.tsx
@@ -18,6 +18,13 @@ function plainSeconds(text: string): number {
   return Number(m[1] ?? 0) * 3600 + Number(m[2] ?? 0) * 60 + Number(m[3] ?? 0);
 }
 
+/**
+ * Ink render tests need more than the `unit` project's 5s default — see the
+ * longer note in `App.test.tsx` (#880). File scope for the same reason: the
+ * flush test is the worst case, not the only exposed one.
+ */
+vi.setConfig({ testTimeout: 30_000 });
+
 describe("ElapsedTimer", () => {
   it("renders --:-- when startedAt is missing (AC-5)", () => {
     const { lastFrame } = render(<ElapsedTimer now={Date.now()} />);


### PR DESCRIPTION
## Summary

`App.test.tsx`'s stale-`completedAt` test failed under full-suite load with `Test timed out in 5000ms` (reported at **5100ms**) while passing 4/4 in isolation in ~1s. Not a logic defect and not a wrong assertion — a timeout.

Neither Ink test file has an `.integration.` infix, so both land in the `unit` vitest project, which keeps vitest's 5s default. `vitest.config.ts` states that split deliberately:

> Deliberately scoped to `integration` — the `unit` project keeps vitest's 5s default, where a slow test is a real signal. Files needing more override it locally.

So the sanctioned fix is a local override, which is what this is. Same class as #842, except the cost here is an in-process Ink render rather than a subprocess spawn — which is exactly why #842's fix (raising the *integration* project's timeout) never covered it.

## Scope note: file-level, not just the observed test

#880's AC-3 names the `advanceTimersByTimeAsync` tests. This applies the override at **file** scope instead, because measurement says the class is wider: in isolation the other tests in these files take **180–640ms** each, the same curve the 5100ms case sits on. Gating only the observed instance would leave the next-slowest test one bad scheduling window away from the same failure. The measurements are in the code comment so the widening is reviewable rather than silent.

## Verification

| Check | Result |
|-------|--------|
| Failure is timeout-bound, not logic | Forcing `--testTimeout=150` reproduces `Test timed out` on exactly the render tests; they pass at the default in isolation |
| Override takes effect | All 10 tests in both files pass with `--testTimeout=150` forced globally |
| **AC-2: `unit` default unchanged, no leak** | At `--testTimeout=1`, `version-check.test.ts` fails while both Ink files pass — the override is strictly file-scoped |
| `vitest.config.ts` | Untouched (diff is the two test files only) |
| Build / lint | Clean |

## AC coverage

| AC | Status |
|----|--------|
| AC-1 — no timeout failure under load, via the documented local-override hatch | Met |
| AC-2 — `unit` project's 5s default unchanged | Met, verified empirically as above |
| AC-3 — sibling Ink + `advanceTimersByTimeAsync` tests get the same treatment | Met, and deliberately exceeded: file scope covers all three flush tests plus their plain-render siblings |
| AC-4 — comment explains why >5s is needed | Met — states the Ink-render cause, both measurements, and why file scope |

## Test plan

- `npx vitest run src/ui/tui/` → 43 passed
- `npx vitest run src/ui/tui/App.test.tsx src/ui/tui/ElapsedTimer.test.tsx --testTimeout=150` → 10 passed
- `npx vitest run … src/lib/version-check.test.ts --testTimeout=1` → the non-overridden file fails, the two overridden files pass
- Full suite runs in CI on this PR

Found by QA on #871 / PR #876, where this was the only failure in an otherwise-green 4727-test run.

Closes #880

Generated with [Claude Code](https://claude.com/claude-code)
