### PR TITLE
fix(#883): spawn the CLI flag-surface tests in a manifest-less temp dir

### DIFF
--- a/src/commands/cli.integration.test.ts
+++ b/src/commands/cli.integration.test.ts
@@ -14,9 +14,10 @@ import {
   ExecSyncOptionsWithStringEncoding,
 } from "child_process";
 import { describe, it, expect, beforeAll } from "vitest";
-import { resolve, dirname } from "path";
+import { resolve, dirname, join } from "path";
 import { fileURLToPath } from "url";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "../..");
@@ -197,27 +198,71 @@ describe("run command flag surface (#705)", () => {
   // AC-5: `--experimental-tui` still parses without error. Use --dry-run so the
   // CLI parses flags without executing a real workflow.
   //
-  // These tests run in the repo root, which is not itself an initialized Sequant
-  // project, so every run trips the not-initialized pre-flight guard in run.ts.
-  // That guard prints "Sequant is not initialized" — but only *after* Commander
-  // has parsed every flag, so reaching it proves the flag under test was accepted.
-  // Since #848 the guard exits 1 (was 0), so exit-0 is no longer a valid
-  // "parsed OK" proxy; assert on the guard's output instead. A genuine Commander
-  // usage error (unknown option) never reaches the guard and prints
-  // "error: unknown option" to stderr.
+  // The proxy for "Commander accepted this flag" is the not-initialized
+  // pre-flight guard in run.ts: it prints "Sequant is not initialized", but only
+  // *after* Commander has parsed every flag, so reaching it proves the flag under
+  // test was accepted. Since #848 the guard exits 1 (was 0), so exit-0 is no
+  // longer a valid "parsed OK" proxy; assert on the guard's output instead. A
+  // genuine Commander usage error (unknown option) never reaches the guard and
+  // prints "error: unknown option" to stderr — pinned by the positive control
+  // below, so this cannot pass vacuously.
+  //
+  // Spawned in an EMPTY TEMP DIR, not the repo root (#883). The guard fires on
+  // `getManifest()` returning null, and `MANIFEST_PATH` is cwd-relative with no
+  // upward walk — so whether it fires depends entirely on the spawn cwd. The repo
+  // root looks manifest-less on a fresh CI checkout (`.sequant-manifest.json` is
+  // gitignored) but NOT on a clone that has been `sequant init`\'d, where these
+  // four tests failed while CI stayed green. A directory we create ourselves is
+  // manifest-less by construction, in both environments.
+  const runInUninitializedDir = (
+    ...args: string[]
+  ): { stdout: string; stderr: string } => {
+    const cwd = mkdtempSync(join(tmpdir(), "sequant-cli-flags-"));
+    try {
+      const r = spawnSync(process.execPath, [cliPath, ...args], {
+        cwd,
+        encoding: "utf-8",
+      });
+      return { stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+    } finally {
+      // Belt-and-braces before a recursive delete: only ever remove something we
+      // just created under the OS temp dir. An edit that points `cwd` at
+      // `projectRoot` while leaving this cleanup in place would recursively
+      // delete the working tree; the check makes that fail loudly instead.
+      if (!resolve(cwd).startsWith(resolve(tmpdir()))) {
+        throw new Error(`refusing to rm outside tmpdir: ${cwd}`);
+      }
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  };
+
   const expectFlagAccepted = (flag: string): void => {
-    const r = spawnSync(
-      process.execPath,
-      [cliPath, "run", "1", flag, "--dry-run"],
-      { cwd: projectRoot, encoding: "utf-8" },
+    const { stdout, stderr } = runInUninitializedDir(
+      "run",
+      "1",
+      flag,
+      "--dry-run",
     );
-    const stdout = r.stdout ?? "";
-    const stderr = r.stderr ?? "";
     // Reached the pre-flight guard ⇒ Commander parsed every flag, incl. `flag`.
     expect(stdout + stderr).toMatch(/Sequant is not initialized/);
     // ...and it was not rejected as an unknown option.
     expect(stderr).not.toMatch(/error: unknown option/);
   };
+
+  // Positive control for the proxy above. If an unknown option ALSO reached the
+  // guard, `expectFlagAccepted` would pass for any string and gate nothing —
+  // the failure mode that makes a green suite meaningless.
+  it("an unknown option is rejected and never reaches the pre-flight guard", () => {
+    const { stdout, stderr } = runInUninitializedDir(
+      "run",
+      "1",
+      "--definitely-not-a-flag",
+      "--dry-run",
+    );
+
+    expect(stderr).toMatch(/error: unknown option/);
+    expect(stdout + stderr).not.toMatch(/Sequant is not initialized/);
+  });
 
   it("-q parses without error (hidden quality-loop alias) (AC-1)", () => {
     // Proves the hidden `-q` alias is accepted by Commander.


### PR DESCRIPTION
## Summary

Four `run command flag surface (#705)` tests failed on any locally `sequant init`'d clone while passing in CI.

They assert on run.ts's not-initialized pre-flight guard as a proxy for *"Commander parsed this flag"*, and spawned the CLI with `cwd: projectRoot`. The comment claimed the repo root *"is not itself an initialized Sequant project"* — true only on a fresh checkout. The guard fires on `getManifest()` returning null, and `MANIFEST_PATH` is cwd-relative with no upward walk, so whether it fires depends entirely on the spawn cwd. `.sequant-manifest.json` is gitignored:

| Environment | manifest | guard fires | result |
|---|---|---|---|
| CI (fresh checkout) | absent | yes | 4 pass |
| locally `init`'d clone | present | **no** | 4 **fail** |

So `npm test` could not go green on a dev machine that had ever run `sequant init`. Same family as #842 and #880 — a test coupled to ambient environment rather than to what it means to assert.

## Fix

Spawn in a directory the test creates itself — manifest-less by construction in both environments. Added a positive control (AC-3) asserting an unknown option *is* rejected and never reaches the guard, so the proxy can't pass vacuously. Corrected the stale comment (AC-4).

The temp-dir cleanup guards its own recursive delete against any path outside `tmpdir()`. Not hypothetical: while mutation-testing this, pointing `cwd` at `projectRoot` with the cleanup in place **deleted the worktree**. The guard turns that class of edit into a loud failure.

## Verification

Run with a manifest copied in, reproducing an `init`'d clone:

| State | Result |
|---|---|
| Fixed code | **17/17 pass** |
| Pre-fix code | 4 failed / 16 |
| Mutation: spawn back in `projectRoot` | 4 fail (reproduces #883) |
| Mutation: positive control given a real flag | control fails (not vacuous) |

## Known: pre-existing tautology-detector false positive

`npm test` on this branch also fails 3 `tautology-detector-cli` tests. **Not caused by this change** — the detector scans only files in `git diff main...HEAD`, and this file scores **100% tautological at `origin/main` too** (16/16 there, 17/17 here). Its heuristic can't see assertions made on subprocess stdout/stderr, which is exactly how this integration file works by design. Any PR touching this file trips it. Tracked separately rather than silenced here.

Closes #883

Generated with [Claude Code](https://claude.com/claude-code)