### PR TITLE
test(qa): pin the tautology CI job's annotation format and summary marker shape

### DIFF
--- a/scripts/qa/tautology-detector-cli.test.ts
+++ b/scripts/qa/tautology-detector-cli.test.ts
@@ -3,16 +3,22 @@
  */
 import { describe, it, expect } from "vitest";
 import { execSync } from "child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import * as path from "path";
 
 const CLI_PATH = path.resolve(__dirname, "tautology-detector-cli.ts");
 
-function runCli(args: string[] = []): { stdout: string; exitCode: number } {
+function runCli(
+  args: string[] = [],
+  env: Record<string, string> = {},
+): { stdout: string; exitCode: number } {
   try {
     const stdout = execSync(`npx tsx ${CLI_PATH} ${args.join(" ")}`, {
       encoding: "utf-8",
       cwd: path.resolve(__dirname, "../.."),
       timeout: 30000,
+      env: { ...process.env, ...env },
     });
     return { stdout: stdout.trim(), exitCode: 0 };
   } catch (error: unknown) {
@@ -85,6 +91,35 @@ describe("tautology-detector-cli", { timeout: 60_000 }, () => {
       expect(file).toHaveProperty("tautologicalCount");
       expect(file).toHaveProperty("tautologicalTests");
       expect(Array.isArray(file.tautologicalTests)).toBe(true);
+    }
+  });
+
+  // #940 gap follow-up: --github was previously only exercised on real CI
+  // runs where a diff happened to have changed test files. `--base HEAD`
+  // deterministically produces zero changed files regardless of environment
+  // (diffing a commit against itself), covering the --github + zero-files
+  // combination this test file never spawned before.
+  it("--github with zero changed test files writes the skip summary and marker to $GITHUB_STEP_SUMMARY", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tautology-cli-summary-"));
+    const summaryFile = path.join(dir, "summary.md");
+    writeFileSync(summaryFile, "");
+
+    try {
+      const { exitCode } = runCli(
+        ["--base", "HEAD", "--advisory", "--github"],
+        {
+          GITHUB_STEP_SUMMARY: summaryFile,
+        },
+      );
+      expect(exitCode).toBe(0);
+
+      const content = readFileSync(summaryFile, "utf-8");
+      expect(content).toContain("No test files changed in diff");
+      expect(content).toMatch(
+        /<!-- TAUTOLOGY_SUMMARY \{"filesScanned":0,"totalTests":0,"findings":0,"skipped":0,"score":0,"reason":"no-test-files"\} -->/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/scripts/qa/tautology-detector-cli.ts
+++ b/scripts/qa/tautology-detector-cli.ts
@@ -143,7 +143,7 @@ function readFileContent(filePath: string): string | null {
   }
 }
 
-interface TautologySummary {
+export interface TautologySummary {
   pr?: number;
   filesScanned: number;
   totalTests: number;
@@ -153,11 +153,15 @@ interface TautologySummary {
   reason?: "base-not-found" | "no-test-files";
 }
 
-function summaryMarker(summary: TautologySummary): string {
+/** @internal Exported for testing — pins the TAUTOLOGY_SUMMARY marker shape (#940 AC-3). */
+export function summaryMarker(summary: TautologySummary): string {
   return `<!-- TAUTOLOGY_SUMMARY ${JSON.stringify(summary)} -->`;
 }
 
-function emitGithubAnnotations(fileResults: TautologyFileResult[]): void {
+/** @internal Exported for testing — pins the ::warning annotation format (#940 AC-2). */
+export function emitGithubAnnotations(
+  fileResults: TautologyFileResult[],
+): void {
   for (const fileResult of fileResults) {
     for (const block of fileResult.testBlocks) {
       if (!block.isTautological) continue;
@@ -170,7 +174,8 @@ function emitGithubAnnotations(fileResults: TautologyFileResult[]): void {
   }
 }
 
-function emitGithubStepSummary(markdown: string, marker: string): void {
+/** @internal Exported for testing (#940 AC-3). */
+export function emitGithubStepSummary(markdown: string, marker: string): void {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   const body = `${markdown}\n\n${marker}\n`;
   if (summaryPath) {

--- a/scripts/qa/tautology-github-output.test.ts
+++ b/scripts/qa/tautology-github-output.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the CI `--github` output helpers (#940 AC-2, AC-3)
+ *
+ * Nothing previously pinned the `::warning` annotation format or the
+ * TAUTOLOGY_SUMMARY marker's JSON shape — only live CI runs and manual
+ * verification covered them. A future refactor of either format could
+ * silently break Phase A's FP-rate accounting with no test going red.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { TautologyFileResult } from "../../src/lib/test-tautology-detector.js";
+import {
+  emitGithubAnnotations,
+  emitGithubStepSummary,
+  summaryMarker,
+} from "./tautology-detector-cli.js";
+
+function fileResult(
+  overrides: Partial<TautologyFileResult> = {},
+): TautologyFileResult {
+  return {
+    filePath: "src/lib/foo.test.ts",
+    totalTests: 1,
+    tautologicalCount: 0,
+    tautologicalPercentage: 0,
+    testBlocks: [],
+    importedFunctions: [],
+    parseSuccess: true,
+    ...overrides,
+  };
+}
+
+describe("summaryMarker (#940 AC-3)", () => {
+  it("emits an HTML-comment-wrapped, greppable JSON line with all fields", () => {
+    const marker = summaryMarker({
+      pr: 940,
+      filesScanned: 2,
+      totalTests: 4,
+      findings: 1,
+      skipped: 0,
+      score: 0.25,
+    });
+
+    expect(marker).toMatch(/^<!-- TAUTOLOGY_SUMMARY \{.*\} -->$/);
+    const json = marker
+      .replace("<!-- TAUTOLOGY_SUMMARY ", "")
+      .replace(" -->", "");
+    expect(JSON.parse(json)).toEqual({
+      pr: 940,
+      filesScanned: 2,
+      totalTests: 4,
+      findings: 1,
+      skipped: 0,
+      score: 0.25,
+    });
+  });
+
+  it("carries the reason field for skip cases (base-not-found / no-test-files)", () => {
+    const marker = summaryMarker({
+      filesScanned: 0,
+      totalTests: 0,
+      findings: 0,
+      skipped: 0,
+      score: 0,
+      reason: "no-test-files",
+    });
+    const json = JSON.parse(
+      marker.replace("<!-- TAUTOLOGY_SUMMARY ", "").replace(" -->", ""),
+    );
+    expect(json.reason).toBe("no-test-files");
+    expect(json.pr).toBeUndefined();
+  });
+});
+
+describe("emitGithubAnnotations (#940 AC-2)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("emits one ::warning line per tautological block, in workflow-command format", () => {
+    const results = [
+      fileResult({
+        filePath: "src/lib/foo.test.ts",
+        testBlocks: [
+          {
+            description: "is tautological",
+            lineNumber: 4,
+            isTautological: true,
+            style: "it",
+          },
+        ],
+      }),
+    ];
+
+    emitGithubAnnotations(results);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      '::warning file=src/lib/foo.test.ts,line=4,title=Tautological test::it("is tautological") — no production function calls',
+    );
+  });
+
+  it("skips non-tautological blocks — no annotation for real tests", () => {
+    const results = [
+      fileResult({
+        testBlocks: [
+          {
+            description: "calls production code",
+            lineNumber: 10,
+            isTautological: false,
+            style: "test",
+          },
+        ],
+      }),
+    ];
+
+    emitGithubAnnotations(results);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("emitGithubStepSummary (#940 AC-2, AC-3)", () => {
+  let tmpDir: string;
+  let summaryFile: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  const originalSummaryEnv = process.env.GITHUB_STEP_SUMMARY;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "tautology-summary-"));
+    summaryFile = join(tmpDir, "summary.md");
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (originalSummaryEnv === undefined) {
+      delete process.env.GITHUB_STEP_SUMMARY;
+    } else {
+      process.env.GITHUB_STEP_SUMMARY = originalSummaryEnv;
+    }
+  });
+
+  it("appends the markdown table and marker together to $GITHUB_STEP_SUMMARY", () => {
+    process.env.GITHUB_STEP_SUMMARY = summaryFile;
+    // appendFileSync requires the file to exist first, matching the real
+    // GITHUB_STEP_SUMMARY contract (the runner pre-creates it).
+    writeFileSync(summaryFile, "");
+
+    const marker = summaryMarker({
+      filesScanned: 0,
+      totalTests: 0,
+      findings: 0,
+      skipped: 0,
+      score: 0,
+      reason: "no-test-files",
+    });
+    emitGithubStepSummary(
+      "### Test Tautology (Phase A, advisory)\n\nNo test files changed in diff",
+      marker,
+    );
+
+    const content = readFileSync(summaryFile, "utf-8");
+    expect(content).toContain("### Test Tautology (Phase A, advisory)");
+    expect(content).toContain("No test files changed in diff");
+    expect(content).toContain(marker);
+  });
+
+  it("falls back to stdout instead of silently dropping the summary when GITHUB_STEP_SUMMARY is unset", () => {
+    delete process.env.GITHUB_STEP_SUMMARY;
+
+    emitGithubStepSummary("some table", "<!-- TAUTOLOGY_SUMMARY {} -->");
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0][0]).toContain("some table");
+    expect(logSpy.mock.calls[0][0]).toContain("<!-- TAUTOLOGY_SUMMARY {} -->");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #940/#955 closing test-coverage gaps identified in QA self-review after that PR merged:

- **AC-2/AC-3 had no unit test** pinning the `::warning` annotation format or the `TAUTOLOGY_SUMMARY` marker's JSON shape — only live CI runs and manual verification covered them. A future refactor could silently break either with nothing going red.
- **The `--github` + zero-changed-test-files combination was never exercised on a real CLI invocation** — every commit on #955 happened to touch test files.

## Changes

- Exports `emitGithubAnnotations`, `emitGithubStepSummary`, and `summaryMarker` (previously private) so tests can assert on their output directly, matching the existing `selectChangedTestFiles` pattern in this file.
- New `scripts/qa/tautology-github-output.test.ts` (unit): annotation format for tautological vs. non-tautological blocks, marker JSON shape (including the `reason` field), step-summary file writing, and the stdout fallback when `$GITHUB_STEP_SUMMARY` is unset.
- New subprocess integration test in `tautology-detector-cli.test.ts`: runs the real CLI with `--base HEAD --advisory --github` (a deterministic zero-files diff — HEAD against itself) and asserts the skip message + marker land in a real `$GITHUB_STEP_SUMMARY` file.

No production behavior changes — this is test coverage only. `selectChangedTestFiles`, `main()`, and every existing code path are untouched except for the three functions changing from private to exported.

## Mutation verification (AC-2, AC-3 — both gate tests)

- **AC-2:** mutated `emitGithubAnnotations`'s `if (!block.isTautological) continue` to `if (true) continue`. "emits one ::warning line per tautological block, in workflow-command format" failed as expected; no other tests affected. Restored.
- **AC-3:** mutated `emitGithubStepSummary` to drop the marker from its body. Both step-summary unit tests and the new integration test failed as expected; no other tests affected. Restored.

## Test plan

- [x] `npm run build` / `npm run lint` / `npm run typecheck:scripts` — all pass
- [x] `npm test` — full suite: 270 files / 5523 tests passing (1 pre-existing expected fail, 2 pre-existing skips)
- [x] New unit tests (6) and new integration test — all pass
- [x] Mutation-verified per above

References #940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)