### PR TITLE
fix(lint): exclude gitignored scripts/dev from the widened lint/typecheck scope

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -92,6 +92,13 @@ export default tseslint.config(
       "dist/",
       "node_modules/",
       "templates/",
+      // `scripts/dev/` is gitignored developer scratch with zero tracked
+      // files (.gitignore:65). It does not exist in CI, so linting it makes
+      // local `npm run lint` fail on a file CI never sees — which is how the
+      // #922 lint-scope widening shipped green: `scripts/dev/tui-demo.tsx`
+      // has no home in `tsconfig.scripts.json`, and only developers who had
+      // the directory saw the parser error.
+      "scripts/dev/",
       "**/*.js",
       "**/*.test.ts",
       "**/*.test.tsx",

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -16,5 +16,23 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["scripts/**/*"]
+  "include": ["scripts/**/*"],
+  // `exclude` REPLACES the inherited list rather than extending it, so the
+  // base entries are repeated here verbatim. Dropping them silently pulled
+  // `**/*.test.ts` into the project and surfaced three pre-existing errors in
+  // `lint-skill-calls.test.ts` — test files are excluded repo-wide by
+  // `tsconfig.json` and this project keeps that convention.
+  //
+  // `scripts/dev/` is gitignored developer scratch (.gitignore:65) with zero
+  // tracked files. Absent in CI, so including it makes local and CI
+  // typechecks disagree — the same asymmetry that let a lint failure ship
+  // green.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "templates",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "scripts/dev/"
+  ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #928, which widened `npm run lint` to `scripts/` and added `tsconfig.scripts.json`. Both then reached `scripts/dev/` — gitignored developer scratch with **zero tracked files** (`.gitignore:65`).

That directory does not exist in CI, so **CI went green while `npm run lint` failed for every developer who has it**:

```
scripts/dev/tui-demo.tsx
  0:0  error  Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.
  The file was not found in any of the provided project(s): scripts/dev/tui-demo.tsx
```

The eslint override #928 added matches `scripts/**/*.ts`, so the `.tsx` file had no project to resolve against. Rather than extend the override to `.tsx`, the directory is excluded from both tools: linting untracked scratch is meaningless, and any rule applied there can only ever fail locally and never in CI.

## A second trap, worth recording

Adding `exclude` to `tsconfig.scripts.json` surfaced this: **`exclude` replaces the inherited list rather than extending it.** The first attempt dropped the base's `**/*.test.ts` entry, pulled test files into the project, and surfaced three pre-existing errors in `lint-skill-calls.test.ts`. The base entries are now repeated verbatim with a comment explaining why they cannot be omitted.

Worth knowing generally: any `extends` + `exclude` combination in this repo has the same hazard.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | ✅ (was failing on main) |
| `npm run typecheck:scripts` | ✅ |
| `npx tsc --noEmit` | ✅ |
| `npm run build` | ✅ |
| `scripts/spec/` suite | ✅ 50 tests |

CI behavior is unchanged by construction — `scripts/dev/` is absent there, so both settings are no-ops in CI. That asymmetry is exactly what made the original defect invisible, so it is stated here rather than inferred from a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mqb5dzMesLxK8GAVKEijr
